### PR TITLE
Release v0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.25",
+			"version": "0.0.26",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.25",
+	"version": "0.0.26",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This change increments release number to 0.0.26 to create a release containing the following.

- 86a159399ba680fcb8b83dcc33d8dec5804bc841     Add `(SOLANA | TRON | BITCOIN)_SEND` types and related locations (#116)
- 56b443e67d9473de76702d45cb8944ad07fa9ba9     Add "intermediates" to SharableCertificateAttributes (#117)