### PR TITLE
Keeta Network Anchor SDK v0.0.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.42",
+	"version": "0.0.43",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.42",
+			"version": "0.0.43",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.42",
+	"version": "0.0.43",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This is KeetaNet Anchor v0.0.43 which has the following changes:
- 339c9f3c40138a8fa4043bd9160bb3d19ea6ad38     Allow fx anchors to list the affinities they support in the metadata (#215)
- 08972f93614e9c54b3e644aa1304ec332782683c     Feature: Icons Storage Client (#214)
- 6659d098effc3aefbdfae2de7ab9097aa37382be     Add metadata and errors on which operations an asset movement provider supports for a rail (#171)
- 6a7eba8303ffdbc89b48874a09c1ed769017d30f     Upgrade to KeetaNet Node and Client v0.16.0 (#217)
- 39578562a94569cf57e5d8d5cbf4f33e85f9d8e1     Add pricing only FX server and client methods to get pricing information from estimates (#210)
- efa2c5220aa104e0bb8cb5180763f7f78e179879     Add codegen to make adding new bank account locations easier (#168)
- 6dd9abe0997317d87be3fb770ec83d907c39b366     Add additional opaque metadata to asset movement transfers (#213)
- 1ad15ed8ac4ac966b72165ab79b96e76d7ff3424     Cleanup JSON Exports (#209)
