### PR TITLE
Allow errors to specify their log level

### DIFF
--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,3 +1,4 @@
+import type { LogLevel } from './log/index.ts';
 /**
  * Type for error classes that can be deserialized
  */
@@ -53,6 +54,7 @@ export class KeetaAnchorError extends Error {
 	private readonly keetaAnchorErrorObjectTypeID!: string;
 	private static readonly keetaAnchorErrorObjectTypeID = '5d7f1578-e887-4104-bab0-4115ae33b08f';
 	protected userError = false;
+	readonly logLevel: LogLevel = 'ERROR';
 
 	get name(): string {
 		return(this.#name);

--- a/src/services/kyc/common.ts
+++ b/src/services/kyc/common.ts
@@ -83,6 +83,7 @@ class KeetaKYCAnchorVerificationNotFoundError extends KeetaAnchorUserError {
 	static override readonly name: string = 'KeetaKYCAnchorVerificationNotFoundError';
 	private readonly KeetaKYCAnchorVerificationNotFoundErrorObjectTypeID!: string;
 	private static readonly KeetaKYCAnchorVerificationNotFoundErrorObjectTypeID = '79d7036f-58ad-4eec-b64c-26bdf98cd3c1';
+	override readonly logLevel = 'DEBUG';
 
 	constructor(message?: string) {
 		super(message ?? 'Verification ID not found');


### PR DESCRIPTION
This change improves the `KeetaAnchorError`s to include a `logLevel` property, which can be used to indicate to the HTTP server component (and anyone else who cares) the severity of the error.

Some errors, like `CertificateNotFound` from the KYC provider are routine and do not warrant being logged to the logger as an error so they are set (by default) to a lower log level.