### PR TITLE
Exclude +/-Inf and decimals >1024 when parsing decimals

### DIFF
--- a/src/lib/token-metadata.test.ts
+++ b/src/lib/token-metadata.test.ts
@@ -16,12 +16,28 @@ test('Token metadata encoding / decoding', async function({ expect }) {
 		[ { decimalPlaces: '18' }, 'eyJkZWNpbWFsUGxhY2VzIjoxOH0=' ] // cspell:disable-line
 	] as const;
 
+	let testIndex = -1;
 	for (const test of tests) {
-		const decoded = decodeTokenMetadata(test[0]);
-		const encoded = encodeTokenMetadata(decoded);
+		testIndex++;
 
-		expect(decodeTokenMetadata(encoded)).toEqual(decodeTokenMetadata(test[1]));
-		expect(encoded).toEqual(test[1]);
+
+		let decoded;
+		let encoded;
+		try {
+			decoded = decodeTokenMetadata(test[0]);
+			encoded = encodeTokenMetadata(decoded);
+			expect(decodeTokenMetadata(encoded)).toEqual(decodeTokenMetadata(test[1]));
+		} catch (error) {
+			console.error(`Decoding failed for test #${testIndex}`, test);
+			throw(error);
+		}
+
+		try {
+			expect(encoded).toEqual(test[1]);
+		} catch (error) {
+			console.error(`Re-encoding failed for test #${testIndex}`, test);
+			throw(error);
+		}
 	}
 
 	const invalidTests: (TokenMetadataJSON | string)[] = [

--- a/src/lib/token-metadata.ts
+++ b/src/lib/token-metadata.ts
@@ -22,7 +22,7 @@ function parseDecimalPlaces(input: number | string): number {
 		value = Number(value);
 	}
 
-	if (Number.isFinite(value) || value < 0 || value > 1024 || !Number.isInteger(value)) {
+	if (!Number.isFinite(value) || value < 0 || value > 1024 || !Number.isInteger(value)) {
 		valid = false;
 	}
 

--- a/src/lib/token-metadata.ts
+++ b/src/lib/token-metadata.ts
@@ -6,7 +6,6 @@ export interface TokenMetadata {
 	logoURI?: string;
 }
 
-
 export interface TokenMetadataJSON extends Omit<TokenMetadata, "decimalPlaces"> {
 	decimalPlaces: number | string;
 }
@@ -23,7 +22,7 @@ function parseDecimalPlaces(input: number | string): number {
 		value = Number(value);
 	}
 
-	if (Number.isNaN(value) || value < 0 || !Number.isInteger(value)) {
+	if (Number.isFinite(value) || value < 0 || value > 1024 || !Number.isInteger(value)) {
 		valid = false;
 	}
 


### PR DESCRIPTION
This change improves the robustness of parsing token metadata decimals to match what the explorer does now (KeetaNetwork/explorer#17)