### PR TITLE
Try to parse documents encoded in JSON

### DIFF
--- a/src/lib/utils/asn1.ts
+++ b/src/lib/utils/asn1.ts
@@ -358,7 +358,7 @@ export function normalizeDecodedASN1(input: unknown, principals: KeetaNetAccount
 					throw(new Error(`Failed to fetch remote data from ${url}: ${result.status} ${result.statusText}`));
 				}
 
-				let dataBlob = await result.blob();
+				const dataBlob = await result.blob();
 				let data = await dataBlob.arrayBuffer();
 
 				/*


### PR DESCRIPTION
This change will allow parsing documents that are stored as Base64 text within an encrypted container, likely because the HTTP server didn't support binary responses -- although fixed in #71, some HTTP servers are not updated.

This can be reverted in the future.