### PR TITLE
Upgrade to Keeta Network Node SDK v0.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",
-				"@keetanetwork/keetanet-client": "0.16.1",
+				"@keetanetwork/keetanet-client": "0.16.2",
 				"typia": "9.5.0"
 			},
 			"devDependencies": {
@@ -18,7 +18,7 @@
 				"@cspell/dict-typescript": "3.2.3",
 				"@google-cloud/firestore": "8.2.0",
 				"@keetanetwork/eslint-config-typescript": "1.4.7",
-				"@keetanetwork/keetanet-node": "0.16.1",
+				"@keetanetwork/keetanet-node": "0.16.2",
 				"@ryoppippi/unplugin-typia": "2.6.5",
 				"@types/asn1js": "2.0.2",
 				"@types/node": "20.16.10",
@@ -3071,9 +3071,9 @@
 			}
 		},
 		"node_modules/@keetanetwork/keetanet-client": {
-			"version": "0.16.1",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-client/0.16.1/886b3e01b22a41b3b205647649caa40afd9e5f28",
-			"integrity": "sha512-SS31ZlQvz/qvcZf039K3COjSje3FiQOPBbhB0xAfn2Mwrc+QSqvM/FEi/3uWZdEWqeu4+cziUi1vMRReBUMGwA==",
+			"version": "0.16.2",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-client/0.16.2/841ce5d38bd08105c6606bfe48ec0bea8111f2d3",
+			"integrity": "sha512-ifhICBG8k4r1Fyi+SaMgu9DUCIHuu5iV/YVmn2NKCwF7U+6kOoEJeRgrVyan9Vd8tF+xHtrj2O8dIwAWu44x9w==",
 			"license": "see LICENSE",
 			"dependencies": {
 				"secp256k1": "5.0.1"
@@ -3084,9 +3084,9 @@
 			}
 		},
 		"node_modules/@keetanetwork/keetanet-node": {
-			"version": "0.16.1",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.16.1/e0701c0dab7a98a7911cc50873c5ce4417080cfa",
-			"integrity": "sha512-2521ja/QC70WD3oGPUpm+/YdqurzBfrn8B92rOr4WbyEl4LtqnkPjx6GQLlIvQRPprEbU9K39z2RJAWJYSNHJQ==",
+			"version": "0.16.2",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.16.2/aa50f047efe2ab8cd24e1ee758b0078ece347fbc",
+			"integrity": "sha512-4st64U5LbmKPWR2lHovMNr3aMvFDGjbhcFrYuBIQ7akkJm/bxrINa+u6MjlaLK6c6Tg0U1dD+sFmRL+qapDl8A==",
 			"dev": true,
 			"license": "see LICENSE",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@cspell/dict-typescript": "3.2.3",
 		"@google-cloud/firestore": "8.2.0",
 		"@keetanetwork/eslint-config-typescript": "1.4.7",
-		"@keetanetwork/keetanet-node": "0.16.1",
+		"@keetanetwork/keetanet-node": "0.16.2",
 		"@ryoppippi/unplugin-typia": "2.6.5",
 		"@types/asn1js": "2.0.2",
 		"@types/node": "20.16.10",
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@keetanetwork/currency-info": "1.2.5",
-		"@keetanetwork/keetanet-client": "0.16.1",
+		"@keetanetwork/keetanet-client": "0.16.2",
 		"typia": "9.5.0"
 	},
 	"engines": {


### PR DESCRIPTION
This change upgrades to the latest release of the Keeta Network Node SDK ([v0.16.2](https://github.com/KeetaNetwork/node/releases/tag/releases%2Fv0.16.2)).