### PR TITLE
Try to sync HTTP logger when finalizing a connection

### DIFF
--- a/src/lib/http-server.ts
+++ b/src/lib/http-server.ts
@@ -240,7 +240,7 @@ export abstract class KeetaNetAnchorHTTPServer<ConfigType extends KeetaAnchorHTT
 				}
 
 				response.end();
-			}
+			};
 
 			/*
 			 * Lookup the route based on the request


### PR DESCRIPTION
This change adds a manual `Logger.sync()` to the Anchor SDK HTTP server, which will help to ensure logs are pushed to the appropriate log targets while running within Google Cloud Run.

Google Cloud Run puts the NodeJS process to sleep if there are no on-going requests, preventing auto-sync from capturing all logs, especially if the process terminates before any new requests come in.

The `sync()` method wasn't exposed in `Logger` until the node change (https://github.com/KeetaNetwork/node/pull/940) is available in a released version.