### PR TITLE
Upgrade to KeetaNet v0.14.6 and release KeetaNet Anchor v0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.8",
+			"version": "0.0.9",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This change upgrades to the latest release of KeetaNet (v0.14.6) and releases the KeetaNet Anchor v0.0.9.