### PR TITLE
Add a mechanism for sharing KYC Certificate Attributes

### DIFF
--- a/src/lib/certificates.generated.ts
+++ b/src/lib/certificates.generated.ts
@@ -1,0 +1,4 @@
+import * as typia from 'typia';
+import type { SharableCertificateAttributesTypes } from './certificates.js';
+
+export const assertSharableCertificateAttributesContentsSchema: (input: unknown) => SharableCertificateAttributesTypes.ContentsSchema = typia.createAssert<SharableCertificateAttributesTypes.ContentsSchema>();


### PR DESCRIPTION
This change adds a `SharableCertificateAttributes` which allows one to share the attributes values (whether sensitive or not) from a certificate with a proof of the value for sensitive attributes.