### PR TITLE
Ensure that all fields in an FX quote are signed

### DIFF
--- a/src/lib/utils/never.ts
+++ b/src/lib/utils/never.ts
@@ -12,3 +12,8 @@ export function assertNever(value: never): never {
 
 	throw(new Error(`Unexpected value: ${value}`));
 }
+
+/**
+ * Asserts that the provided type is never.
+ */
+export type AssertNever<T extends never> = T;


### PR DESCRIPTION
This change ensures that all fields in an FX quote are included in the signature, and adds the missing `account` field from the signature.  There is no security risk from not signing it currently because the account field is not referenced in the quote (and this is probably a bug, since it doesn't make sense to require the `getConversionRateAndFee()` callback to have to compute this, and then ignore the result in the actual exchange)