### PR TITLE
Make EVM tokenAddress optional to indicate native asset transfers in instructions

### DIFF
--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -533,9 +533,10 @@ export type AssetTransferInstructions = ({
 	value: string;
 
 	/**
-	 * The EVM token contract address to send.
+	 * The ERC20 token contract address if non-native.
+	 * Omitting will indicate the network's native asset.
 	 */
-	tokenAddress: HexString;
+	tokenAddress?: HexString;
 } | {
 	/**
 	 * An EVM contract call instruction, used for assets that require contract interaction to transfer (ex: ERC20 contract deposit() method).


### PR DESCRIPTION
This would make `EVM_SEND` match the behavior of `TRON_SEND` and `SOLANA_SEND`.