### PR TITLE
Fix: Use Correct Hash Utility

### DIFF
--- a/src/services/storage/clients/contacts.ts
+++ b/src/services/storage/clients/contacts.ts
@@ -178,7 +178,10 @@ export class StorageContactsClient implements ContactsClient {
 
 	deriveId(address: ContactAddress): string {
 		const data = Buffer.from(canonicalizeContactAddress(address));
-		return(Buffer.from(KeetaNetLib.Utils.Hash.Hash(data)).toString('hex'));
+		const hash = KeetaNetLib.Utils.Hash.Hash(data);
+
+		const result = Buffer.from(hash).toString('hex');
+		return(result);
 	}
 
 	#serialize(contact: Contact): Buffer {


### PR DESCRIPTION
# Summary

The hash util was accidentally auto-imported by the contacts SDK. This updates to use `Hash` from `@keetanetwork/keetanet-client` instead.