### PR TITLE
Fix circular imports in Asset Movement Anchor

### DIFF
--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -6,7 +6,7 @@ import type { ToJSONSerializable } from '@keetanetwork/keetanet-client/lib/utils
 import type { HTTPSignedField } from '../../lib/http-server/common.js';
 import type { Signable } from '../../lib/utils/signing.js';
 import type { SharableCertificateAttributes } from '../../lib/certificates.js';
-import { KeetaNet } from '../../client/index.js';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
 import { KeetaAnchorUserError } from '../../lib/error.js';
 import type { AssetLocationLike, AssetLocationString, AssetLocationInput, AssetLocationCanonical } from './lib/location.js';
 import { convertAssetLocationInputToCanonical } from './lib/location.js';


### PR DESCRIPTION
This change fixes a circular import issue where `client/index.js` imports `lib/index.js` which imports `lib/resolver.js` which imports  `services/asset-movement/common.js` which in turn imports `client/index.js` creating an issue where some imports are not resolvable.