### PR TITLE
fix union input error in ToValuizable

### DIFF
--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -605,7 +605,7 @@ interface ToValuizableExpectArray<T extends unknown[]> extends ValuizableMethodB
 }
 
 /* eslint-disable @stylistic/indent */
-type ToValuizable<T> = 
+type ToValuizable<T> =
 	T extends string ? ToValuizableExpectString :
 	T extends number ? ToValuizableExpectNumber :
 	T extends boolean ? ToValuizableExpectBoolean :


### PR DESCRIPTION
Previously, `ToValuizable<string | { hello: true }>` would equal any, this fixes that.