### PR TITLE
Filter Same Tokens from listPossibleConversions

### DIFF
--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -109,7 +109,7 @@ test('FX Anchor Client Test', async function() {
 						from: [
 							{
 								currencyCodes: [testCurrencyUSD.publicKeyString.get()],
-								to: [testCurrencyEUR.publicKeyString.get()]
+								to: [testCurrencyEUR.publicKeyString.get(), testCurrencyUSD.publicKeyString.get()]
 							},
 							{
 								currencyCodes: [testCurrencyEUR.publicKeyString.get()],

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -552,11 +552,19 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 			for (const conversionPair of serviceInfo.from) {
 				if (conversion.from !== undefined) {
 					if (conversionPair.currencyCodes.includes(conversion.from)) {
-						conversionPair.to.forEach(token => conversions.add(token));
+						conversionPair.to.forEach((token) => {
+							if (conversion.from !== token) {
+								conversions.add(token);
+							}
+						});
 					}
 				} else if (conversion.to !== undefined) {
 					if (conversionPair.to.includes(conversion.to)) {
-						conversionPair.currencyCodes.forEach(token => conversions.add(token));
+						conversionPair.currencyCodes.forEach((token) => {
+							if (conversion.to !== token) {
+								conversions.add(token);
+							}
+						});
 					}
 				}
 			}


### PR DESCRIPTION
This change fixes listPossibleConversions so it doesn't include the same token being searched for (eg. USD <> USD) should not be a possible combination.