### PR TITLE
add valueRules to KeetaAnchorUserValidationError

### DIFF
--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -281,7 +281,7 @@ interface KeetaAnchorUserValidationErrorDetails {
 		allowedValues?: string[];
 		expected?: string;
 		receivedValue?: unknown;
-		valueRules?: { minimum?: string | number | undefined; maximum?: string | number | undefined };
+		valueRules?: { minimum?: string | undefined; maximum?: string | undefined };
 	}[];
 }
 


### PR DESCRIPTION
This PR allows anchors to provide additional context around what values are correct for a field, after a user enters an incorrect value.

This change adds an optional minimum/maximum for a field to tell the client what range of values would be accepted.