### PR TITLE
Fix: Change KeetaNet import to namespace import to resolve undefined error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import type {
 	Client as KeetaNetClient,
 	UserClient as KeetaNetUserClient
 } from '@keetanetwork/keetanet-client';
-import KeetaNet from '@keetanetwork/keetanet-client';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
 
 type KeetaNetNetworks = typeof KeetaNet.Client.Config.networksArray[number];
 type ResolverOptions = Partial<Omit<ConstructorParameters<typeof Resolver>[0], 'client'>> & {


### PR DESCRIPTION
 ## Problem
When using `getDefaultResolverConfig` in wallet, the following error occurred:

```
  TypeError: Cannot read properties of undefined (reading  'lib')
      at getDefaultResolverConfig (config.ts:41:34)
      at createRootResolver (hooks.ts:136:18)
```

## Root Cause
The `@keetanetwork/keetanet-client` module doesn't export a default export, but the code was attempting to import it as a default import. This resulted in `KeetaNet` being `undefined`, causing the error when trying to access properties like `KeetaNet.lib.Account` or `KeetaNet.Client.Config`.

## Solution
Changed the import statement from:
```typescript
import KeetaNet from '@keetanetwork/keetanet-client';
```

to:
```typescript
import * as KeetaNet from '@keetanetwork/keetanet-client';
```

This correctly imports the namespace object containing all named exports from the module.

### Testing

- Verified `getDefaultResolverConfig` can now be called without errors
- Confirmed the resolver config is properly initialized with access to `KeetaNet.Client.Config` properties