### PR TITLE
Add support for a GraphemeString utility class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ help:
 node_modules/.done: package.json package-lock.json Makefile
 	rm -rf node_modules
 	npm clean-install
+	cp node_modules/unicode-confusables/index.ts.d node_modules/unicode-confusables/index.d.ts
 	@touch node_modules/.done
 
 # Creates the "node_modules" directory -- this target is for

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",
 				"@keetanetwork/keetanet-client": "0.14.14",
-				"typia": "9.5.0"
+				"typia": "9.5.0",
+				"unicode-confusables": "0.1.1"
 			},
 			"devDependencies": {
 				"@cspell/cspell-types": "9.6.0",
@@ -17216,6 +17217,12 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
 			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
 			"devOptional": true,
+			"license": "MIT"
+		},
+		"node_modules/unicode-confusables": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/unicode-confusables/-/unicode-confusables-0.1.1.tgz",
+			"integrity": "sha512-XTPBWmT88BDpXz9NycWk4KxDn+/AJmJYYaYBwuIH9119sopwk2E9GxU9azc+JNbhEsfiPul78DGocEihCp6MFQ==",
 			"license": "MIT"
 		},
 		"node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 	"dependencies": {
 		"@keetanetwork/currency-info": "1.2.5",
 		"@keetanetwork/keetanet-client": "0.14.14",
-		"typia": "9.5.0"
+		"typia": "9.5.0",
+		"unicode-confusables": "0.1.1"
 	},
 	"engines": {
 		"node": "20.18.0"

--- a/src/lib/utils/grapheme-string.ts
+++ b/src/lib/utils/grapheme-string.ts
@@ -1,53 +1,210 @@
+/* cspell:ignore NKFC Confusables remappings deconfused */
+import * as unicodeConfusables from 'unicode-confusables/index.js';
+
 const whitespaceRegex = /\s/;
 function isWhitespace(char: string): boolean {
 	return(whitespaceRegex.test(char));
 }
 
+const utf16SurrogatePairRegex = /^[\uD800-\uDBFF][\uDC00-\uDFFF]$/;
+function isSingleUTF16EncodedCodePoint(segment: string): boolean {
+	if (segment.length === 1) {
+		return(true);
+	}
+
+	if (segment.length === 2) {
+		return(utf16SurrogatePairRegex.test(segment));
+	}
+
+	return(false);
+}
+
+
 type removeIndexSignature<T> = {
 	[K in keyof T as string extends K ? never : number extends K ? never : K]: T[K]
 };
 
+const PARANOID = true;
+
+type GraphemeStringOptions = {
+	/**
+	 * Any locale that is supported by Intl.Segmenter, if not provided,
+	 * the default locale will be used. This will affect how the string
+	 * is segmented into grapheme clusters, as different locales may have
+	 * different rules for what constitutes a grapheme cluster.
+	 */
+	locale?: ConstructorParameters<typeof Intl.Segmenter>[0];
+}
+
 // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
-export class GraphemeString implements removeIndexSignature<String> {
+abstract class GraphemeStringBase implements removeIndexSignature<String> {
 	readonly #parts: string[];
-	readonly #locale: ConstructorParameters<typeof Intl.Segmenter>[0] | undefined;
+	protected readonly options: GraphemeStringOptions;
+
+	#original: string | null;
 	#bytes: Uint8Array | null = null;
-	#byteLength: number | null = null;
 
 	readonly length: number;
 
-	constructor(input: string | string[] | Uint8Array, locale?: ConstructorParameters<typeof Intl.Segmenter>[0]);
-	constructor(input: GraphemeString);
-	constructor(input: string | string[] | GraphemeString | Uint8Array, locale?: ConstructorParameters<typeof Intl.Segmenter>[0]) {
-		if (input instanceof GraphemeString) {
-			if (locale !== undefined) {
-				throw(new Error('Locale argument must not be provided when input is a GraphemeString'));
+	private static readonly KeetaAnchorGraphemeStringBaseObjectTypeID = 'c44bb821-d35b-43c2-9dfe-aae7fc9cfe7f';
+
+	/**
+	 * Get the constructor of the actual GraphemeString subclass to
+	 * construct new instances of the correct type when constructing
+	 * from parts.
+	 */
+	protected get newConstructor(): new (input: string | string[] | GraphemeStringBase | Uint8Array, options?: GraphemeStringOptions) => this {
+		throw(new Error('newConstructor getter must be implemented by subclasses of GraphemeStringBase'));
+	}
+
+	/**
+	 * Validate a segment of the input string to determine if it should be
+	 * allowed as a grapheme cluster segment. This will be called for each
+	 * segment and should return true if the segment is valid and should be
+	 * included in the GraphemeString or false if it's invalid, in which
+	 * case the string will not be able to be constructed from the input
+	 * and an error will be thrown.
+	 *
+	 * Flow is [filterSegment -> remapSegment -> validateSegment], so if a
+	 * segment is filtered out by filterSegment, it will not be passed to
+	 * remapSegment or validateSegment, and if a segment is remapped by
+	 * remapSegment, the remapped segments will be passed to validateSegment
+	 * instead of the original segment.
+	 */
+	protected abstract validateSegment(segment: string): boolean;
+
+	/**
+	 * Filter out segments that are not part of the original representation
+	 * of the string -- this includes things like SHY, zero-width-joiners,
+	 * zero-width-non-joiners, and other non-printable characters that
+	 * should not be treated as separate grapheme clusters, but should
+	 * instead be attached to the previous segment (if valid).
+	 */
+	protected abstract filterSegment(segment: string): boolean;
+
+	/**
+	 * Remap a segment of the input string to zero or more segments that
+	 * should be done canonically. This will be called for each
+	 * segment and should return an array of segments that should be
+	 * included in the GraphemeString in place of the original segment.
+	 *
+	 * If the segment should be excluded entirely, return an empty array.
+	 * If the segment should be included as-is, return an array containing
+	 * just the original segment.
+	 */
+	protected abstract remapSegment(segment: string): string[];
+
+	static isInstance(value: unknown): value is GraphemeStringBase {
+		if (typeof value !== 'object' || value === null) {
+			return(false);
+		}
+
+		if (!('KeetaAnchorGraphemeStringBaseObjectTypeID' in value)) {
+			return(false);
+		}
+
+		if (value.KeetaAnchorGraphemeStringBaseObjectTypeID === GraphemeStringBase.KeetaAnchorGraphemeStringBaseObjectTypeID) {
+			return(true);
+		}
+
+		return(false);
+	}
+
+	constructor(input: string | string[] | Uint8Array, options?: GraphemeStringOptions);
+	constructor(input: GraphemeStringBase);
+	constructor(input: string | string[] | GraphemeStringBase | Uint8Array, options?: GraphemeStringOptions) {
+		let paranoidCheckRequired = false;
+
+		Object.defineProperty(this, 'KeetaAnchorGraphemeStringBaseObjectTypeID', {
+			value: GraphemeStringBase.KeetaAnchorGraphemeStringBaseObjectTypeID,
+			enumerable: false
+		});
+
+		if (GraphemeStringBase.isInstance(input)) {
+			if (options !== undefined) {
+				throw(new Error('Options cannot be provided when constructing a GraphemeString from another GraphemeString'));
 			}
 
 			this.#parts = [...input.#parts];
-			this.#locale = input.#locale;
+			this.options = { ...input.options };
+			this.#original = input.#original;
 		} else if (Array.isArray(input)) {
 			this.#parts = [...input];
-			this.#locale = locale;
+			this.options = { ...options };
+			this.#original = null;
+
+			paranoidCheckRequired = true;
 		} else {
+			this.options = { ...options };
+
 			if (input instanceof Uint8Array) {
 				const decoder = new TextDecoder();
 				input = decoder.decode(input);
 			}
 
-			const segmenter = new Intl.Segmenter(locale, { granularity: 'grapheme' });
-			const normalizedInput = input.normalize('NFC');
-			const segments = segmenter.segment(normalizedInput);
-			const parts = Array.from(segments);
-			this.#parts = parts.map(function(part) {
+			const inputNormalized = input.normalize('NFC');
+
+			const segmenter = new Intl.Segmenter(options?.locale, { granularity: 'grapheme' });
+			const segments = segmenter.segment(inputNormalized);
+			const parts = Array.from(segments).map(function(part) {
 				return(part.segment);
 			});
-			this.#locale = locale;
+
+			/*
+			 * Apply any lossless normalization to the original
+			 * string
+			 */
+			const original = parts.filter((part) => {
+				return(this.filterSegment(part));
+			});
+			this.#original = original.join('');
+
+			/*
+			 * Apply any remapping to the segments, which may
+			 * result in some segments being split into multiple
+			 * segments or some segments being removed entirely.
+			 */
+			this.#parts = original.map((part) => {
+				const remappedSegments = this.remapSegment(part);
+
+				for (const remappedSegment of remappedSegments) {
+					if (!this.validateSegment(remappedSegment)) {
+						throw(new Error(`Invalid segment in input string: ${part}`));
+					}
+				}
+
+				return(remappedSegments);
+
+			}).flat(1);
+
 		}
 
 		Object.freeze(this.#parts);
 
 		this.length = this.#parts.length;
+
+		if (PARANOID && paranoidCheckRequired) {
+			/*
+			 * Validate that the input is already a
+			 * canonicalized grapheme cluster string by
+			 * constructing a new GraphemeString from the
+			 * parts and comparing it to the original input.
+			 *
+			 * This will ensure that the input is what we
+			 * would have generated if we had constructed
+			 * the GraphemeString from a regular string
+			 * directly instead of from parts, which is
+			 * important because otherwise you could end
+			 * up with a GraphemeString that has parts that
+			 * are not actually grapheme clusters, which
+			 * would break the API and cause various
+			 * methods to behave incorrectly.
+			 */
+			const checked = new this.newConstructor(this.toString(), this.options);
+			if (checked.bytes.join(',') !== this.bytes.join(',') || checked.toString() !== this.toString()) {
+				throw(new Error('Paranoid check failed: GraphemeString constructed from parts does not match original input'));
+			}
+		}
 	}
 
 	/**
@@ -62,11 +219,22 @@ export class GraphemeString implements removeIndexSignature<String> {
 	}
 
 	valueOf(): string {
-		return(this.toString());
+		return(this.toCanonicalString());
+	}
+
+	/**
+	 * Get the canonicalized interpretation of the GraphemeString
+	 */
+	toCanonicalString(): string {
+		return(this.#parts.join(''));
 	}
 
 	toString(): string {
-		return(this.#parts.join(''));
+		if (this.#original === null) {
+			this.#original = this.toCanonicalString();
+		}
+
+		return(this.#original);
 	}
 
 	/**
@@ -75,6 +243,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 	get bytes(): Uint8Array {
 		if (this.#bytes === null) {
 			const encoder = new TextEncoder();
+
 			this.#bytes = encoder.encode(this.toString());
 		}
 
@@ -85,11 +254,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 	 * The byte length of the UTF-8 Encoding of this GraphemeString.
 	 */
 	get byteLength(): number {
-		if (this.#byteLength === null) {
-			this.#byteLength = this.bytes.length;
-		}
-
-		return(this.#byteLength);
+		return(this.bytes.length);
 	}
 
 	charAt(pos: number): string {
@@ -112,11 +277,11 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new Error('charCodeAt is not supported by GraphemeString'));
 	}
 
-	concatGrapheme(...strings: (string | GraphemeString)[]): GraphemeString {
+	concatGrapheme(...strings: (string | GraphemeStringBase)[]): this {
 		const stringsToConcat = strings.map(function(str) {
 			if (typeof str === 'string') {
 				return(str);
-			} else if (str instanceof GraphemeString) {
+			} else if (GraphemeStringBase.isInstance(str)) {
 				/* XXX:TODO: What do we do about multiple locales ? */
 				return(str.toString());
 			} else {
@@ -126,14 +291,14 @@ export class GraphemeString implements removeIndexSignature<String> {
 
 		const concatenatedString = this.toString() + stringsToConcat.join('');
 
-		return(new GraphemeString(concatenatedString, this.#locale));
+		return(new this.newConstructor(concatenatedString, this.options));
 	}
 
-	concat(...strings: (string | GraphemeString)[]): string {
+	concat(...strings: (string | GraphemeStringBase)[]): string {
 		return(this.concatGrapheme(...strings).toString());
 	}
 
-	includes(searchString: string | GraphemeString, position?: number): boolean {
+	includes(searchString: string | GraphemeStringBase, position?: number): boolean {
 		const indexOf = this.indexOf(searchString, position);
 
 		if (indexOf !== -1) {
@@ -143,10 +308,10 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(false);
 	}
 
-	indexOf(searchString: string | GraphemeString, position?: number): number {
-		let searchStringEncoded: GraphemeString;
+	indexOf(searchString: string | GraphemeStringBase, position?: number): number {
+		let searchStringEncoded: GraphemeStringBase;
 		if (typeof searchString === 'string') {
-			searchStringEncoded = new GraphemeString(searchString);
+			searchStringEncoded = new this.newConstructor(searchString);
 		} else {
 			searchStringEncoded = searchString;
 		}
@@ -155,7 +320,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 
 		for (let index = startPos; index <= this.length - searchStringEncoded.length; index++) {
 			const segment = this.#parts.slice(index, index + searchStringEncoded.length).join('');
-			if (segment === searchStringEncoded.toString()) {
+			if (segment === searchStringEncoded.toCanonicalString()) {
 				return(index);
 			}
 		}
@@ -163,10 +328,10 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(-1);
 	}
 
-	lastIndexOf(searchString: string | GraphemeString, position?: number): number {
-		let searchStringEncoded: GraphemeString;
+	lastIndexOf(searchString: string | GraphemeStringBase, position?: number): number {
+		let searchStringEncoded: GraphemeStringBase;
 		if (typeof searchString === 'string') {
-			searchStringEncoded = new GraphemeString(searchString);
+			searchStringEncoded = new this.newConstructor(searchString);
 		} else {
 			searchStringEncoded = searchString;
 		}
@@ -180,7 +345,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 
 		for (let index = startPos; index >= 0; index--) {
 			const segment = this.#parts.slice(index, index + searchStringEncoded.length).join('');
-			if (segment === searchStringEncoded.toString()) {
+			if (segment === searchStringEncoded.toCanonicalString()) {
 				return(index);
 			}
 		}
@@ -223,12 +388,12 @@ export class GraphemeString implements removeIndexSignature<String> {
 		 */
 		if (match instanceof RegExp) {
 			const regex = new RegExp(match.source, match.flags);
-			return(regex.exec(this.toString()));
+			return(regex.exec(this.toCanonicalString()));
 		}
 
 		if (typeof match[Symbol.match] === 'function') {
 			const matcher = match[Symbol.match].bind(match);
-			return(matcher(this.toString()));
+			return(matcher(this.toCanonicalString()));
 		}
 
 		throw(new TypeError('Argument must be a string, RegExp, or an object with a [Symbol.match] method'));
@@ -237,7 +402,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 	/**
 	 * TODO
 	 */
-	replaceGrapheme(..._ignore_args: unknown[]): GraphemeString {
+	replaceGrapheme(..._ignore_args: unknown[]): this {
 		throw(new Error('not implemented'));
 	}
 
@@ -250,7 +415,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new Error('not implemented'));
 	}
 
-	search(start: string | GraphemeString): number;
+	search(start: string | GraphemeStringBase): number;
 	/**
 	 * Partially supported by GraphemeString, but it will not work correctly for regexes that match within grapheme clusters. Use with caution.
 	 * @deprecated
@@ -258,14 +423,14 @@ export class GraphemeString implements removeIndexSignature<String> {
 	// eslint-disable-next-line @typescript-eslint/unified-signatures
 	search(start: RegExp): number;
 	// Cannot be combined - some overloads are deprecated, others are not
-	search(start: string | GraphemeString | RegExp): number {
-		if (typeof start === 'string' || start instanceof GraphemeString) {
+	search(start: string | GraphemeStringBase | RegExp): number {
+		if (typeof start === 'string' || GraphemeStringBase.isInstance(start)) {
 			return(this.indexOf(start));
 		}
 
 		if (start instanceof RegExp) {
 			const regex = new RegExp(start.source, start.flags);
-			const match = regex.exec(this.toString());
+			const match = regex.exec(this.toCanonicalString());
 			if (match) {
 				return(match.index);
 			} else {
@@ -276,9 +441,9 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new TypeError('Argument must be a string, GraphemeString, or RegExp'));
 	}
 
-	sliceGrapheme(start?: number, end?: number): GraphemeString {
+	sliceGrapheme(start?: number, end?: number): this {
 		const slicedParts = this.#parts.slice(start, end);
-		return(new GraphemeString(slicedParts, this.#locale));
+		return(new this.newConstructor(slicedParts, this.options));
 	}
 
 	/**
@@ -311,9 +476,9 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new Error('not implemented'));
 	}
 
-	substringGrapheme(start: number, end?: number): GraphemeString {
+	substringGrapheme(start: number, end?: number): this {
 		const slicedParts = this.#parts.slice(start, end);
-		return(new GraphemeString(slicedParts, this.#locale));
+		return(new this.newConstructor(slicedParts, this.options));
 	}
 
 	/**
@@ -358,7 +523,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new Error('toLocaleUpperCase is not supported by GraphemeString'));
 	}
 
-	trimStartGrapheme(): GraphemeString {
+	trimStartGrapheme(): this {
 		let start = 0;
 		for (let index = start; index < this.length; index++) {
 			const char = this.charAt(index);
@@ -372,7 +537,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(this.sliceGrapheme(start));
 	}
 
-	trimEndGrapheme(): GraphemeString {
+	trimEndGrapheme(): this {
 		let end = this.length - 1;
 		for (let index = end; index >= 0; index--) {
 			const char = this.charAt(index);
@@ -386,15 +551,15 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(this.sliceGrapheme(0, end + 1));
 	}
 
-	trimLeftGrapheme(): GraphemeString {
+	trimLeftGrapheme(): this {
 		return(this.trimStartGrapheme());
 	}
 
-	trimRightGrapheme(): GraphemeString {
+	trimRightGrapheme(): this {
 		return(this.trimEndGrapheme());
 	}
 
-	trimGrapheme(): GraphemeString {
+	trimGrapheme(): this {
 		return(this.trimStartGrapheme().trimEndGrapheme());
 	}
 
@@ -418,7 +583,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(this.trimGrapheme().toString());
 	}
 
-	substrGrapheme(start: number, length?: number): GraphemeString {
+	substrGrapheme(start: number, length?: number): this {
 		let end: number | undefined;
 		if (length !== undefined) {
 			end = start + length;
@@ -446,10 +611,10 @@ export class GraphemeString implements removeIndexSignature<String> {
 		throw(new Error('codePointAt is not supported by GraphemeString'));
 	}
 
-	endsWith(searchString: string | GraphemeString, position?: number): boolean {
-		let searchStringEncoded: GraphemeString;
+	endsWith(searchString: string | GraphemeStringBase, position?: number): boolean {
+		let searchStringEncoded: GraphemeStringBase;
 		if (typeof searchString === 'string') {
-			searchStringEncoded = new GraphemeString(searchString);
+			searchStringEncoded = new this.newConstructor(searchString);
 		} else {
 			searchStringEncoded = searchString;
 		}
@@ -478,10 +643,10 @@ export class GraphemeString implements removeIndexSignature<String> {
 
 	// eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
 	normalize(...args: Parameters<String['normalize']>): string {
-		return(this.toString().normalize(...args));
+		return(this.toCanonicalString().normalize(...args));
 	}
 
-	repeatGrapheme(count: number): GraphemeString {
+	repeatGrapheme(count: number): this {
 		if (count < 0 || count === Infinity) {
 			throw(new RangeError('repeat count must be non-negative and not Infinity'));
 		}
@@ -493,17 +658,17 @@ export class GraphemeString implements removeIndexSignature<String> {
 		const baseString = this.toString();
 		const repeatedString = baseString.repeat(count);
 
-		return(new GraphemeString(repeatedString, this.#locale));
+		return(new this.newConstructor(repeatedString, this.options));
 	}
 
 	repeat(count: number): string {
 		return(this.repeatGrapheme(count).toString());
 	}
 
-	startsWith(searchString: string | GraphemeString, position = 0): boolean {
-		let searchStringEncoded: GraphemeString;
+	startsWith(searchString: string | GraphemeStringBase, position = 0): boolean {
+		let searchStringEncoded: GraphemeStringBase;
 		if (typeof searchString === 'string') {
-			searchStringEncoded = new GraphemeString(searchString);
+			searchStringEncoded = new this.newConstructor(searchString);
 		} else {
 			searchStringEncoded = searchString;
 		}
@@ -524,16 +689,16 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(false);
 	}
 
-	padStartGrapheme(targetLength: number, padString?: string | GraphemeString): GraphemeString {
+	padStartGrapheme(targetLength: number, padString?: string | GraphemeStringBase): this {
 		if (targetLength <= this.length) {
 			return(this);
 		}
 
 		padString ??= ' ';
 
-		let padStringEncoded: GraphemeString;
+		let padStringEncoded: GraphemeStringBase;
 		if (typeof padString === 'string') {
-			padStringEncoded = new GraphemeString(padString);
+			padStringEncoded = new this.newConstructor(padString);
 		} else {
 			padStringEncoded = padString;
 		}
@@ -552,23 +717,24 @@ export class GraphemeString implements removeIndexSignature<String> {
 
 		const retval = fullPaddingString.concatGrapheme(remainderPaddingString, this);
 
-		return(retval);
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		return(retval as this);
 	}
 
-	padStart(targetLength: number, padString?: string | GraphemeString): string {
+	padStart(targetLength: number, padString?: string | GraphemeStringBase): string {
 		return(this.padStartGrapheme(targetLength, padString).toString());
 	}
 
-	padEndGrapheme(targetLength: number, padString?: string | GraphemeString): GraphemeString {
+	padEndGrapheme(targetLength: number, padString?: string | GraphemeStringBase): this {
 		if (targetLength <= this.length) {
 			return(this);
 		}
 
 		padString ??= ' ';
 
-		let padStringEncoded: GraphemeString;
+		let padStringEncoded: GraphemeStringBase;
 		if (typeof padString === 'string') {
-			padStringEncoded = new GraphemeString(padString);
+			padStringEncoded = new this.newConstructor(padString);
 		} else {
 			padStringEncoded = padString;
 		}
@@ -590,7 +756,7 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(retval);
 	}
 
-	padEnd(targetLength: number, padString?: string | GraphemeString): string {
+	padEnd(targetLength: number, padString?: string | GraphemeStringBase): string {
 		return(this.padEndGrapheme(targetLength, padString).toString());
 	}
 
@@ -678,3 +844,153 @@ export class GraphemeString implements removeIndexSignature<String> {
 		return(this.toString().sup());
 	}
 }
+
+const isInvisible: { [key: string]: true } = {
+	'\u00AD': true, /* soft hyphen */
+	'\u200B': true, /* zero-width space */
+	'\u200C': true, /* zero-width non-joiner */
+	'\u200D': true, /* zero-width joiner */
+	'\uFEFF': true /* zero-width no-break space, also bom */
+};
+
+/*
+ * Extra re-mappings beyond the NKFC normalization and Unicode Confusables
+ */
+const remappings: { [key: string]: string[] } = {
+};
+
+type GraphemeStringTagOptions = {
+	/**
+	 * Whether to allow whitespace characters as valid grapheme clusters.
+
+	 * The default value is false.
+	 */
+	allowWhitespace?: boolean;
+}
+
+/**
+ * GraphemeStringTag provides a representation suitable for encoding short
+ * strings (usernames, tags, slugs, etc) with a canonical representation that
+ * can be compared to other strings in a way that is resistant to various types
+ * of spoofing and confusion attacks, while still being human-readable for
+ * things like length calculations.
+ *
+ * A normalized form of the original string, suitable for display purposes is
+ * available via the toString() method, while a canonicalized form of the
+ * string, suitable for comparison and length checking is available via the
+ * toCanonicalString() method.  The UTF-8 encoded original string is available
+ * via the bytes property
+ */
+export class GraphemeStringTag extends GraphemeStringBase {
+	constructor(input: string | string[] | Uint8Array, options?: GraphemeStringOptions & GraphemeStringTagOptions);
+	constructor(input: GraphemeStringBase);
+	constructor(input: string | string[] | GraphemeStringBase | Uint8Array, options?: GraphemeStringOptions & GraphemeStringTagOptions) {
+		if (GraphemeStringBase.isInstance(input)) {
+			if (options !== undefined) {
+				throw(new Error('Options cannot be provided when constructing a GraphemeString from another GraphemeString'));
+			}
+			super(input);
+		} else {
+			super(input, options);
+		}
+	}
+
+	protected get newConstructor(): new (input: string | string[] | GraphemeStringBase | Uint8Array, options?: GraphemeStringOptions & GraphemeStringTagOptions) => this {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		return(GraphemeStringTag as never);
+	}
+
+	protected get tagOptions(): GraphemeStringTagOptions {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		return(this.options as GraphemeStringOptions & GraphemeStringTagOptions);
+	}
+
+	protected validateSegment(segment: string): boolean {
+		/*
+		 * Disallow any whitespace characters (unless allowed by
+		 * options) because usernames are generally not expected
+		 * to contain whitespace
+		 */
+		if (!this.tagOptions.allowWhitespace) {
+			if (/^\p{White_Space}$/u.test(segment)) {
+				return(false);
+			}
+		}
+
+		/*
+		 * Disallow any segments that are entirely made up of non-printable
+		 * characters, specifically:
+		 *    p{M} (Mark) - combining marks, which are not standalone
+		 *                  grapheme clusters and should be attached
+		 *                  to the previous segment if valid
+		 *    p{Zl} (Separator, Line) - line separator characters,
+		 *                              which are not really acceptable
+		 *                              for usernames, tags, slugs, etc
+		 *    p{C} (Other) - control characters and other non-printable
+		 *                   characters, such as tabs, null, delete,
+		 *                   bom, etc, which are inappropriate for
+		 *                   snippets of text for human consumption
+		 *                   like usernames, tags, slugs, etc
+		 */
+		if (/^[\p{M}\p{Zl}\p{C}]+$/u.test(segment)) {
+			return(false);
+		}
+
+		return(true);
+	}
+
+	protected filterSegment(segment: string): boolean {
+		if (isInvisible[segment]) {
+			return(false);
+		}
+
+		return(true);
+	}
+
+	protected remapSegment(segment: string): string[] {
+		if (/^[a-zA-Z0-9]$/u.test(segment)) {
+			return([segment]);
+		}
+
+		const nfkc = segment.normalize('NFKC');
+		if (nfkc !== segment) {
+			return(nfkc.split(''));
+		}
+
+		/*
+		 * If the input is a single unicode codepoint (which may be
+		 * represented as one or two UTF-16 code units), check if
+		 * it's a confusable character and if so, remap it to the
+		 * original character(s) that it is confusable with.
+		 */
+		if (isSingleUTF16EncodedCodePoint(segment)) {
+			const deconfused = unicodeConfusables.rectifyConfusion(segment);
+			if (deconfused !== segment) {
+				return(deconfused.split(''));
+			}
+		}
+
+		const toRemap = remappings[segment];
+		if (toRemap !== undefined) {
+			return(toRemap);
+		}
+
+		return([segment]);
+	}
+
+	compare(other: string | this): boolean {
+		let otherEncoded: GraphemeStringTag;
+		if (typeof other === 'string') {
+			otherEncoded = new this.newConstructor(other, this.options);
+		} else {
+			otherEncoded = other;
+		}
+
+		return(this.toCanonicalString() === otherEncoded.toCanonicalString());
+	}
+}
+
+/** @internal */
+export const _Testing = {
+	GraphemeStringBase
+};


### PR DESCRIPTION
This change provides support for a `GraphemeString` utility class for handling short user strings that they tend to think of as having a length equivalent to their visible length.