### PR TITLE
Cache inflight metadata requests

### DIFF
--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -611,6 +611,12 @@ test('Concurrent Lookups', async function() {
 		countryCodes: ['US' as const]
 	});
 
+	const initialCacheStats = { ...resolver.stats.cache };
+	expect(initialCacheStats).toEqual({ hit: 0, miss: 8 });
+
+	// Clear cache to ensure that following tests do not read more than the initial read
+	resolver.clearCache();
+
 	const lookupPromises = [];
 	for (let lookupID = 0; lookupID < concurrency; lookupID++) {
 		lookupPromises.push(resolver.lookup('banking', {
@@ -635,9 +641,9 @@ test('Concurrent Lookups', async function() {
 		const createAccount = await operations?.createAccount?.('string');
 		expect(createAccount).toEqual('https://banchor.testaccountexternal.com/api/v1/createAccount');
 	}
+
+	expect(resolver.stats.cache.miss).toEqual(initialCacheStats.miss);
 	expect(resolver.stats.reads).toBeGreaterThan(concurrency * 3);
-	expect(resolver.stats.cache.hit).toBeGreaterThan(resolver.stats.cache.miss);
-	expect(resolver.stats.cache.miss).toBeLessThan(concurrency * 2);
 	expect(resolver.stats.keetanet.reads + resolver.stats.https.reads + resolver.stats.unsupported.reads).toBe(resolver.stats.cache.miss);
 }, 30000);
 

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -809,7 +809,7 @@ type URLCacheObjectEntry = {
 /**
  * A cache object
  */
-type URLCacheObject = Map<string, URLCacheObjectEntry | Promise<URLCacheObjectEntry>>;
+type URLCacheObject = Map<string, Promise<URLCacheObjectEntry>>;
 
 
 type ResolverConfig = {
@@ -1223,8 +1223,6 @@ class Metadata implements ValuizableInstance {
 		this.#cache.instance.set(cacheKey, readPromise);
 
 		const resolvedValue = await readPromise;
-
-		this.#cache.instance.set(cacheKey, resolvedValue);
 
 		if (resolvedValue.pass) {
 			return(resolvedValue.value);

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -199,14 +199,17 @@ type ServiceMetadata = {
 		assetMovement?: {
 			[id: string]: {
 				operations: {
-					initiateTransfer?: ServiceMetadataEndpoint;
-					getTransferStatus?: ServiceMetadataEndpoint;
-					createPersistentForwardingTemplate?: ServiceMetadataEndpoint;
-					listPersistentForwardingTemplate?: ServiceMetadataEndpoint;
-					createPersistentForwarding?: ServiceMetadataEndpoint;
-					listPersistentForwarding?: ServiceMetadataEndpoint;
-					listTransactions?: ServiceMetadataEndpoint;
-					shareKYC?: ServiceMetadataEndpoint;
+					[Operation in (
+						'initiateTransfer' |
+						'executeTransfer' |
+						'getTransferStatus' |
+						'createPersistentForwardingTemplate' |
+						'listPersistentForwardingTemplate' |
+						'createPersistentForwarding' |
+						'listPersistentForwarding' |
+						'listTransactions' |
+						'shareKYC'
+					)]?: ServiceMetadataEndpoint;
 				};
 
 				supportedAssets: SupportedAssetsMetadata[];
@@ -793,10 +796,7 @@ type ValuizeResolvable = JSONSerializablePrimitive | ValuizableObject | Valuizab
  */
 const statsAccessToken = Symbol('statsAccessToken');
 
-/**
- * A cache object
- */
-type URLCacheObject = Map<string, {
+type URLCacheObjectEntry = {
 	pass: true;
 	value: JSONSerializable;
 	expires: Date;
@@ -804,7 +804,12 @@ type URLCacheObject = Map<string, {
 	pass: false;
 	error: unknown;
 	expires: Date;
-}>;
+};
+
+/**
+ * A cache object
+ */
+type URLCacheObject = Map<string, URLCacheObjectEntry | Promise<URLCacheObjectEntry>>;
 
 
 type ResolverConfig = {
@@ -1165,58 +1170,67 @@ class Metadata implements ValuizableInstance {
 		 * Verify that the cache entry is still valid.  If it is not,
 		 * then remove it from the cache.
 		 */
-		let cacheVal = this.#cache.instance.get(cacheKey);
+		const cacheValue = this.#cache.instance.get(cacheKey);
+		if (cacheValue) {
+			const resolvedCacheValue = await cacheValue;
 
-		if (this.#cache.instance.has(cacheKey) && cacheVal !== undefined) {
-			if (cacheVal.expires < new Date()) {
+			if (resolvedCacheValue.expires < new Date()) {
 				this.#cache.instance.delete(cacheKey);
-				cacheVal = undefined;
-			}
-		}
-
-		if (cacheVal !== undefined) {
-			this.#stats.cache.hit++;
-
-			if (cacheVal.pass) {
-				return(cacheVal.value);
 			} else {
-				throw(cacheVal.error);
+				this.#stats.cache.hit++;
+
+				if (resolvedCacheValue.pass) {
+					return(resolvedCacheValue.value);
+				} else {
+					throw(resolvedCacheValue.error);
+				}
 			}
 		}
 
 		this.#stats.cache.miss++;
 
-		let retval: JSONSerializable;
-		try {
-			const protocol = url.protocol;
-			if (protocol === 'keetanet:') {
-				retval = await this.readKeetaNetURL(url);
-			} else if (protocol === 'https:') {
-				retval = await this.readHTTPSURL(url);
-			} else {
-				this.#stats.unsupported.reads++;
-				throw(new Error(`Unsupported protocol: ${protocol}`));
+		const readPromise = (async (): Promise<URLCacheObjectEntry> => {
+			let retval: JSONSerializable;
+			try {
+				const protocol = url.protocol;
+				if (protocol === 'keetanet:') {
+					retval = await this.readKeetaNetURL(url);
+				} else if (protocol === 'https:') {
+					retval = await this.readHTTPSURL(url);
+				} else {
+					this.#stats.unsupported.reads++;
+					throw(new Error(`Unsupported protocol: ${protocol}`));
+				}
+
+				this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), ':', retval);
+
+				return({
+					pass: true,
+					value: retval,
+					expires: new Date(Date.now() + this.#cache.positiveTTL)
+				});
+			} catch (readError) {
+				this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), 'failed:', readError);
+
+				return({
+					pass: false,
+					error: readError,
+					expires: new Date(Date.now() + this.#cache.negativeTTL)
+				});
 			}
-		} catch (readError) {
-			this.#cache.instance.set(cacheKey, {
-				pass: false,
-				error: readError,
-				expires: new Date(Date.now() + this.#cache.negativeTTL)
-			});
+		})();
 
-			this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), 'failed:', readError);
-			throw(readError);
+		this.#cache.instance.set(cacheKey, readPromise);
+
+		const resolvedValue = await readPromise;
+
+		this.#cache.instance.set(cacheKey, resolvedValue);
+
+		if (resolvedValue.pass) {
+			return(resolvedValue.value);
+		} else {
+			throw(resolvedValue.error);
 		}
-
-		this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), ':', retval);
-
-		this.#cache.instance.set(cacheKey, {
-			pass: true,
-			value: retval,
-			expires: new Date(Date.now() + this.#cache.positiveTTL)
-		});
-
-		return(retval);
 	}
 
 	private async resolveValue<T extends ExternalURL | undefined>(value: T): Promise<JSONSerializable>;


### PR DESCRIPTION
Currently if the same request is made multiple times in parallel, it makes network requests each time. This update caches the promise for in-flight requests.