### PR TITLE
Feature: add cors support for authenticated GET /api/object

### DIFF
--- a/src/services/storage/server.test.ts
+++ b/src/services/storage/server.test.ts
@@ -558,12 +558,12 @@ describe('Storage Server', function() {
 		const corsCases = [
 			{
 				name: 'GET /api/object includes CORS header when authenticatedCorsOrigin is configured',
-				authenticatedCorsOrigin: 'https://testing.example.com',
+				authenticatedCORSOrigin: 'https://testing.example.com',
 				expectedCorsHeader: 'https://testing.example.com'
 			},
 			{
 				name: 'GET /api/object includes default CORS header when authenticatedCorsOrigin is not configured',
-				authenticatedCorsOrigin: undefined,
+				authenticatedCORSOrigin: undefined,
 				expectedCorsHeader: '*'
 			}
 		] as const;
@@ -599,7 +599,7 @@ describe('Storage Server', function() {
 
 				expect(response.status).toBe(200);
 				expect(response.headers.get('Access-Control-Allow-Origin')).toBe(testCase.expectedCorsHeader);
-			}, testCase.authenticatedCorsOrigin ? { authenticatedCorsOrigin: testCase.authenticatedCorsOrigin } : undefined));
+			}, testCase.authenticatedCORSOrigin ? { authenticatedCORSOrigin: testCase.authenticatedCORSOrigin } : undefined));
 		});
 
 	});

--- a/src/services/storage/server.ts
+++ b/src/services/storage/server.ts
@@ -346,14 +346,14 @@ export interface KeetaAnchorStorageServerConfig extends KeetaAnchorHTTPServer.Ke
 	 * - specific origin string restricts to that origin
 	 * - false (default) disables CORS headers on public responses
 	 */
-	publicCorsOrigin?: string | false;
+	publicCORSOrigin?: string | false;
 
 	/**
 	 * CORS origin for authenticated object endpoints (default: '*').
 	 * - '*' allows all origins
 	 * - specific origin string restricts to that origin
 	 */
-	authenticatedCorsOrigin?: string;
+	authenticatedCORSOrigin?: string;
 
 	/**
 	 * Path policies for parsing, validating, and access control of storage paths.
@@ -411,8 +411,8 @@ export class KeetaNetStorageAnchorHTTPServer extends KeetaAnchorHTTPServer.Keeta
 		this.quotas = { ...DEFAULT_QUOTAS, ...config.quotas };
 		this.validators = config.validators ?? [];
 		this.signedUrlDefaultTTL = config.signedUrlDefaultTTL ?? DEFAULT_SIGNED_URL_TTL_SECONDS;
-		this.publicCorsOrigin = config.publicCorsOrigin ?? false;
-		this.authenticatedCorsOrigin = config.authenticatedCorsOrigin ?? '*';
+		this.publicCorsOrigin = config.publicCORSOrigin ?? false;
+		this.authenticatedCorsOrigin = config.authenticatedCORSOrigin ?? '*';
 		this.pathPolicies = config.pathPolicies;
 		this.tagValidation = {
 			maxTags: config.tagValidation?.maxTags ?? DEFAULT_TAG_VALIDATION.maxTags,


### PR DESCRIPTION
Adds a configuration parameter to define CORS rules for object access, with a default of `*`