### PR TITLE
fix(fx-client): Get exchange status using wrong param name

### DIFF
--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -200,7 +200,7 @@ for (const useDeprecated of [false, true]) {
 								getEstimate: `${serverURL}/api/getEstimate`,
 								getQuote: `${serverURL}/api/getQuote`,
 								createExchange: `${serverURL}/api/createExchange`,
-								getExchangeStatus: `${serverURL}/api/getExchangeStatus/{exchangeID}`
+								getExchangeStatus: `${serverURL}/api/getExchangeStatus/{id}`
 							}
 						},
 						Test2: {

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -397,7 +397,7 @@ class KeetaFXAnchorProviderBase extends KeetaFXAnchorBase {
 	}
 
 	async getExchangeStatus(exchangeID: string): Promise<KeetaFXAnchorExchange> {
-		const serviceURL = (await this.serviceInfo.operations.getExchangeStatus)({ exchangeID });
+		const serviceURL = (await this.serviceInfo.operations.getExchangeStatus)({ id: exchangeID });
 		const requestInformation = await fetch(serviceURL, {
 			method: 'GET',
 			headers: {


### PR DESCRIPTION
On the current implementation, there's an error on **FX Client** when using `getExchangeStatus`.

Example:
```ts
const retval = await quote.createExchange(block)
const updated = await retval.getExchangeStatus()
```

The request URL is `https://demo-fx-anchor.test.keeta.com/api/getExchangeStatus/%7Bid%7D` instead of using the correct `exchangeID`.

This PR fixes that problem, calling the correct URL: `https://demo-fx-anchor.test.keeta.com/api/getExchangeStatus/736FE8F5DAE19F8E2DEA437788D196992D6C4CAB0FD5B7CA296E99A8C6C267D6`