### PR TITLE
Add helper "waitForCertificates" to KYC Client

### DIFF
--- a/src/services/kyc/client.ts
+++ b/src/services/kyc/client.ts
@@ -273,6 +273,22 @@ class KeetaKYCVerification {
 			...this.request
 		}));
 	}
+
+	/**
+	 * Wait for the certificates to be available, polling at the given interval
+	 * and timing out after the given timeout period.
+	 */
+	async waitForCertificates(pollInterval: number = 500, timeout: number = 600000): Promise<KeetaKYCAnchorClientGetCertificateResponse> {
+		for (const startTime = Date.now(); Date.now() - startTime < timeout; ) {
+			try {
+				return(await this.getCertificates());
+			} catch (getCertificatesError) {
+				/* XXX:TODO */
+				throw(getCertificatesError);
+			}
+		}
+		throw(new Error('Timeout waiting for KYC certificates'));
+	}
 }
 
 /**


### PR DESCRIPTION
This change adds a `waitForCertificates` utility method to the KYC client to handle waiting for the certificate from the service provider.

TODO:
1. Finish waiting
2. Handle back-offs
3. Handle permanent fatal errors
4. Deserialize errors
5. Add timeout
6. Add signal to abort
7. Tests