### PR TITLE
Fix double-compression of certificate attributes

### DIFF
--- a/src/lib/certificates.test.ts
+++ b/src/lib/certificates.test.ts
@@ -530,8 +530,7 @@ test('Certificate Sharable Attributes', async function() {
 		 * 1. Decode the container
 		 */
 		const container = EncryptedContainer.fromEncodedBuffer(sharedSerialized, [viewerAccount]);
-		const valueCompressed = await container.getPlaintext();
-		const value = KeetaNetClient.lib.Utils.Buffer.ZlibInflate(valueCompressed);
+		const value = await container.getPlaintext();
 		const valueBuffer = Buffer.from(value);
 		const valueString = valueBuffer.toString('utf-8');
 		const valueObject: unknown = JSON.parse(valueString);

--- a/src/lib/encrypted-container.ts
+++ b/src/lib/encrypted-container.ts
@@ -7,8 +7,8 @@ import type {
 import { Buffer, arrayBufferToBuffer, bufferToArrayBuffer } from './utils/buffer.js';
 import { isArray } from './utils/array.js';
 
-const zlibDeflate = KeetaNetLib.Utils.Buffer.ZlibDeflate; /* XXX:TODO: Change this to ZlibDeflateAsync when merged in */
-const zlibInflate = KeetaNetLib.Utils.Buffer.ZlibInflate; /* XXX:TODO: Change this to ZlibInflateAsync when merged in */
+const zlibDeflateAsync = KeetaNetLib.Utils.Buffer.ZlibDeflateAsync;
+const zlibInflateAsync = KeetaNetLib.Utils.Buffer.ZlibInflateAsync;
 const ASN1toJS = KeetaNetLib.Utils.ASN1.ASN1toJS;
 const JStoASN1 = KeetaNetLib.Utils.ASN1.JStoASN1;
 const Account: typeof KeetaNetLib.Account = KeetaNetLib.Account;
@@ -133,7 +133,7 @@ const oidDB = {
 * @returns The ASN.1 DER data
 */
 async function buildASN1(plaintext: Buffer, encryptionOptions?: ASN1Options): Promise<Buffer> {
-	const compressedPlaintext = Buffer.from(zlibDeflate(plaintext));
+	const compressedPlaintext = Buffer.from(await zlibDeflateAsync(plaintext));
 
 	const sequence: Partial<ContainerPackage> = [];
 
@@ -409,7 +409,7 @@ async function parseASN1Decrypt(inputInfo: ReturnType<typeof parseASN1Bare>, key
 		};
 	}
 
-	const plaintext = Buffer.from(zlibInflate(containedCompressed));
+	const plaintext = Buffer.from(await zlibInflateAsync(containedCompressed));
 
 	return({
 		version: inputInfo.version,


### PR DESCRIPTION
This changeset fixes an issue where Certificate Attributes for a `SharableCertificateAttributes` instance were double-compressed (since an encrypted container already compresses the plaintext).  It retains backwards compatibility with older `SharableCertificateAttributes` instances.