### PR TITLE
Fix GitHub Release notes

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,9 +16,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # We need to fetch the tags to get the tag message for the release notes,
+          # otherwise the "gh release create" command will use the commit message
+          # instead of the tag message for the release notes.
+          fetch-tags: true
 
       - name: Extract version from tag
         id: get_version
@@ -29,20 +33,10 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Tag: $TAG_NAME, Version: $VERSION"
 
-      - name: Extract notes from tag
-        id: get_notes
-        run: |
-          NOTES_FILE="$(mktemp)"
-          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
-          git show "${GITHUB_REF}" | sed '/^commit /,$ d;/^-----BEGIN PGP SIGNATURE-----/,$ d;0,/^ *$/ d' > "$NOTES_FILE"
-          echo "Extracted release notes to $NOTES_FILE"
-          ls -l "$NOTES_FILE"
-          cat "$NOTES_FILE"
-
       - name: Create GitHub Release
         run: |
           gh release create "${{ steps.get_version.outputs.tag }}" \
-            --notes-file "${{ steps.get_notes.outputs.notes_file }}" \
+            --notes-from-tag \
             --title "v${{ steps.get_version.outputs.version }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change fixes a bug in creating the GitHub release notes for a release of the Keeta Anchor SDK.  Prior to this change it would pull the notes from the commit instead of the tag.  This change fixes it so that it pull it from the tag instead of the commit.

This was caused by a bug: https://github.com/actions/checkout/issues/290

Fixed in v6.0.2: https://github.com/actions/checkout/pull/2356