### PR TITLE
Asset Movement Types, Client and Provider Classes

### DIFF
--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -1520,7 +1520,7 @@ class Resolver {
 		return(assetWithRails);
 	}
 
-	private async parseSupportedAssets(assetService: ValuizableObject, criteria: ServiceSearchCriteria<'assetMovement'>): Promise<NonNullable<ServiceMetadata['services']['assetMovement']>[string]['supportedAssets']> {
+	async parseSupportedAssets(assetService: ValuizableObject | ToValuizableObject<NonNullable<ServiceMetadata['services']['assetMovement']>[string]>, criteria: ServiceSearchCriteria<'assetMovement'> = {}): Promise<NonNullable<ServiceMetadata['services']['assetMovement']>[string]['supportedAssets']> {
 		if (criteria.rail !== undefined) {
 			throw(new Error('Asset movement service does not support rail search criteria'));
 		}
@@ -1543,7 +1543,7 @@ class Resolver {
 				}
 				const asset = await supportedAssetObject.asset('string');
 				if (assetCanonical && asset !== assetCanonical) {
-					throw(new Error('Asset does not match search'));
+					continue;
 				}
 
 				if (!('paths' in supportedAssetObject) || supportedAssetObject.paths === undefined) {

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -167,6 +167,7 @@ test('FX Anchor Client Test', async function() {
 	});
 
 	const baseTokenProvider = await assetTransferClient.getProvidersForTransfer({ asset: baseToken });
+	expect(baseTokenProvider?.length).toBe(1);
 
 	const conversionTests = [
 		{
@@ -174,9 +175,8 @@ test('FX Anchor Client Test', async function() {
 			result: [testCurrencyUSDC.publicKeyString.get(), baseToken.publicKeyString.get()].sort()
 		},
 		{
-			// no provider offers this pair
-			test: async function() { return(await assetTransferClient.getProvidersForTransfer({ asset: baseToken, from: { location: 'chain:keeta:100' }, to: { location: 'chain:evm:100', recipient: '123' }, value: 100n })) },
-			result: null
+			test: async function() { return((await assetTransferClient.getProvidersForTransfer({ asset: baseToken, from: { location: 'chain:keeta:100' }, to: { location: 'chain:evm:100', recipient: '123' }, value: 100n }))?.length) },
+			result: 1
 		},
 		{
 			// @ts-expect-error

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -15,7 +15,7 @@ type TokenSearchCanonical = TokenPublicKeyString;
 
 export type MovableAssetSearchInput = CurrencySearchInput | TokenSearchInput;
 export type MovableAssetSearchCanonical = CurrencySearchCanonical | TokenSearchCanonical;
-export type MovableAsset = TokenAddress | CurrencyInfo.Currency;
+export type MovableAsset = TokenAddress | TokenPublicKeyString | CurrencyInfo.Currency;
 
 export function assertMovableAsset(input: unknown): asserts input is MovableAsset {
 
@@ -67,6 +67,9 @@ export interface AssetWithRails extends Asset {
 	} | {
 		inbound?: Rail[];
 		outbound: Rail[];
+	} | {
+		inbound: never;
+		outbound: never;
 	}) & {
 		common?: Rail[];
 	});
@@ -78,6 +81,11 @@ export interface AssetPath {
 	kycProviders?: string[];
 };
 
+export interface SupportedAssets {
+	asset: MovableAsset,
+	paths: AssetPath[]
+}
+
 export interface AssetWithRailsMetadata {
 	location: string;
 	id: string;
@@ -87,9 +95,12 @@ export interface AssetWithRailsMetadata {
 	} | {
 		inbound?: string[];
 		outbound: string[];
+	} | {
+		inbound: never;
+		outbound: never;
 	}) & {
 		common?: string[];
-	});
+	})
 }
 
 


### PR DESCRIPTION
This change refactors the asset movement client and providers to follow the structure used for FX more closely.

1. Create a `KeetaAssetMovementAnchorClient` for a given transfer request - This returns the available providers that match the request.
2. `KeetaAssetMovementAnchorClient.startTransfer` - begins a `KeetaAssetMovementTransfer` from a given provider
3. `KeetaAssetMovementTransfer.getTransferStatus` - gets the status from the provider

All client/server requests should happen through the `KeetaAssetMovementAnchorProvider` class and 

TODO
1. Implement `createPersistentForwarding` and `listPersistentForwardingTransactions`
2. How do we check the status if we aren't sure what provider it was initially created with?  Where would we persist that information on the wallet for example?