### PR TITLE
Keeta Network Anchor SDK v0.0.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.37",
+	"version": "0.0.38",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.37",
+			"version": "0.0.38",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.37",
+	"version": "0.0.38",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This is KeetaNet Anchor v0.0.38 which has the following changes:
- a692f60a733806510ed127e0fd9f4ebeca8ccaa5     Do not require fx quote before anchor exchange (#152)
- 0aafa2e46d81f15997179b0bc0fc87e66c930002     Keep worker lock updated timestamp up-to-date as progress happens (#156)
- 353c8f6cb133445ec44b6d8a11e269d87111f391     Upgrade to latest KeetaNet Node (v0.14.14) (#157)
- f02c13fa883d81aad9e3d45bac6875594b392a05     fix(fx-client): Get exchange status using wrong param name (#154)
- 6363985d5bb994f041f8a9bc5bf14358fd047c2c     fix: When creating exchange, add status if it's missing on FX anchor response for backward compatibility (#153)
- 045dec3109a32e96ffdbb9dce19543d64dcd5570     Add more comments to asset movement `common.ts` (#147)

