### PR TITLE
Release: `v0.0.27`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.26",
+			"version": "0.0.27",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.26",
+	"version": "0.0.27",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This change increments release number to 0.0.27 to create a release containing the following:

https://github.com/KeetaNetwork/anchor/commit/f9b0b75a5ae9cd58e1b21a7c8ad34ec1cdeede04 Fix: ASN.1 Encoding Fixes with Backward Compatibility (https://github.com/KeetaNetwork/anchor/pull/120)