### PR TITLE
Keetanet v0.14.5 and Release 0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			},
 			"devDependencies": {
 				"@keetanetwork/eslint-config-typescript": "1.4.7",
-				"@keetanetwork/keetanet-node": "0.14.2",
+				"@keetanetwork/keetanet-node": "0.14.5",
 				"@ryoppippi/unplugin-typia": "2.6.5",
 				"@types/asn1js": "2.0.2",
 				"@types/node": "20.16.10",
@@ -2105,9 +2105,9 @@
 			}
 		},
 		"node_modules/@keetanetwork/keetanet-node": {
-			"version": "0.14.2",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.14.2/28c999d058079ce927b9fc9578b994de80ff7144",
-			"integrity": "sha512-sxxp29bzBSzDYhMe5SDkPUHsmnh3AWN5t+BEHy/rvskGLIMn2z3AxyTpBo/JrhtAjY9HPpSf9GIhlSqVygXogg==",
+			"version": "0.14.5",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.14.5/5d2ab0370253c67e2f977cf68133a0e836b68d8d",
+			"integrity": "sha512-mjI+VVj0Dm/oblCeVet535+L3hRW0x/qL3h1jvi7BJj+8tEhlpRKskdBJRWO8C2vUvt4XJnZBqwql9zIVUzlXw==",
 			"dev": true,
 			"license": "see LICENSE",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"sideEffects": false,
 	"devDependencies": {
 		"@keetanetwork/eslint-config-typescript": "1.4.7",
-		"@keetanetwork/keetanet-node": "0.14.2",
+		"@keetanetwork/keetanet-node": "0.14.5",
 		"@ryoppippi/unplugin-typia": "2.6.5",
 		"@types/asn1js": "2.0.2",
 		"@types/node": "20.16.10",


### PR DESCRIPTION
This change upgrades to the latest keetanet-client and keetanet-node 0.14.5 and Releases 0.0.7