### PR TITLE
Add Discord release notification

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Notify Discord
         continue-on-error: true
         run: |
+          # 1427361285888016635 is the Discord role ID to ping on release.
+          # To find a role ID: enable Developer Mode in Discord (Settings -> Advanced -> Developer Mode),
+          # then right-click the role in Server Settings -> Roles and select "Copy Role ID".
           curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -d '{"content": "<@&1427361285888016635> **Anchor v${{ steps.get_version.outputs.version }}** has been released! https://github.com/KeetaNetwork/anchor/releases/tag/${{ steps.get_version.outputs.tag }}"}'


### PR DESCRIPTION
Adds a Discord webhook notification to the create-release workflow that pings a role and posts a link when a new release is published.