### PR TITLE
Support more complex scripts with run-ts

### DIFF
--- a/utils/run-ts
+++ b/utils/run-ts
@@ -26,6 +26,16 @@ mkdir -p "${tmpdir}" || exit 1
 npm run --silent tsc -- --module NodeNext --moduleResolution NodeNext --isolatedModules false --outDir "${tmpdir}" "${script}"
 bin="$(find "${tmpdir}" -name '*.js')"
 if [ ! -f "${bin}" ]; then
+	canonicalScript="$(realpath "${script}")"
+	# Trim the length of ${workdir} from the canonical path
+	relativeScript="${canonicalScript#"${workdir}"}"
+	# Trim the "/src/" prefix if it exists
+	relativeScript="${relativeScript#/src/}"
+	# Prepend tmpdir
+	bin="${tmpdir}/${relativeScript%.ts}.js"
+fi
+
+if [ ! -f "${bin}" ]; then
 	echo "Compiled file not found"
 	exit 1
 fi


### PR DESCRIPTION
This change updates the "run-ts" script to support running scripts that rely on more files, meaning the binFile may not be the only file compiled.  It does this by keeping track of the pathname relative to the `src` directory and converting the pathname in the same way `tsc` does.