### PR TITLE
Feature: Add Signed Metadata

### DIFF
--- a/src/lib/anchor-metadata-server.ts
+++ b/src/lib/anchor-metadata-server.ts
@@ -1,7 +1,7 @@
 import type { KeetaAnchorHTTPServerConfig } from './http-server/index.js';
 import type { HTTPSignedField } from './http-server/common.js';
 import type { SignableAccount, VerifiableAccount } from './utils/signing.js';
-import type { SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
+import type { ServiceMetadataEndpoint, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
 import { KeetaNetAnchorHTTPServer } from './http-server/index.js';
 import { SignData, VerifySignedData, objectToSignable } from './utils/signing.js';
 
@@ -15,7 +15,7 @@ export const METADATA_SIGNATURE_NAMESPACE = 'keetanet/anchor/service-metadata/v1
  * by {@link KeetaAnchorMetadataServer}.
  */
 export type SignableServiceMetadata = SharedAnchorMetadataLegalExtension & {
-	operations: { [operationName: string]: unknown };
+	operations: { [operationName: string]: ServiceMetadataEndpoint | undefined };
 };
 
 /**

--- a/src/lib/anchor-metadata-server.ts
+++ b/src/lib/anchor-metadata-server.ts
@@ -1,0 +1,106 @@
+import type { KeetaAnchorHTTPServerConfig } from './http-server/index.js';
+import type { HTTPSignedField } from './http-server/common.js';
+import type { SignableAccount, VerifiableAccount } from './utils/signing.js';
+import type { SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
+import { KeetaNetAnchorHTTPServer } from './http-server/index.js';
+import { SignData, VerifySignedData, objectToSignable } from './utils/signing.js';
+
+/**
+ * Namespace tag bound into every service metadata signature.
+ */
+export const METADATA_SIGNATURE_NAMESPACE = 'keetanet/anchor/service-metadata/v1';
+
+/**
+ * Service metadata shape whose signed fields can be authenticated
+ * by {@link KeetaAnchorMetadataServer}.
+ */
+export type SignableServiceMetadata = SharedAnchorMetadataLegalExtension & {
+	operations: { [operationName: string]: unknown };
+};
+
+/**
+ * Canonical fields covered by the metadata signature. `namespace` scopes
+ * the signature to this protocol/version.
+ */
+export type SignedServiceMetadataFields = {
+	namespace: typeof METADATA_SIGNATURE_NAMESPACE;
+	account: string;
+	operations: SignableServiceMetadata['operations'];
+	legal?: SignableServiceMetadata['legal'];
+};
+
+export interface KeetaAnchorMetadataServerConfig extends KeetaAnchorHTTPServerConfig {
+	/** Signs the published metadata. Omit for unsigned metadata. */
+	metadataSigner?: SignableAccount | undefined;
+}
+
+/**
+ * Extracts the subset of `metadata` that is covered by the signature.
+ * `account` is the public-key string of the claimed signer.
+ */
+export function extractSignedFields(account: string, metadata: SignableServiceMetadata): SignedServiceMetadataFields {
+	const fields: SignedServiceMetadataFields = {
+		namespace: METADATA_SIGNATURE_NAMESPACE,
+		account: account,
+		operations: metadata.operations
+	};
+	if (metadata.legal !== undefined) {
+		fields.legal = metadata.legal;
+	}
+
+	return(fields);
+}
+
+/**
+ * Verifies that `signed` was produced by `account` over the signed
+ * fields of `metadata` (see {@link extractSignedFields}).
+ */
+export async function verifyMetadataSignature(account: VerifiableAccount, metadata: SignableServiceMetadata, signed: HTTPSignedField): Promise<boolean> {
+	const signedFields = extractSignedFields(account.publicKeyString.get(), metadata);
+	const signable = objectToSignable(signedFields);
+	const verifyOptions = { maxSkewMs: Number.POSITIVE_INFINITY };
+
+	return(await VerifySignedData(account, signable, signed, verifyOptions));
+}
+
+/**
+ * Publishes anchor service metadata, optionally signed by `metadataSigner`.
+ * Subclasses implement {@link buildServiceMetadata}.
+ */
+export abstract class KeetaAnchorMetadataServer<
+	Built extends SignableServiceMetadata,
+	C extends KeetaAnchorMetadataServerConfig = KeetaAnchorMetadataServerConfig
+> extends KeetaNetAnchorHTTPServer<C> {
+	readonly #metadataSigner: SignableAccount | undefined;
+
+	constructor(config: C) {
+		super(config);
+		this.#metadataSigner = config.metadataSigner;
+	}
+
+	get metadataSigner(): SignableAccount | undefined {
+		return(this.#metadataSigner);
+	}
+
+	protected abstract buildServiceMetadata(): Promise<Built>;
+
+	async serviceMetadata(): Promise<Built & SharedAnchorMetadataSignedExtension> {
+		const built = await this.buildServiceMetadata();
+
+		const signer = this.#metadataSigner;
+		if (signer === undefined) {
+			return(built);
+		}
+
+		const account = signer.publicKeyString.get();
+		const signedFields = extractSignedFields(account, built);
+		const signable = objectToSignable(signedFields);
+		const signed = await SignData(signer, signable);
+
+		return({
+			...built,
+			account,
+			signed
+		});
+	}
+}

--- a/src/lib/http-server/common.ts
+++ b/src/lib/http-server/common.ts
@@ -9,13 +9,13 @@ import { VerifySignedData } from "../utils/signing.js";
 
 export type ExtractOk<T> = Omit<Extract<T, { ok: true }>, 'ok'>;
 
-export interface HTTPSignedField {
+export type HTTPSignedField = {
 	nonce: string;
 	/* Date and time of the request in ISO 8601 format */
 	timestamp: string;
 	/* Signature of the account public key and the nonce as an ASN.1 Sequence, Base64 DER */
 	signature: string;
-}
+};
 
 export const assertHTTPSignedField: (input: unknown) => HTTPSignedField = createAssertEquals<HTTPSignedField>();
 

--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -26,6 +26,19 @@ export interface SharedAnchorMetadataLegalExtension {
 	legal?: AnchorMetadataLegalField;
 }
 
+/**
+ * Signature over `{ operations, legal }` for a service entry. When `account`
+ * is set, `signed` MUST be present and verify against it.
+ */
+export type SharedAnchorMetadataSignedExtension = {
+	account?: string;
+	signed?: {
+		nonce: string;
+		timestamp: string;
+		signature: string;
+	};
+};
+
 export type SharedAnchorCallerCertificateRequirementMetadata = {
 	/**
 	 * Issuer DNs this anchor accepts for caller authentication. Outer array

--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -1,4 +1,5 @@
 import { assertClientRenderableContentType } from "./metadata.types.generated.js";
+import type { HTTPSignedField } from "./http-server/common.js";
 import type { Logger } from "./log/index.js";
 import type { ToValuizable } from "./resolver.js";
 
@@ -32,11 +33,7 @@ export interface SharedAnchorMetadataLegalExtension {
  */
 export type SharedAnchorMetadataSignedExtension = {
 	account?: string;
-	signed?: {
-		nonce: string;
-		timestamp: string;
-		signature: string;
-	};
+	signed?: HTTPSignedField;
 };
 
 export type SharedAnchorCallerCertificateRequirementMetadata = {

--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -12,6 +12,19 @@ import type { ToValuizable } from "./resolver.js";
 export type ClientRenderableContent = { type: 'markdown' | 'plaintext'; content: string; };
 
 
+/**
+ * Authentication requirement attached to a service operation endpoint.
+ */
+export type ServiceMetadataAuthenticationType = {
+	method: 'keeta-account';
+	type: 'required' | 'optional' | 'none';
+};
+
+/**
+ * Operation endpoint exposed by a service.
+ */
+export type ServiceMetadataEndpoint = string | { url: string; options?: { authentication?: ServiceMetadataAuthenticationType; }};
+
 export interface AnchorMetadataLegalField {
 	disclaimers?: {
 		purpose: 'general';

--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -41,12 +41,16 @@ export interface SharedAnchorMetadataLegalExtension {
 }
 
 /**
- * Signature over `{ operations, legal }` for a service entry.
- * When `account` is set, `signed` MUST be present and verify against it.
+ * Signature over `{ operations, legal }` for a service entry. `account` and
+ * `signed` are coupled at runtime: either both are absent (unsigned entry)
+ * or both are present (signed entry that MUST verify). The coupling cannot
+ * be expressed at the type level without breaking `JSONSerializable`
+ * compatibility, so consumers MUST treat one-sided forms as malformed.
  */
-export type SharedAnchorMetadataSignedExtension =
-	| { account?: undefined; signed?: undefined }
-	| { account: string; signed: HTTPSignedField };
+export type SharedAnchorMetadataSignedExtension = {
+	account?: string;
+	signed?: HTTPSignedField;
+};
 
 export type SharedAnchorCallerCertificateRequirementMetadata = {
 	/**

--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -41,13 +41,12 @@ export interface SharedAnchorMetadataLegalExtension {
 }
 
 /**
- * Signature over `{ operations, legal }` for a service entry. When `account`
- * is set, `signed` MUST be present and verify against it.
+ * Signature over `{ operations, legal }` for a service entry.
+ * When `account` is set, `signed` MUST be present and verify against it.
  */
-export type SharedAnchorMetadataSignedExtension = {
-	account?: string;
-	signed?: HTTPSignedField;
-};
+export type SharedAnchorMetadataSignedExtension =
+	| { account?: undefined; signed?: undefined }
+	| { account: string; signed: HTTPSignedField };
 
 export type SharedAnchorCallerCertificateRequirementMetadata = {
 	/**

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -5,6 +5,8 @@ import { createAssert } from 'typia';
 import Resolver from './resolver.js';
 import type { ServiceMetadata, ServiceMetadataExternalizable, ServiceSearchCriteria } from './resolver.ts';
 import { createNodeAndClient, setResolverInfo as setInfo } from './utils/tests/node.js';
+import { SignData, objectToSignable } from './utils/signing.js';
+import { extractSignedFields } from './anchor-metadata-server.js';
 
 async function setupForResolverTests() {
 	const testAccountSeed = KeetaNetClient.lib.Account.generateRandomSeed();
@@ -12,6 +14,7 @@ async function setupForResolverTests() {
 	const testAccountExternal = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
 	const testAccountExternalRef = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
 	const testAccountLoop = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
+	const metadataSigner = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0).assertAccount();
 	const testCurrencyUSD = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
 	const testCurrencyMXN = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
 	const testCurrencyBTC = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
@@ -51,6 +54,40 @@ async function setupForResolverTests() {
 		external: '2b828e33-2692-46e9-817e-9b93d63f28fd',
 		url: `keetanet://${testAccountLoop.publicKeyString.get()}/metadata`
 	});
+
+	/*
+	 * Banking entries that exercise the metadata signature gate:
+	 * - keeta_signed: valid signature, MUST appear in lookups
+	 * - keeta_signed_tampered: signature does not cover the published
+	 *   operations, MUST be dropped
+	 * - keeta_signed_missing: account present without `signed`, MUST be dropped
+	 */
+	const signedBankingOperations = {
+		createAccount: 'https://banchor.signed.com/api/v1/createAccount'
+	};
+	const signedBankingAccount = metadataSigner.publicKeyString.get();
+	const signedBankingFields = extractSignedFields(signedBankingAccount, { operations: signedBankingOperations });
+	const signedBankingSignable = objectToSignable(signedBankingFields);
+	const signedBankingSignature = await SignData(metadataSigner, signedBankingSignable);
+	const signedBankingEntry = {
+		operations: signedBankingOperations,
+		countryCodes: ['US'],
+		currencyCodes: ['USD'],
+		kycProviders: ['Keeta'],
+		account: signedBankingAccount,
+		signed: signedBankingSignature
+	};
+	const tamperedBankingEntry = {
+		...signedBankingEntry,
+		operations: { createAccount: 'https://banchor.attacker.com/api/v1/createAccount' }
+	};
+	const missingSignatureBankingEntry = {
+		operations: { createAccount: 'https://banchor.missing-signature.com/api/v1/createAccount' },
+		countryCodes: ['US'],
+		currencyCodes: ['USD'],
+		kycProviders: ['Keeta'],
+		account: metadataSigner.publicKeyString.get()
+	};
 
 	/*
 	 * Set the metadata for the root account
@@ -99,6 +136,9 @@ async function setupForResolverTests() {
 						currencyCodes: ['MXN'],
 						kycProviders: ['Keeta']
 					},
+					keeta_signed: signedBankingEntry,
+					keeta_signed_tampered: tamperedBankingEntry,
+					keeta_signed_missing: missingSignatureBankingEntry,
 					keeta_https: {
 						/* HTTPS Link */
 						external: '2b828e33-2692-46e9-817e-9b93d63f28fd',
@@ -173,7 +213,7 @@ async function setupForResolverTests() {
 		 */
 		brokenServiceMetadata: {
 			services: {
-				banking: ['keeta_https', testAccountLoop.publicKeyString.get(), 'keeta_broken1', 'keeta_broken2', 'keeta_broken3', 'keeta_broken4', 'keeta_nomatch1', 'keeta_nomatch2']
+				banking: ['keeta_https', testAccountLoop.publicKeyString.get(), 'keeta_broken1', 'keeta_broken2', 'keeta_broken3', 'keeta_broken4', 'keeta_nomatch1', 'keeta_nomatch2', 'keeta_signed_tampered', 'keeta_signed_missing']
 			}
 		}
 	});
@@ -191,12 +231,12 @@ test('Basic Tests', async function() {
 			input: {
 				countryCodes: ['US' as const]
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				currencyCodes: ['USD' as const]
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				countryCodes: ['MX' as const]
@@ -212,7 +252,7 @@ test('Basic Tests', async function() {
 				countryCodes: ['US' as const],
 				currencyCodes: ['USD' as const]
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				countryCodes: ['MX' as const] ,
@@ -268,31 +308,31 @@ test('Basic Tests', async function() {
 			input: {
 				countryCodes: undefined
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				// @ts-expect-error
 				currencyCodes: null
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			// @ts-expect-error
 			input: {
 				countryCodes: undefined
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				// @ts-expect-error
 				countryCodes: null
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}, {
 			input: {
 				// @ts-expect-error
 				countryCodes: '123'
 			},
-			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount']
+			createAccount: ['https://banchor.testaccountexternal.com/api/v1/createAccount', 'https://banchor.signed.com/api/v1/createAccount']
 		}],
 		kyc: [],
 		fx: []
@@ -631,15 +671,21 @@ test('Concurrent Lookups', async function() {
 			throw(new Error('internal error: lookupResults is undefined'));
 		}
 
-		/*
-		 * Just look at the first result
-		 */
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-		const lookupResult = lookupResults[Object.keys(lookupResults)[0] as keyof typeof lookupResults];
+		const foundCreateAccountURLs: string[] = [];
+		for (const lookupResultID of Object.keys(lookupResults)) {
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			const lookupResult = lookupResults[lookupResultID as keyof typeof lookupResults];
+			const operations = await lookupResult?.operations('object');
+			const createAccount = await operations?.createAccount?.('string');
+			if (createAccount !== undefined) {
+				foundCreateAccountURLs.push(createAccount);
+			}
+		}
 
-		const operations = await lookupResult?.operations('object');
-		const createAccount = await operations?.createAccount?.('string');
-		expect(createAccount).toEqual('https://banchor.testaccountexternal.com/api/v1/createAccount');
+		expect(foundCreateAccountURLs.sort()).toEqual([
+			'https://banchor.signed.com/api/v1/createAccount',
+			'https://banchor.testaccountexternal.com/api/v1/createAccount'
+		]);
 	}
 
 	expect(resolver.stats.cache.miss).toEqual(initialCacheStats.miss);

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -202,6 +202,7 @@ async function setupForResolverTests() {
 
 	return({
 		resolver: resolver,
+		signedBankingAccount: signedBankingAccount,
 		tokens: {
 			USD: testCurrencyUSD,
 			MXN: testCurrencyMXN,
@@ -889,4 +890,64 @@ test('Multi-Root Resolver Tests', async function() {
 	});
 	expect(bankingServicesUSReverse).toBeDefined();
 	expect(Object.keys(bankingServicesUSReverse ?? {})).toContain('bank_root1');
+});
+
+type AccountsFilterCase = {
+	name: string;
+	criteria: ServiceSearchCriteria<'banking'>;
+	shared: { accounts?: string[]; providerIDs?: string[] };
+	expected: string[] | undefined;
+};
+
+function summarizeBankingLookup(result: Awaited<ReturnType<Resolver['lookup']>>): string[] | undefined {
+	if (result === undefined) {
+		return(undefined);
+	}
+
+	return(Object.keys(result));
+}
+
+test('SharedLookupCriteria.accounts: filters banking entries by signing account', async function() {
+	const { resolver, signedBankingAccount } = await setupForResolverTests();
+	const unrelatedAccountSeed = KeetaNetClient.lib.Account.generateRandomSeed();
+	const unrelatedAccountInstance = KeetaNetClient.lib.Account.fromSeed(unrelatedAccountSeed, 0);
+	const unrelatedAccount = unrelatedAccountInstance.publicKeyString.get();
+
+	const cases: AccountsFilterCase[] = [
+		{
+			name: 'matching account keeps signed entry',
+			criteria: { countryCodes: ['US'] },
+			shared: { accounts: [signedBankingAccount] },
+			expected: ['keeta_signed']
+		},
+		{
+			name: 'non-matching account drops all entries',
+			criteria: { countryCodes: ['US'] },
+			shared: { accounts: [unrelatedAccount] },
+			expected: undefined
+		},
+		{
+			name: 'unsigned entries are dropped when accounts filter is set',
+			criteria: { countryCodes: ['MX'] },
+			shared: { accounts: [unrelatedAccount] },
+			expected: undefined
+		},
+		{
+			name: 'composes with providerIDs (both match)',
+			criteria: { countryCodes: ['US'] },
+			shared: { accounts: [signedBankingAccount], providerIDs: ['keeta_signed'] },
+			expected: ['keeta_signed']
+		},
+		{
+			name: 'composes with providerIDs (no overlap)',
+			criteria: { countryCodes: ['US'] },
+			shared: { accounts: [signedBankingAccount], providerIDs: ['keeta_foo'] },
+			expected: undefined
+		}
+	];
+
+	for (const testCase of cases) {
+		const result = await resolver.lookup('banking', testCase.criteria, testCase.shared);
+		expect(summarizeBankingLookup(result), testCase.name).toEqual(testCase.expected);
+	}
 });

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -3,7 +3,7 @@ import * as KeetaNetClient from '@keetanetwork/keetanet-client';
 import * as CurrencyInfo from '@keetanetwork/currency-info';
 import { createAssert } from 'typia';
 import Resolver from './resolver.js';
-import type { ServiceMetadata, ServiceMetadataExternalizable, ServiceSearchCriteria } from './resolver.ts';
+import type { ServiceMetadata, ServiceMetadataExternalizable, ServiceSearchCriteria, SharedLookupCriteria } from './resolver.ts';
 import { createNodeAndClient, setResolverInfo as setInfo } from './utils/tests/node.js';
 import { SignData, objectToSignable } from './utils/signing.js';
 import { extractSignedFields } from './anchor-metadata-server.js';
@@ -203,6 +203,7 @@ async function setupForResolverTests() {
 	return({
 		resolver: resolver,
 		signedBankingAccount: signedBankingAccount,
+		signedBankingAccountInstance: metadataSigner,
 		tokens: {
 			USD: testCurrencyUSD,
 			MXN: testCurrencyMXN,
@@ -895,7 +896,7 @@ test('Multi-Root Resolver Tests', async function() {
 type AccountsFilterCase = {
 	name: string;
 	criteria: ServiceSearchCriteria<'banking'>;
-	shared: { accounts?: string[]; providerIDs?: string[] };
+	shared: SharedLookupCriteria;
 	expected: string[] | undefined;
 };
 
@@ -908,16 +909,22 @@ function summarizeBankingLookup(result: Awaited<ReturnType<Resolver['lookup']>>)
 }
 
 test('SharedLookupCriteria.accounts: filters banking entries by signing account', async function() {
-	const { resolver, signedBankingAccount } = await setupForResolverTests();
+	const { resolver, signedBankingAccount, signedBankingAccountInstance } = await setupForResolverTests();
 	const unrelatedAccountSeed = KeetaNetClient.lib.Account.generateRandomSeed();
-	const unrelatedAccountInstance = KeetaNetClient.lib.Account.fromSeed(unrelatedAccountSeed, 0);
-	const unrelatedAccount = unrelatedAccountInstance.publicKeyString.get();
+	const unrelatedAccount = KeetaNetClient.lib.Account.fromSeed(unrelatedAccountSeed, 0);
+	const unrelatedAccountString = unrelatedAccount.publicKeyString.get();
 
 	const cases: AccountsFilterCase[] = [
 		{
-			name: 'matching account keeps signed entry',
+			name: 'matching account (string form) keeps signed entry',
 			criteria: { countryCodes: ['US'] },
 			shared: { accounts: [signedBankingAccount] },
+			expected: ['keeta_signed']
+		},
+		{
+			name: 'matching account (Account instance) keeps signed entry',
+			criteria: { countryCodes: ['US'] },
+			shared: { accounts: [signedBankingAccountInstance] },
 			expected: ['keeta_signed']
 		},
 		{
@@ -929,7 +936,7 @@ test('SharedLookupCriteria.accounts: filters banking entries by signing account'
 		{
 			name: 'unsigned entries are dropped when accounts filter is set',
 			criteria: { countryCodes: ['MX'] },
-			shared: { accounts: [unrelatedAccount] },
+			shared: { accounts: [unrelatedAccountString] },
 			expected: undefined
 		},
 		{

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -652,7 +652,7 @@ test('Concurrent Lookups', async function() {
 	});
 
 	const initialCacheStats = { ...resolver.stats.cache };
-	expect(initialCacheStats).toEqual({ hit: 0, miss: 8 });
+	expect(initialCacheStats).toEqual({ hit: 6, miss: 8 });
 
 	// Clear cache to ensure that following tests do not read more than the initial read
 	resolver.clearCache();

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -1,5 +1,5 @@
 import * as KeetaNetClient from '@keetanetwork/keetanet-client';
-import type { GenericAccount as KeetaNetGenericAccount } from '@keetanetwork/keetanet-client/lib/account.js';
+import type { AccountPublicKeyString, GenericAccount as KeetaNetGenericAccount } from '@keetanetwork/keetanet-client/lib/account.js';
 import * as CurrencyInfo from '@keetanetwork/currency-info';
 import type { Logger } from './log/index.ts';
 import type { JSONSerializable } from './utils/json.ts';
@@ -1435,10 +1435,12 @@ type ResolverStats = {
 type SharedLookupCriteria = {
 	providerIDs?: string[];
 	/**
-	 * Restrict to entries signed by one of the listed account public keys.
-	 * Entries without a matching `account` are filtered out.
+	 * Restrict to entries signed by one of the listed accounts. Each entry
+	 * may be a {@link KeetaNetGenericAccount} or its public-key string
+	 * form. Entries without a matching `account` are filtered out
+	 * (including unsigned entries).
 	 */
-	accounts?: string[];
+	accounts?: (AccountPublicKeyString | VerifiableAccount)[];
 };
 
 /**
@@ -2595,8 +2597,12 @@ class Resolver {
 	 * without `account`, with an unresolvable `account`, or that fail to
 	 * resolve are dropped.
 	 */
-	async #filterByAccounts(servicesByID: ValuizableObject, accounts: string[]): Promise<ValuizableObject> {
-		const allowed = new Set(accounts);
+	async #filterByAccounts(servicesByID: ValuizableObject, accounts: (AccountPublicKeyString | VerifiableAccount)[]): Promise<ValuizableObject> {
+		const allowedKeys = new Set<string>();
+		for (const allowed of accounts) {
+			allowedKeys.add(KeetaNetClient.lib.Account.toPublicKeyString(allowed));
+		}
+
 		const retval: ValuizableObject = {};
 		for (const [ id, entry ] of Object.entries(servicesByID)) {
 			if (entry === undefined) {
@@ -2613,15 +2619,16 @@ class Resolver {
 				continue;
 			}
 
-			let entryAccount: string;
+			let entryAccountKey: string;
 			try {
-				entryAccount = await accountValuizable('string');
+				const entryAccountString = await accountValuizable('string');
+				entryAccountKey = KeetaNetClient.lib.Account.toPublicKeyString(entryAccountString);
 			} catch (resolveError) {
 				this.#logger?.debug(`Resolver:${this.id}`, 'Could not resolve `account` for service entry', id, ':', resolveError);
 				continue;
 			}
 
-			if (!allowed.has(entryAccount)) {
+			if (!allowedKeys.has(entryAccountKey)) {
 				continue;
 			}
 

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -12,7 +12,7 @@ import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCa
 import type { AssetLocationString, Rail, SupportedAssetsMetadata, RailOrRailWithExtendedDetails, AssetMovementRailSearchInput, AnchorCustomLocationMetadata } from '../services/asset-movement/common.js';
 import type { MovableAssetSearchInput, KeetaNetTokenPublicKeyString } from './asset.js';
 import type { NotificationChannelType, NotificationSubscriptionType, SupportedChannelConfigurationMetadata } from '../services/notification/common.js';
-import type { SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
+import type { ServiceMetadataAuthenticationType, ServiceMetadataEndpoint, SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
 import type { VerifiableAccount } from './utils/signing.js';
 import type { HTTPSignedField } from './http-server/common.js';
 import type { SignableServiceMetadata } from './anchor-metadata-server.js';
@@ -42,11 +42,6 @@ type CountrySearchCanonical = CurrencyInfo.ISOCountryCode; /* XXX:TODO */
 
 const isCurrencySearchCanonical = createIs<CurrencySearchCanonical>();
 
-type ServiceMetadataAuthenticationType = {
-	method: 'keeta-account';
-	type: 'required' | 'optional' | 'none';
-};
-type ServiceMetadataEndpoint = string | { url: string; options?: { authentication?: ServiceMetadataAuthenticationType; }}
 // #region Global Service Metadata
 /**
  * Service Metadata General Structure

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -1185,74 +1185,82 @@ class Metadata implements ValuizableInstance {
 		 * To ensure any circular references are handled correctly, we
 		 * keep track of a chain of accessed URLs.  If we see the same
 		 * URL twice, then we have a circular reference.
+		 *
+		 * The URL is removed from the set in the `finally` below once
+		 * this resolution returns, so the set tracks only the active
+		 * recursion chain rather than the lifetime history.
 		 */
 		if (this.seenURLs.has(cacheKey)) {
 			return(null);
 		}
 		this.seenURLs.add(cacheKey);
 
-		/*
-		 * Verify that the cache entry is still valid.  If it is not,
-		 * then remove it from the cache.
-		 */
-		const cacheValue = this.#cache.instance.get(cacheKey);
-		if (cacheValue) {
-			const resolvedCacheValue = await cacheValue;
+		try {
+			/*
+			 * Verify that the cache entry is still valid.  If it is not,
+			 * then remove it from the cache.
+			 */
+			const cacheValue = this.#cache.instance.get(cacheKey);
+			if (cacheValue) {
+				const resolvedCacheValue = await cacheValue;
 
-			if (resolvedCacheValue.expires < new Date()) {
-				this.#cache.instance.delete(cacheKey);
+				if (resolvedCacheValue.expires < new Date()) {
+					this.#cache.instance.delete(cacheKey);
+				} else {
+					this.#stats.cache.hit++;
+
+					if (resolvedCacheValue.pass) {
+						return(resolvedCacheValue.value);
+					} else {
+						throw(resolvedCacheValue.error);
+					}
+				}
+			}
+
+			this.#stats.cache.miss++;
+
+			const readPromise = (async (): Promise<URLCacheObjectEntry> => {
+				let retval: JSONSerializable;
+				try {
+					const protocol = url.protocol;
+					if (protocol === 'keetanet:') {
+						retval = await this.readKeetaNetURL(url);
+					} else if (protocol === 'https:' || (protocol === 'http:' && this.#allowInsecureProtocols)) {
+						retval = await this.readHTTPSURL(url);
+					} else {
+						this.#stats.unsupported.reads++;
+						throw(new Error(`Unsupported protocol: ${protocol}`));
+					}
+
+					this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), ':', retval);
+
+					return({
+						pass: true,
+						value: retval,
+						expires: new Date(Date.now() + this.#cache.positiveTTL)
+					});
+				} catch (readError) {
+					this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), 'failed:', readError);
+
+					return({
+						pass: false,
+						error: readError,
+						expires: new Date(Date.now() + this.#cache.negativeTTL)
+					});
+				}
+			})();
+
+			this.#cache.instance.set(cacheKey, readPromise);
+
+			const resolvedValue = await readPromise;
+
+			if (resolvedValue.pass) {
+				return(resolvedValue.value);
 			} else {
-				this.#stats.cache.hit++;
-
-				if (resolvedCacheValue.pass) {
-					return(resolvedCacheValue.value);
-				} else {
-					throw(resolvedCacheValue.error);
-				}
+				throw(resolvedValue.error);
 			}
-		}
-
-		this.#stats.cache.miss++;
-
-		const readPromise = (async (): Promise<URLCacheObjectEntry> => {
-			let retval: JSONSerializable;
-			try {
-				const protocol = url.protocol;
-				if (protocol === 'keetanet:') {
-					retval = await this.readKeetaNetURL(url);
-				} else if (protocol === 'https:' || (protocol === 'http:' && this.#allowInsecureProtocols)) {
-					retval = await this.readHTTPSURL(url);
-				} else {
-					this.#stats.unsupported.reads++;
-					throw(new Error(`Unsupported protocol: ${protocol}`));
-				}
-
-				this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), ':', retval);
-
-				return({
-					pass: true,
-					value: retval,
-					expires: new Date(Date.now() + this.#cache.positiveTTL)
-				});
-			} catch (readError) {
-				this.#logger?.debug(`Resolver:${this.#resolver.id}`, 'Read URL', url.toString(), 'failed:', readError);
-
-				return({
-					pass: false,
-					error: readError,
-					expires: new Date(Date.now() + this.#cache.negativeTTL)
-				});
-			}
-		})();
-
-		this.#cache.instance.set(cacheKey, readPromise);
-
-		const resolvedValue = await readPromise;
-
-		if (resolvedValue.pass) {
-			return(resolvedValue.value);
-		} else {
-			throw(resolvedValue.error);
+		} finally {
+			this.seenURLs.delete(cacheKey);
 		}
 	}
 
@@ -1430,30 +1438,6 @@ type ResolverStats = {
 type SharedLookupCriteria = { providerIDs?: string[]; };
 
 /**
- * Wraps a resolved object so subsequent `('object')` calls hit the cached
- * value instead of re-entering {@link Metadata.value} (which short-circuits
- * to `null` on a second call due to the circular-reference guard).
- */
-function wrapResolvedAsValuizableMethod(resolved: ValuizableObject): ValuizableMethod {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	return((async function(expect: ValuizableKind = 'any') {
-		if (expect === 'any' || expect === 'object') {
-			return(resolved);
-		}
-
-		throw(new Error(`expected ${expect}, got object`));
-	}) as ValuizableMethod);
-}
-
-/**
- * Casts a fully-resolved `JSONSerializable` to its expected typed shape.
- */
-function asResolved<T>(value: JSONSerializable): T {
-	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	return(value as T);
-}
-
-/**
  * Verify the optional metadata signature on a service entry.
  *
  * @returns boolean:
@@ -1496,15 +1480,17 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, logger?: Log
 		return(false);
 	}
 
-	const operations = asResolved<SignableServiceMetadata['operations']>(await Metadata.fullyResolveValuizable(operationsValuizable));
+	/* eslint-disable @typescript-eslint/consistent-type-assertions -- wire JSON to typed shape */
+	const operations = (await Metadata.fullyResolveValuizable(operationsValuizable)) as SignableServiceMetadata['operations'];
 	const metadata: SignableServiceMetadata = { operations };
 	const legalValuizable = entry['legal'];
 	if (legalValuizable !== undefined) {
 		const legal = await Metadata.fullyResolveValuizable(legalValuizable);
 		if (legal !== null) {
-			metadata.legal = asResolved<NonNullable<SignableServiceMetadata['legal']>>(legal);
+			metadata.legal = legal as NonNullable<SignableServiceMetadata['legal']>;
 		}
 	}
+	/* eslint-enable @typescript-eslint/consistent-type-assertions */
 
 	const valid = await verifyMetadataSignature(account, metadata, signed);
 	if (!valid) {
@@ -2578,8 +2564,8 @@ class Resolver {
 
 	/**
 	 * Drop service entries whose signature does not verify. Entries without
-	 * `account` pass through. Resolved values are wrapped to avoid a second
-	 * URL fetch by downstream service search.
+	 * `account` pass through. Entries that fail to resolve pass through so
+	 * downstream asserters surface the resolution error to the caller.
 	 */
 	async #filterSignedServiceEntries(servicesByID: ValuizableObject | undefined): Promise<ValuizableObject | undefined> {
 		if (servicesByID === undefined) {
@@ -2605,15 +2591,14 @@ class Resolver {
 			try {
 				const valid = await verifyServiceEntrySignature(resolved, this.#logger);
 				if (!valid) {
-					this.#logger?.debug(`Resolver:${this.id}`, 'Dropping service entry', id, 'due to invalid signature');
 					continue;
 				}
 			} catch (verifyError) {
-				this.#logger?.debug(`Resolver:${this.id}`, 'Error verifying signature for service entry', id, ':', verifyError, ' -- dropping');
+				this.#logger?.warn(`Resolver:${this.id}`, 'Error verifying signature for service entry', id, ':', verifyError, '-- dropping');
 				continue;
 			}
 
-			retval[id] = wrapResolvedAsValuizableMethod(resolved);
+			retval[id] = entry;
 		}
 
 		return(retval);

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -12,7 +12,7 @@ import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCa
 import type { AssetLocationString, Rail, SupportedAssetsMetadata, RailOrRailWithExtendedDetails, AssetMovementRailSearchInput, AnchorCustomLocationMetadata } from '../services/asset-movement/common.js';
 import type { MovableAssetSearchInput, KeetaNetTokenPublicKeyString } from './asset.js';
 import type { NotificationChannelType, NotificationSubscriptionType, SupportedChannelConfigurationMetadata } from '../services/notification/common.js';
-import type { ServiceMetadataAuthenticationType, ServiceMetadataEndpoint, SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
+import type { ServiceMetadataEndpoint, SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
 import type { VerifiableAccount } from './utils/signing.js';
 import type { HTTPSignedField } from './http-server/common.js';
 import type { SignableServiceMetadata } from './anchor-metadata-server.js';
@@ -2733,8 +2733,7 @@ export type {
 	ServiceMetadata,
 	ServiceMetadataExternalizable,
 	ServiceSearchCriteria,
-	ServiceMetadataEndpoint,
-	ServiceMetadataAuthenticationType,
 	Services,
 	SharedLookupCriteria
 };
+export type { ServiceMetadataEndpoint, ServiceMetadataAuthenticationType } from './metadata.types.js';

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -1460,7 +1460,7 @@ function asResolved<T>(value: JSONSerializable): T {
  * - `true` when the entry has neither `account` nor `signed`.
  * - `false` when one is present without the other or when verification fails.
  */
-async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logger?: Logger): Promise<boolean> {
+async function verifyServiceEntrySignature(entry: ValuizableObject, logger?: Logger): Promise<boolean> {
 	const accountValuizable = entry['account'];
 	const signedValuizable = entry['signed'];
 
@@ -1468,6 +1468,7 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logg
 		return(true);
 	}
 	if (accountValuizable === undefined || signedValuizable === undefined) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: one of `account`/`signed` present without the other');
 		return(false);
 	}
 
@@ -1475,7 +1476,8 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logg
 	let account: VerifiableAccount;
 	try {
 		account = KeetaNetClient.lib.Account.fromPublicKeyString(accountString);
-	} catch {
+	} catch (parseError) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: invalid account public key', accountString, parseError);
 		return(false);
 	}
 
@@ -1483,12 +1485,14 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logg
 	let signed: HTTPSignedField;
 	try {
 		signed = assertHTTPSignedField(signedRaw);
-	} catch {
+	} catch (assertError) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: malformed `signed` field for account', accountString, assertError);
 		return(false);
 	}
 
 	const operationsValuizable = entry['operations'];
 	if (operationsValuizable === undefined) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: missing `operations` for signed account', accountString);
 		return(false);
 	}
 
@@ -1502,7 +1506,12 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logg
 		}
 	}
 
-	return(await verifyMetadataSignature(account, metadata, signed));
+	const valid = await verifyMetadataSignature(account, metadata, signed);
+	if (!valid) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: signature does not verify for account', accountString);
+	}
+
+	return(valid);
 }
 
 class Resolver {

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -12,7 +12,12 @@ import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCa
 import type { AssetLocationString, Rail, SupportedAssetsMetadata, RailOrRailWithExtendedDetails, AssetMovementRailSearchInput, AnchorCustomLocationMetadata } from '../services/asset-movement/common.js';
 import type { MovableAssetSearchInput, KeetaNetTokenPublicKeyString } from './asset.js';
 import type { NotificationChannelType, NotificationSubscriptionType, SupportedChannelConfigurationMetadata } from '../services/notification/common.js';
-import type { SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension } from './metadata.types.js';
+import type { SharedAnchorCallerCertificateRequirementMetadata, SharedAnchorMetadataLegalExtension, SharedAnchorMetadataSignedExtension } from './metadata.types.js';
+import type { VerifiableAccount } from './utils/signing.js';
+import type { HTTPSignedField } from './http-server/common.js';
+import type { SignableServiceMetadata } from './anchor-metadata-server.js';
+import { assertHTTPSignedField } from './http-server/common.js';
+import { verifyMetadataSignature } from './anchor-metadata-server.js';
 
 type ExternalURL = { external: '2b828e33-2692-46e9-817e-9b93d63f28fd'; url: string; };
 
@@ -57,7 +62,7 @@ type ServiceMetadata = {
 	};
 	services: {
 		banking?: {
-			[id: string]: {
+			[id: string]: SharedAnchorMetadataSignedExtension & {
 				operations: {
 					createAccount?: string;
 				};
@@ -67,7 +72,7 @@ type ServiceMetadata = {
 			};
 		};
 		kyc?: {
-			[id: string]: {
+			[id: string]: SharedAnchorMetadataSignedExtension & {
 				operations: {
 					/**
 					 * Check if the KYC provider can
@@ -117,7 +122,7 @@ type ServiceMetadata = {
 			/**
 			 * Provider ID which identifies the FX provider
 			 */
-			[id: string]: SharedAnchorMetadataLegalExtension & {
+			[id: string]: SharedAnchorMetadataLegalExtension & SharedAnchorMetadataSignedExtension & {
 				operations: {
 					/**
 					 * Get an estimate for a currency
@@ -182,7 +187,7 @@ type ServiceMetadata = {
 			}
 		};
 		username?: {
-			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & {
+			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & SharedAnchorMetadataSignedExtension & {
 				operations: {
 					resolve: ServiceMetadataEndpoint;
 					claim?: ServiceMetadataEndpoint;
@@ -198,7 +203,7 @@ type ServiceMetadata = {
 			}
 		};
 		assetMovement?: {
-			[id: string]: SharedAnchorMetadataLegalExtension & {
+			[id: string]: SharedAnchorMetadataLegalExtension & SharedAnchorMetadataSignedExtension & {
 				operations: {
 					[Operation in (
 						'initiateTransfer' |
@@ -227,7 +232,7 @@ type ServiceMetadata = {
 			};
 		};
 		storage?: {
-			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & {
+			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & SharedAnchorMetadataSignedExtension & {
 				operations: {
 					put?: ServiceMetadataEndpoint;
 					get?: ServiceMetadataEndpoint;
@@ -263,7 +268,7 @@ type ServiceMetadata = {
 			};
 		};
 		notification?: {
-			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & {
+			[id: string]: SharedAnchorCallerCertificateRequirementMetadata & SharedAnchorMetadataSignedExtension & {
 				supportedChannels?: Partial<SupportedChannelConfigurationMetadata>;
 				supportedSubscriptions?: NotificationSubscriptionType[];
 
@@ -1424,6 +1429,82 @@ type ResolverStats = {
 
 type SharedLookupCriteria = { providerIDs?: string[]; };
 
+/**
+ * Wraps a resolved object so subsequent `('object')` calls hit the cached
+ * value instead of re-entering {@link Metadata.value} (which short-circuits
+ * to `null` on a second call due to the circular-reference guard).
+ */
+function wrapResolvedAsValuizableMethod(resolved: ValuizableObject): ValuizableMethod {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return((async function(expect: ValuizableKind = 'any') {
+		if (expect === 'any' || expect === 'object') {
+			return(resolved);
+		}
+
+		throw(new Error(`expected ${expect}, got object`));
+	}) as ValuizableMethod);
+}
+
+/**
+ * Casts a fully-resolved `JSONSerializable` to its expected typed shape.
+ */
+function asResolved<T>(value: JSONSerializable): T {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return(value as T);
+}
+
+/**
+ * Verify the optional metadata signature on a service entry.
+ *
+ * @returns boolean:
+ * - `true` when the entry has neither `account` nor `signed`.
+ * - `false` when one is present without the other or when verification fails.
+ */
+async function verifyServiceEntrySignature(entry: ValuizableObject, _ignore_logger?: Logger): Promise<boolean> {
+	const accountValuizable = entry['account'];
+	const signedValuizable = entry['signed'];
+
+	if (accountValuizable === undefined && signedValuizable === undefined) {
+		return(true);
+	}
+	if (accountValuizable === undefined || signedValuizable === undefined) {
+		return(false);
+	}
+
+	const accountString = await accountValuizable('string');
+	let account: VerifiableAccount;
+	try {
+		account = KeetaNetClient.lib.Account.fromPublicKeyString(accountString);
+	} catch {
+		return(false);
+	}
+
+	const signedRaw = await Metadata.fullyResolveValuizable(signedValuizable);
+	let signed: HTTPSignedField;
+	try {
+		signed = assertHTTPSignedField(signedRaw);
+	} catch {
+		return(false);
+	}
+
+	const operationsValuizable = entry['operations'];
+	if (operationsValuizable === undefined) {
+		return(false);
+	}
+
+	const operations = asResolved<SignableServiceMetadata['operations']>(await Metadata.fullyResolveValuizable(operationsValuizable));
+	const metadata: SignableServiceMetadata = { operations };
+	const legalValuizable = entry['legal'];
+	if (legalValuizable !== undefined) {
+		const legal = await Metadata.fullyResolveValuizable(legalValuizable);
+		if (legal !== null) {
+			metadata.legal = asResolved<NonNullable<SignableServiceMetadata['legal']>>(legal);
+		}
+	}
+
+	return(await verifyMetadataSignature(account, metadata, signed));
+}
+
 class Resolver {
 	readonly #roots: KeetaNetGenericAccount[];
 	readonly #trustedCAs: ResolverConfig['trustedCAs'];
@@ -2486,6 +2567,49 @@ class Resolver {
 		});
 	}
 
+	/**
+	 * Drop service entries whose signature does not verify. Entries without
+	 * `account` pass through. Resolved values are wrapped to avoid a second
+	 * URL fetch by downstream service search.
+	 */
+	async #filterSignedServiceEntries(servicesByID: ValuizableObject | undefined): Promise<ValuizableObject | undefined> {
+		if (servicesByID === undefined) {
+			return(undefined);
+		}
+
+		const retval: ValuizableObject = {};
+		for (const [ id, entry ] of Object.entries(servicesByID)) {
+			if (entry === undefined) {
+				continue;
+			}
+
+			let resolved: ValuizableObject;
+			try {
+				resolved = await entry('object');
+			} catch (resolveError) {
+				this.#logger?.debug(`Resolver:${this.id}`, 'Could not pre-resolve service entry', id, 'for signature verification:', resolveError);
+
+				retval[id] = entry;
+				continue;
+			}
+
+			try {
+				const valid = await verifyServiceEntrySignature(resolved, this.#logger);
+				if (!valid) {
+					this.#logger?.debug(`Resolver:${this.id}`, 'Dropping service entry', id, 'due to invalid signature');
+					continue;
+				}
+			} catch (verifyError) {
+				this.#logger?.debug(`Resolver:${this.id}`, 'Error verifying signature for service entry', id, ':', verifyError, ' -- dropping');
+				continue;
+			}
+
+			retval[id] = wrapResolvedAsValuizableMethod(resolved);
+		}
+
+		return(retval);
+	}
+
 	async lookup<T extends keyof ServicesMetadataLookupMap>(service: T, criteria: ServicesMetadataLookupMap[T]['criteria'], sharedCriteria?: SharedLookupCriteria): Promise<ServicesMetadataLookupMap[T]['results'] | undefined> {
 		const rootMetadata = await this.#getRootMetadata();
 
@@ -2514,6 +2638,8 @@ class Resolver {
 		} else {
 			filteredDefinedServicesObject = definedServicesObject;
 		}
+
+		filteredDefinedServicesObject = await this.#filterSignedServiceEntries(filteredDefinedServicesObject);
 
 		const serviceLookup = this.lookupMap[service].search;
 

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -882,6 +882,8 @@ type MetadataConfig = {
 type ValuizableInstance = { value: ValuizableMethod };
 
 const assertServiceMetadata = createAssert<ToJSONValuizable<ServiceMetadata>>();
+const assertSignableServiceMetadataOperations = createAssert<SignableServiceMetadata['operations']>();
+const assertSignableServiceMetadataLegal = createAssert<NonNullable<SignableServiceMetadata['legal']>>();
 
 /**
  * Instance type ID for anonymous Valuizable methods created dynamically
@@ -1475,17 +1477,27 @@ async function verifyServiceEntrySignature(entry: ValuizableObject, logger?: Log
 		return(false);
 	}
 
-	/* eslint-disable @typescript-eslint/consistent-type-assertions -- wire JSON to typed shape */
-	const operations = (await Metadata.fullyResolveValuizable(operationsValuizable)) as SignableServiceMetadata['operations'];
+	let operations: SignableServiceMetadata['operations'];
+	try {
+		operations = assertSignableServiceMetadataOperations(await Metadata.fullyResolveValuizable(operationsValuizable));
+	} catch (assertError) {
+		logger?.warn('verifyServiceEntrySignature', 'rejecting entry: malformed `operations` for account', accountString, assertError);
+		return(false);
+	}
+
 	const metadata: SignableServiceMetadata = { operations };
 	const legalValuizable = entry['legal'];
 	if (legalValuizable !== undefined) {
-		const legal = await Metadata.fullyResolveValuizable(legalValuizable);
-		if (legal !== null) {
-			metadata.legal = legal as NonNullable<SignableServiceMetadata['legal']>;
+		const legalRaw = await Metadata.fullyResolveValuizable(legalValuizable);
+		if (legalRaw !== null) {
+			try {
+				metadata.legal = assertSignableServiceMetadataLegal(legalRaw);
+			} catch (assertError) {
+				logger?.warn('verifyServiceEntrySignature', 'rejecting entry: malformed `legal` for account', accountString, assertError);
+				return(false);
+			}
 		}
 	}
-	/* eslint-enable @typescript-eslint/consistent-type-assertions */
 
 	const valid = await verifyMetadataSignature(account, metadata, signed);
 	if (!valid) {

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -1432,7 +1432,14 @@ type ResolverStats = {
 	}
 };
 
-type SharedLookupCriteria = { providerIDs?: string[]; };
+type SharedLookupCriteria = {
+	providerIDs?: string[];
+	/**
+	 * Restrict to entries signed by one of the listed account public keys.
+	 * Entries without a matching `account` are filtered out.
+	 */
+	accounts?: string[];
+};
 
 /**
  * Verify the optional metadata signature on a service entry.
@@ -2570,6 +2577,61 @@ class Resolver {
 	}
 
 	/**
+	 * Resolve a service entry to its object form. Returns `undefined` and
+	 * logs at debug if resolution fails. `context` describes the caller
+	 * for the log message.
+	 */
+	async #resolveServiceEntry(id: string, entry: ValuizableMethod, context: string): Promise<ValuizableObject | undefined> {
+		try {
+			return(await entry('object'));
+		} catch (resolveError) {
+			this.#logger?.debug(`Resolver:${this.id}`, 'Could not pre-resolve service entry', id, context, resolveError);
+			return(undefined);
+		}
+	}
+
+	/**
+	 * Keep only service entries whose `account` is in `accounts`. Entries
+	 * without `account`, with an unresolvable `account`, or that fail to
+	 * resolve are dropped.
+	 */
+	async #filterByAccounts(servicesByID: ValuizableObject, accounts: string[]): Promise<ValuizableObject> {
+		const allowed = new Set(accounts);
+		const retval: ValuizableObject = {};
+		for (const [ id, entry ] of Object.entries(servicesByID)) {
+			if (entry === undefined) {
+				continue;
+			}
+
+			const resolved = await this.#resolveServiceEntry(id, entry, 'for account filter:');
+			if (resolved === undefined) {
+				continue;
+			}
+
+			const accountValuizable = resolved['account'];
+			if (accountValuizable === undefined) {
+				continue;
+			}
+
+			let entryAccount: string;
+			try {
+				entryAccount = await accountValuizable('string');
+			} catch (resolveError) {
+				this.#logger?.debug(`Resolver:${this.id}`, 'Could not resolve `account` for service entry', id, ':', resolveError);
+				continue;
+			}
+
+			if (!allowed.has(entryAccount)) {
+				continue;
+			}
+
+			retval[id] = entry;
+		}
+
+		return(retval);
+	}
+
+	/**
 	 * Drop service entries whose signature does not verify. Entries without
 	 * `account` pass through. Entries that fail to resolve pass through so
 	 * downstream asserters surface the resolution error to the caller.
@@ -2585,12 +2647,8 @@ class Resolver {
 				continue;
 			}
 
-			let resolved: ValuizableObject;
-			try {
-				resolved = await entry('object');
-			} catch (resolveError) {
-				this.#logger?.debug(`Resolver:${this.id}`, 'Could not pre-resolve service entry', id, 'for signature verification:', resolveError);
-
+			const resolved = await this.#resolveServiceEntry(id, entry, 'for signature verification:');
+			if (resolved === undefined) {
 				retval[id] = entry;
 				continue;
 			}
@@ -2638,6 +2696,10 @@ class Resolver {
 			}
 		} else {
 			filteredDefinedServicesObject = definedServicesObject;
+		}
+
+		if (sharedCriteria?.accounts !== undefined && filteredDefinedServicesObject !== undefined) {
+			filteredDefinedServicesObject = await this.#filterByAccounts(filteredDefinedServicesObject, sharedCriteria.accounts);
 		}
 
 		filteredDefinedServicesObject = await this.#filterSignedServiceEntries(filteredDefinedServicesObject);

--- a/src/lib/utils/signing.test.ts
+++ b/src/lib/utils/signing.test.ts
@@ -222,36 +222,55 @@ test('objectToSignable: equivalent inputs produce a verifiable signature against
 	expect(isValid).toBe(true);
 });
 
-const signedObject = { a: 'first', m: 'middle', '{': 'a', '}': '{' };
-const forgeryAttempts: { name: string; forged: Signing.SignableInput; expected: boolean }[] = [
+const forgerySignedObject: Signing.SignableInput = { a: 'first', m: 'middle', '{': 'a', '}': '{' };
+const forgeryAccount = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
+const forgeryAttempts: { name: string; original: Signing.SignableInput; forged: Signing.SignableInput; expected: boolean }[] = [
 	{
 		name: 'reordered keys verify',
+		original: forgerySignedObject,
 		forged: { '}': '{', '{': 'a', m: 'middle', a: 'first' },
 		expected: true
 	},
 	{
 		name: 'changed value fails',
+		original: forgerySignedObject,
 		forged: { a: 'first', m: 'middle', '{': 'b', '}': '{' },
 		expected: false
 	},
 	{
 		name: 'added key fails',
+		original: forgerySignedObject,
 		forged: { a: 'first', m: 'middle', '{': 'a', '}': '{', extra: 'x' },
 		expected: false
 	},
 	{
 		name: 'removed key fails',
+		original: forgerySignedObject,
 		forged: { a: 'first', m: 'middle', '{': 'a' },
 		expected: false
 	},
 	{
 		name: 'swapped values across keys fails',
+		original: forgerySignedObject,
 		forged: { a: 'middle', m: 'first', '{': 'a', '}': '{' },
 		expected: false
 	},
 	{
 		name: 'reshape into a nested object with the same scalars fails',
+		original: forgerySignedObject,
 		forged: { a: 'first', m: 'middle', n: { '{': 'a', '}': '{' }},
+		expected: false
+	},
+	{
+		name: 'array forged as object with index keys fails',
+		original: [ 'x', 'y' ],
+		forged: { '0': 'x', '1': 'y' },
+		expected: false
+	},
+	{
+		name: 'Account forged as the empty object fails',
+		original: forgeryAccount,
+		forged: {},
 		expected: false
 	}
 ];
@@ -259,7 +278,7 @@ const forgeryAttempts: { name: string; forged: Signing.SignableInput; expected: 
 for (const attempt of forgeryAttempts) {
 	test(`VerifySignedData forgery resistance: ${attempt.name}`, async function() {
 		const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
-		const signed = await Signing.SignData(account, Signing.objectToSignable(signedObject));
+		const signed = await Signing.SignData(account, Signing.objectToSignable(attempt.original));
 
 		const result = await Signing.VerifySignedData(account, Signing.objectToSignable(attempt.forged), signed);
 		expect(result).toBe(attempt.expected);

--- a/src/lib/utils/signing.test.ts
+++ b/src/lib/utils/signing.test.ts
@@ -128,34 +128,49 @@ const verifyOptionsCases = [
 
 const objectToSignableCases: { name: string; input: Signing.SignableInput; expected: Signing.Signable }[] = [
 	{
-		name: 'flat object sorts keys lexicographically',
+		name: 'flat object emits sorted (key, value) pairs inside object framing',
 		input: { z: 1, a: 'first', m: 'middle' },
-		expected: ['first', 'middle', 1]
+		expected: ['{', 'a', 'first', 'm', 'middle', 'z', 1, '}']
 	},
 	{
-		name: 'nested object flattens with dot-prefixed keys',
+		name: 'nested object preserves structure via nested framing',
 		input: { outer: { inner: 'v' }, top: 't' },
-		expected: ['v', 't']
+		expected: ['{', 'outer', '{', 'inner', 'v', '}', 'top', 't', '}']
 	},
 	{
-		name: 'arrays preserve index order via [i] suffix',
+		name: 'arrays emit values in index order inside array framing',
 		input: { items: ['a', 'b', 'c'] },
-		expected: ['a', 'b', 'c']
+		expected: ['{', 'items', '[', 'a', 'b', 'c', ']', '}']
 	},
 	{
-		name: 'undefined and null entries are dropped',
+		name: 'object keys whose values are undefined or null are dropped',
 		input: { a: 'kept', b: undefined, c: null },
-		expected: ['kept']
+		expected: ['{', 'a', 'kept', '}']
 	},
 	{
 		name: 'booleans encode as 1/0',
 		input: { yes: true, no: false },
-		expected: [0, 1]
+		expected: ['{', 'no', 0, 'yes', 1, '}']
 	},
 	{
 		name: 'object key insertion order does not affect output',
 		input: { b: 2, a: 1 },
-		expected: [1, 2]
+		expected: ['{', 'a', 1, 'b', 2, '}']
+	},
+	{
+		name: 'top-level scalar passes through without framing',
+		input: 'lonely',
+		expected: ['lonely']
+	},
+	{
+		name: 'top-level array uses array framing',
+		input: ['x', 'y'],
+		expected: ['[', 'x', 'y', ']']
+	},
+	{
+		name: 'array null and undefined entries become NULL_MARKER preserving index',
+		input: ['x', null, undefined, 'y'],
+		expected: ['[', 'x', 'null', 'null', 'y', ']']
 	}
 ];
 
@@ -166,27 +181,45 @@ for (const testCase of objectToSignableCases) {
 	});
 }
 
-test('objectToSignable: equivalent inputs produce identical sign-and-verify output', async function() {
-	const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
+const objectToSignableDistinctCases: { name: string; a: Signing.SignableInput; b: Signing.SignableInput }[] = [
+	{
+		name: 'object with numeric-string key vs array',
+		a: { '0': 'x' },
+		b: ['x']
+	},
+	{
+		name: 'nested object vs flat object using dot separator',
+		a: { a: { b: 'x' }},
+		b: { 'a.b': 'x' }
+	},
+	{
+		name: 'array with null entry vs array without it',
+		a: ['x', null, 'y'],
+		b: ['x', 'y']
+	}
+];
 
+for (const testCase of objectToSignableDistinctCases) {
+	test(`objectToSignable distinct: ${testCase.name}`, function() {
+		const a = Signing.objectToSignable(testCase.a);
+		const b = Signing.objectToSignable(testCase.b);
+		expect(a).not.toEqual(b);
+	});
+}
+
+test('objectToSignable: equivalent inputs produce a verifiable signature against either form', async function() {
+	const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
 	const a = Signing.objectToSignable({ a: 1, b: { c: 'x', d: 'y' }});
 	const b = Signing.objectToSignable({ b: { d: 'y', c: 'x' }, a: 1 });
-	expect(a).toEqual(b);
-
 	const signed = await Signing.SignData(account, a);
+
 	const isValid = await Signing.VerifySignedData(account, b, signed);
 	expect(isValid).toBe(true);
 });
 
-test('objectToSignable: omitted-undefined and dropped-key produce identical bytes', function() {
-	const withUndefined = Signing.objectToSignable({ a: 'kept', b: undefined });
-	const withoutKey = Signing.objectToSignable({ a: 'kept' });
-	expect(withUndefined).toEqual(withoutKey);
-});
-
-test('objectToSignable: throws when queue exceeds DoS guard', function() {
+test('objectToSignable: throws when token count exceeds DoS guard', function() {
 	const big: { [key: string]: string } = {};
-	for (let i = 0; i < 300; i++) {
+	for (let i = 0; i < 600; i++) {
 		big[`k${i}`] = `v${i}`;
 	}
 

--- a/src/lib/utils/signing.test.ts
+++ b/src/lib/utils/signing.test.ts
@@ -126,6 +126,73 @@ const verifyOptionsCases = [
 	}
 ];
 
+const objectToSignableCases: { name: string; input: Signing.SignableInput; expected: Signing.Signable }[] = [
+	{
+		name: 'flat object sorts keys lexicographically',
+		input: { z: 1, a: 'first', m: 'middle' },
+		expected: ['first', 'middle', 1]
+	},
+	{
+		name: 'nested object flattens with dot-prefixed keys',
+		input: { outer: { inner: 'v' }, top: 't' },
+		expected: ['v', 't']
+	},
+	{
+		name: 'arrays preserve index order via [i] suffix',
+		input: { items: ['a', 'b', 'c'] },
+		expected: ['a', 'b', 'c']
+	},
+	{
+		name: 'undefined and null entries are dropped',
+		input: { a: 'kept', b: undefined, c: null },
+		expected: ['kept']
+	},
+	{
+		name: 'booleans encode as 1/0',
+		input: { yes: true, no: false },
+		expected: [0, 1]
+	},
+	{
+		name: 'object key insertion order does not affect output',
+		input: { b: 2, a: 1 },
+		expected: [1, 2]
+	}
+];
+
+for (const testCase of objectToSignableCases) {
+	test(`objectToSignable: ${testCase.name}`, function() {
+		const out = Signing.objectToSignable(testCase.input);
+		expect(out).toEqual(testCase.expected);
+	});
+}
+
+test('objectToSignable: equivalent inputs produce identical sign-and-verify output', async function() {
+	const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
+
+	const a = Signing.objectToSignable({ a: 1, b: { c: 'x', d: 'y' }});
+	const b = Signing.objectToSignable({ b: { d: 'y', c: 'x' }, a: 1 });
+	expect(a).toEqual(b);
+
+	const signed = await Signing.SignData(account, a);
+	const isValid = await Signing.VerifySignedData(account, b, signed);
+	expect(isValid).toBe(true);
+});
+
+test('objectToSignable: omitted-undefined and dropped-key produce identical bytes', function() {
+	const withUndefined = Signing.objectToSignable({ a: 'kept', b: undefined });
+	const withoutKey = Signing.objectToSignable({ a: 'kept' });
+	expect(withUndefined).toEqual(withoutKey);
+});
+
+test('objectToSignable: throws when queue exceeds DoS guard', function() {
+	const big: { [key: string]: string } = {};
+	for (let i = 0; i < 300; i++) {
+		big[`k${i}`] = `v${i}`;
+	}
+
+	expect(() => Signing.objectToSignable(big)).toThrow();
+});
+
 for (const testCase of verifyOptionsCases) {
 	test(`VerifySignedData: ${testCase.name}`, async function() {
 		const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);

--- a/src/lib/utils/signing.test.ts
+++ b/src/lib/utils/signing.test.ts
@@ -128,54 +128,78 @@ const verifyOptionsCases = [
 
 const objectToSignableCases: { name: string; input: Signing.SignableInput; expected: Signing.Signable }[] = [
 	{
-		name: 'flat object emits sorted (key, value) pairs inside object framing',
+		name: 'flat object emits JCS string with keys sorted by codepoint',
 		input: { z: 1, a: 'first', m: 'middle' },
-		expected: ['{', 'a', 'first', 'm', 'middle', 'z', 1, '}']
+		expected: [ '{"a":"first","m":"middle","z":1}' ]
 	},
 	{
-		name: 'nested object preserves structure via nested framing',
+		name: 'nested object preserves structure',
 		input: { outer: { inner: 'v' }, top: 't' },
-		expected: ['{', 'outer', '{', 'inner', 'v', '}', 'top', 't', '}']
+		expected: [ '{"outer":{"inner":"v"},"top":"t"}' ]
 	},
 	{
-		name: 'arrays emit values in index order inside array framing',
-		input: { items: ['a', 'b', 'c'] },
-		expected: ['{', 'items', '[', 'a', 'b', 'c', ']', '}']
+		name: 'arrays preserve index order',
+		input: { items: [ 'a', 'b', 'c' ] },
+		expected: [ '{"items":["a","b","c"]}' ]
 	},
 	{
-		name: 'object keys whose values are undefined or null are dropped',
+		name: 'object keys with undefined values are dropped, null values are kept',
 		input: { a: 'kept', b: undefined, c: null },
-		expected: ['{', 'a', 'kept', '}']
+		expected: [ '{"a":"kept","c":null}' ]
 	},
 	{
-		name: 'booleans encode as 1/0',
+		name: 'booleans serialize as JSON true/false',
 		input: { yes: true, no: false },
-		expected: ['{', 'no', 0, 'yes', 1, '}']
+		expected: [ '{"no":false,"yes":true}' ]
 	},
 	{
 		name: 'object key insertion order does not affect output',
 		input: { b: 2, a: 1 },
-		expected: ['{', 'a', 1, 'b', 2, '}']
+		expected: [ '{"a":1,"b":2}' ]
 	},
 	{
-		name: 'top-level scalar passes through without framing',
+		name: 'top-level scalar emits a JSON string literal',
 		input: 'lonely',
-		expected: ['lonely']
+		expected: [ '"lonely"' ]
 	},
 	{
-		name: 'top-level array uses array framing',
-		input: ['x', 'y'],
-		expected: ['[', 'x', 'y', ']']
+		name: 'top-level array preserves element order',
+		input: [ 'x', 'y' ],
+		expected: [ '["x","y"]' ]
 	},
 	{
-		name: 'array null and undefined entries become NULL_MARKER preserving index',
-		input: ['x', null, undefined, 'y'],
-		expected: ['[', 'x', 'null', 'null', 'y', ']']
+		name: 'array null and undefined entries serialize as JSON null',
+		input: [ 'x', null, undefined, 'y' ],
+		expected: [ '["x",null,null,"y"]' ]
 	},
 	{
-		name: 'marker characters as keys and values are passed through unchanged',
+		name: 'marker-like characters as keys and values are escaped properly by JCS',
 		input: { a: 'first', m: 'middle', '{': 'a', '}': '{' },
-		expected: ['{', 'a', 'first', 'm', 'middle', '{', 'a', '}', '{', '}']
+		expected: [ '{"a":"first","m":"middle","{":"a","}":"{"}' ]
+	},
+	{
+		name: 'RFC 8785 Section 3.2.3 sort vector: keys ordered by UTF-16 code unit',
+		input: {
+			'\u20ac': 'Euro Sign',
+			'\r': 'Carriage Return',
+			'1': 'One'
+		},
+		expected: [ '{"\\r":"Carriage Return","1":"One","\u20ac":"Euro Sign"}' ]
+	},
+	{
+		name: 'sparse array holes serialize as JSON null preserving index',
+		input: (function() {
+			const arr = new Array<string>(3);
+			arr[0] = 'a';
+			arr[2] = 'c';
+			return(arr);
+		})(),
+		expected: [ '["a",null,"c"]' ]
+	},
+	{
+		name: 'Date instances serialize as their ISO 8601 string',
+		input: { at: new Date('2024-01-02T03:04:05.678Z') },
+		expected: [ '{"at":"2024-01-02T03:04:05.678Z"}' ]
 	}
 ];
 
@@ -285,14 +309,35 @@ for (const attempt of forgeryAttempts) {
 	});
 }
 
-test('objectToSignable: throws when token count exceeds DoS guard', function() {
+test('objectToSignable: throws when node count exceeds DoS guard', function() {
 	const big: { [key: string]: string } = {};
-	for (let i = 0; i < 600; i++) {
+	for (let i = 0; i < 2000; i++) {
 		big[`k${i}`] = `v${i}`;
 	}
 
 	expect(() => Signing.objectToSignable(big)).toThrow();
 });
+
+const objectToSignableRejectionCases: { name: string; input: Signing.SignableInput }[] = [
+	// @ts-expect-error
+	{ name: 'Map instance', input: new Map() },
+	// @ts-expect-error
+	{ name: 'Set instance', input: new Set() },
+	// @ts-expect-error
+	{ name: 'RegExp instance', input: /x/ },
+	{ name: 'NaN value', input: { x: Number.NaN }},
+	{ name: 'positive infinity value', input: { x: Number.POSITIVE_INFINITY }},
+	{ name: 'bigint above MAX_SAFE_INTEGER', input: { x: BigInt(Number.MAX_SAFE_INTEGER) + 1n }},
+	{ name: 'lone high surrogate in value', input: { x: '\uD800' }},
+	{ name: 'lone low surrogate in key', input: { '\uDC00': 'x' }},
+	{ name: 'invalid Date instance', input: { at: new Date('not a date') }}
+];
+
+for (const testCase of objectToSignableRejectionCases) {
+	test(`objectToSignable rejects: ${testCase.name}`, function() {
+		expect(() => Signing.objectToSignable(testCase.input)).toThrow();
+	});
+}
 
 for (const testCase of verifyOptionsCases) {
 	test(`VerifySignedData: ${testCase.name}`, async function() {

--- a/src/lib/utils/signing.test.ts
+++ b/src/lib/utils/signing.test.ts
@@ -171,6 +171,11 @@ const objectToSignableCases: { name: string; input: Signing.SignableInput; expec
 		name: 'array null and undefined entries become NULL_MARKER preserving index',
 		input: ['x', null, undefined, 'y'],
 		expected: ['[', 'x', 'null', 'null', 'y', ']']
+	},
+	{
+		name: 'marker characters as keys and values are passed through unchanged',
+		input: { a: 'first', m: 'middle', '{': 'a', '}': '{' },
+		expected: ['{', 'a', 'first', 'm', 'middle', '{', 'a', '}', '{', '}']
 	}
 ];
 
@@ -216,6 +221,50 @@ test('objectToSignable: equivalent inputs produce a verifiable signature against
 	const isValid = await Signing.VerifySignedData(account, b, signed);
 	expect(isValid).toBe(true);
 });
+
+const signedObject = { a: 'first', m: 'middle', '{': 'a', '}': '{' };
+const forgeryAttempts: { name: string; forged: Signing.SignableInput; expected: boolean }[] = [
+	{
+		name: 'reordered keys verify',
+		forged: { '}': '{', '{': 'a', m: 'middle', a: 'first' },
+		expected: true
+	},
+	{
+		name: 'changed value fails',
+		forged: { a: 'first', m: 'middle', '{': 'b', '}': '{' },
+		expected: false
+	},
+	{
+		name: 'added key fails',
+		forged: { a: 'first', m: 'middle', '{': 'a', '}': '{', extra: 'x' },
+		expected: false
+	},
+	{
+		name: 'removed key fails',
+		forged: { a: 'first', m: 'middle', '{': 'a' },
+		expected: false
+	},
+	{
+		name: 'swapped values across keys fails',
+		forged: { a: 'middle', m: 'first', '{': 'a', '}': '{' },
+		expected: false
+	},
+	{
+		name: 'reshape into a nested object with the same scalars fails',
+		forged: { a: 'first', m: 'middle', n: { '{': 'a', '}': '{' }},
+		expected: false
+	}
+];
+
+for (const attempt of forgeryAttempts) {
+	test(`VerifySignedData forgery resistance: ${attempt.name}`, async function() {
+		const account = KeetaNetLib.Account.fromSeed(KeetaNetLib.Account.generateRandomSeed(), 0);
+		const signed = await Signing.SignData(account, Signing.objectToSignable(signedObject));
+
+		const result = await Signing.VerifySignedData(account, Signing.objectToSignable(attempt.forged), signed);
+		expect(result).toBe(attempt.expected);
+	});
+}
 
 test('objectToSignable: throws when token count exceeds DoS guard', function() {
 	const big: { [key: string]: string } = {};

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -7,7 +7,7 @@ import type {
 import { Buffer, bufferToArrayBuffer, arrayBufferLikeToBuffer } from '../../lib/utils/buffer.js';
 import crypto from '../../lib/utils/crypto.js';
 import { assertNever } from '../../lib/utils/never.js';
-import { KeetaAnchorUserError } from '../error.js';
+import { KeetaAnchorError, KeetaAnchorUserError } from '../error.js';
 
 export type SignableAccount = ReturnType<InstanceType<typeof KeetaNetLib.Account>['assertAccount']>;
 export type VerifiableAccount = InstanceType<typeof KeetaNetLib.Account>;
@@ -17,69 +17,95 @@ export type Signable = (string | number | bigint | InstanceType<typeof KeetaNetL
  * Structural input to {@link objectToSignable}.
  */
 export type SignableInput =
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	{ [key: string | number | symbol]: any } |
+	{ [key: string | number | symbol]: unknown } |
 	SignableInput[] |
 	Signable[number] |
 	undefined |
 	null |
 	boolean;
 
-/** DoS guard for {@link objectToSignable}. */
-const TO_SIGNABLE_MAX_QUEUE_LENGTH = 250;
+const TO_SIGNABLE_MAX_TOKENS = 1000;
+
+const OBJECT_OPEN = '{';
+const OBJECT_CLOSE = '}';
+const ARRAY_OPEN = '[';
+const ARRAY_CLOSE = ']';
+const NULL_MARKER = 'null';
 
 /**
- * Canonicalize a tree into a deterministic {@link Signable}.
+ * Canonicalize a tree into a flat {@link Signable}.
  *
- * Drops `undefined`/`null`, encodes booleans as 1/0, sorts the flattened
- * dot/index key path with a stable locale comparator.
+ * Objects: sort keys by codepoint, frame with `{`/`}`, drop nullish values.
+ * Arrays: keep index order, frame with `[`/`]`, replace nullish entries
+ * with {@link NULL_MARKER}. Booleans become `1`/`0`.
  */
 export function objectToSignable(item: SignableInput): Signable {
-	const queue: [ string, SignableInput ][] = [[ '', item ]];
-	const result: [ string, Signable[number] ][] = [];
+	const result: Signable = [];
 
-	while (queue.length > 0) {
-		const next = queue.shift();
-		if (!next) {
-			continue;
-		}
-
-		const [ prefix, current ] = next;
-		if (current === null || current === undefined) {
-			continue;
-		}
-
-		if (typeof current === 'boolean') {
-			result.push([ prefix, current ? 1 : 0 ]);
-		} else if (Array.isArray(current)) {
-			for (let i = 0; i < current.length; i++) {
-				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-				queue.push([ `${prefix}[${i}]`, current[i] as SignableInput ]);
-			}
-		} else if (typeof current === 'object') {
-			for (const [ key, value ] of Object.entries(current)) {
-				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-				queue.push([ prefix ? `${prefix}.${key}` : key, value as SignableInput ]);
-			}
-		} else {
-			result.push([ prefix, current ]);
-		}
-
-		if (queue.length > TO_SIGNABLE_MAX_QUEUE_LENGTH) {
+	function emit(token: Signable[number]): void {
+		result.push(token);
+		if (result.length > TO_SIGNABLE_MAX_TOKENS) {
 			throw(new KeetaAnchorUserError('Too much data to sign in objectToSignable'));
 		}
 	}
 
-	result.sort((a, b) => {
-		return(a[0].localeCompare(b[0], 'en-US', {
-			usage: 'sort',
-			numeric: true,
-			sensitivity: 'case',
-			ignorePunctuation: false
-		}));
-	});
+	function walk(current: unknown): void {
+		if (current === null || current === undefined) {
+			emit(NULL_MARKER);
+			return;
+		}
 
-	return(result.map(item => item[1]));
+		if (typeof current === 'boolean') {
+			emit(current ? 1 : 0);
+			return;
+		}
+
+		if (Array.isArray(current)) {
+			emit(ARRAY_OPEN);
+
+			for (const value of current) {
+				walk(value);
+			}
+
+			emit(ARRAY_CLOSE);
+			return;
+		}
+
+		if (typeof current === 'object' && !KeetaNetLib.Account.isInstance(current)) {
+			emit(OBJECT_OPEN);
+
+			const entries = Object.entries(current).filter(([ , value ]) => value !== null && value !== undefined);
+			entries.sort(([ a ], [ b ]) => {
+				if (a < b) {
+					return(-1);
+				}
+				if (a > b) {
+					return(1);
+				}
+
+				return(0);
+			});
+
+			for (const [ key, value ] of entries) {
+				emit(key);
+				walk(value);
+			}
+
+			emit(OBJECT_CLOSE);
+			return;
+		}
+
+		if (typeof current === 'string' || typeof current === 'number' || typeof current === 'bigint' || KeetaNetLib.Account.isInstance(current)) {
+			emit(current);
+			return;
+		}
+
+		throw(new KeetaAnchorError('Unsupported value type in objectToSignable'));
+	}
+
+	walk(item);
+
+	return(result);
 }
 
 /**

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -131,7 +131,7 @@ function canonicalizeJson(value: unknown): string {
 
 /**
  * Canonicalize a tree into a {@link Signable} via {@link canonicalizeJson}.
- * {@link KeetaNetLib.Account} instances are replaced by their publicKeyAndTypeString`.
+ * {@link KeetaNetLib.Account} instances are replaced by their `publicKeyAndTypeString`.
  * {@link Date} instances are replaced by their ISO 8601 string.
  */
 export function objectToSignable(item: SignableInput): Signable {

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -7,7 +7,7 @@ import type {
 import { Buffer, bufferToArrayBuffer, arrayBufferLikeToBuffer } from '../../lib/utils/buffer.js';
 import crypto from '../../lib/utils/crypto.js';
 import { assertNever } from '../../lib/utils/never.js';
-import { KeetaAnchorError, KeetaAnchorUserError } from '../error.js';
+import { KeetaAnchorError } from '../error.js';
 
 export type SignableAccount = ReturnType<InstanceType<typeof KeetaNetLib.Account>['assertAccount']>;
 export type VerifiableAccount = InstanceType<typeof KeetaNetLib.Account>;
@@ -24,88 +24,166 @@ export type SignableInput =
 	null |
 	boolean;
 
-const TO_SIGNABLE_MAX_TOKENS = 1000;
-
-const OBJECT_OPEN = '{';
-const OBJECT_CLOSE = '}';
-const ARRAY_OPEN = '[';
-const ARRAY_CLOSE = ']';
-const NULL_MARKER = 'null';
+const TO_SIGNABLE_MAX_NODES = 1000;
+const TO_SIGNABLE_MAX_OUTPUT_BYTES = 65536;
 
 /**
- * Canonicalize a tree into a flat {@link Signable}.
- *
- * Objects: sort keys by codepoint, frame with `{`/`}`, drop nullish values.
- * Arrays: keep index order, frame with `[`/`]`, replace nullish entries
- * with {@link NULL_MARKER}. Booleans become `1`/`0`.
+ * Detects unpaired UTF-16 surrogate code units. JCS
+ * ({@link https://www.rfc-editor.org/rfc/rfc8785 RFC 8785} Section 3.2.2.2)
+ * requires implementations to reject such strings.
+ */
+const LONE_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+/**
+ * Serialize a JSON-shaped value following JCS
+ * ({@link https://www.rfc-editor.org/rfc/rfc8785 RFC 8785}).
+ */
+function canonicalizeJson(value: unknown): string {
+	/**
+	 * Literal serialization (Section 3.2.2.1).
+	 */
+	if (value === null || typeof value === 'boolean') {
+		return(JSON.stringify(value));
+	}
+
+	/**
+	 * String serialization (Section 3.2.2.2). Lone UTF-16 surrogates MUST cause termination.
+	 */
+	if (typeof value === 'string') {
+		if (LONE_SURROGATE_PATTERN.test(value)) {
+			throw(new KeetaAnchorError('Lone UTF-16 surrogate in canonicalizeJson'));
+		}
+
+		return(JSON.stringify(value));
+	}
+
+	/**
+	 * Number serialization (Section 3.2.2.3). NaN and Infinity MUST cause termination.
+	 */
+	if (typeof value === 'number') {
+		if (!Number.isFinite(value)) {
+			throw(new KeetaAnchorError('non-finite number in canonicalizeJson'));
+		}
+
+		return(JSON.stringify(value));
+	}
+
+	/**
+	 * Big integer serialization (Appendix D); I-JSON safe-integer range required.
+	 */
+	if (typeof value === 'bigint') {
+		if (value > BigInt(Number.MAX_SAFE_INTEGER) || value < BigInt(Number.MIN_SAFE_INTEGER)) {
+			throw(new KeetaAnchorError('bigint out of safe integer range in canonicalizeJson'));
+		}
+
+		return(value.toString());
+	}
+
+	/**
+	 * Array element order MUST NOT be changed (Section 3.2.3); sparse holes serialize as JSON `null`.
+	 */
+	if (Array.isArray(value)) {
+		const parts: string[] = [];
+		for (let i = 0; i < value.length; i++) {
+			parts.push(i in value ? canonicalizeJson(value[i]) : 'null');
+		}
+
+		return(`[${parts.join(',')}]`);
+	}
+
+	/**
+	 * Object property sorting by UTF-16 code unit (Section 3.2.3); recursion required.
+	 * Only plain objects are permitted; class instances (Date, Map, etc.) are rejected.
+	 */
+	if (typeof value === 'object') {
+		if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+			throw(new KeetaAnchorError('Non-plain object in canonicalizeJson'));
+		}
+
+		const entries = Object.entries(value);
+		for (const [ key ] of entries) {
+			if (LONE_SURROGATE_PATTERN.test(key)) {
+				throw(new KeetaAnchorError('Lone UTF-16 surrogate in object key'));
+			}
+		}
+
+		entries.sort(([ a ], [ b ]) => {
+			if (a < b) {
+				return(-1);
+			}
+			if (a > b) {
+				return(1);
+			}
+
+			return(0);
+		});
+
+		const parts: string[] = [];
+		for (const [ key, child ] of entries) {
+			parts.push(`${JSON.stringify(key)}:${canonicalizeJson(child)}`);
+		}
+
+		return(`{${parts.join(',')}}`);
+	}
+
+	throw(new KeetaAnchorError('Unsupported value type in canonicalizeJson'));
+}
+
+/**
+ * Canonicalize a tree into a {@link Signable} via {@link canonicalizeJson}.
+ * {@link KeetaNetLib.Account} instances are replaced by their publicKeyAndTypeString`.
+ * {@link Date} instances are replaced by their ISO 8601 string.
  */
 export function objectToSignable(item: SignableInput): Signable {
-	const result: Signable = [];
-
-	function emit(token: Signable[number]): void {
-		result.push(token);
-		if (result.length > TO_SIGNABLE_MAX_TOKENS) {
-			throw(new KeetaAnchorUserError('Too much data to sign in objectToSignable'));
-		}
-	}
-
-	function walk(current: unknown): void {
-		if (current === null || current === undefined) {
-			emit(NULL_MARKER);
-			return;
+	let nodeCount = 0;
+	function visit(value: unknown): unknown {
+		nodeCount++;
+		if (nodeCount > TO_SIGNABLE_MAX_NODES) {
+			throw(new KeetaAnchorError('Too much data to sign in objectToSignable'));
 		}
 
-		if (typeof current === 'boolean') {
-			emit(current ? 1 : 0);
-			return;
+		if (value === undefined || value === null) {
+			return(null);
 		}
-
-		if (Array.isArray(current)) {
-			emit(ARRAY_OPEN);
-
-			for (const value of current) {
-				walk(value);
+		if (value instanceof Date) {
+			if (Number.isNaN(value.valueOf())) {
+				throw(new KeetaAnchorError('Invalid Date in objectToSignable'));
 			}
 
-			emit(ARRAY_CLOSE);
-			return;
+			return(value.toISOString());
 		}
-
-		if (typeof current === 'object' && !KeetaNetLib.Account.isInstance(current)) {
-			emit(OBJECT_OPEN);
-
-			const entries = Object.entries(current).filter(([ , value ]) => value !== null && value !== undefined);
-			entries.sort(([ a ], [ b ]) => {
-				if (a < b) {
-					return(-1);
-				}
-				if (a > b) {
-					return(1);
-				}
-
-				return(0);
-			});
-
-			for (const [ key, value ] of entries) {
-				emit(key);
-				walk(value);
+		if (KeetaNetLib.Account.isInstance(value)) {
+			return(value.publicKeyAndTypeString);
+		}
+		if (Array.isArray(value)) {
+			return(value.map(visit));
+		}
+		if (typeof value === 'object') {
+			if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
+				throw(new KeetaAnchorError('Non-plain object in objectToSignable'));
 			}
 
-			emit(OBJECT_CLOSE);
-			return;
+			const result: { [key: string]: unknown } = {};
+			for (const [ key, child ] of Object.entries(value)) {
+				if (child === undefined) {
+					continue;
+				}
+
+				result[key] = visit(child);
+			}
+
+			return(result);
 		}
 
-		if (typeof current === 'string' || typeof current === 'number' || typeof current === 'bigint' || KeetaNetLib.Account.isInstance(current)) {
-			emit(current);
-			return;
-		}
-
-		throw(new KeetaAnchorError('Unsupported value type in objectToSignable'));
+		return(value);
 	}
 
-	walk(item);
+	const canonical = canonicalizeJson(visit(item));
+	if (canonical.length > TO_SIGNABLE_MAX_OUTPUT_BYTES) {
+		throw(new KeetaAnchorError('Canonical output exceeds size limit in objectToSignable'));
+	}
 
-	return(result);
+	return([ canonical ]);
 }
 
 /**

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -156,7 +156,16 @@ export function objectToSignable(item: SignableInput): Signable {
 			return(value.publicKeyAndTypeString);
 		}
 		if (Array.isArray(value)) {
-			return(value.map(visit));
+			if (value.length > TO_SIGNABLE_MAX_NODES - nodeCount) {
+				throw(new KeetaAnchorError('Too much data to sign in objectToSignable'));
+			}
+
+			const result: unknown[] = [];
+			for (const child of value) {
+				result.push(visit(child));
+			}
+
+			return(result);
 		}
 		if (typeof value === 'object') {
 			if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) {
@@ -179,7 +188,7 @@ export function objectToSignable(item: SignableInput): Signable {
 	}
 
 	const canonical = canonicalizeJson(visit(item));
-	if (canonical.length > TO_SIGNABLE_MAX_OUTPUT_BYTES) {
+	if (Buffer.byteLength(canonical, 'utf8') > TO_SIGNABLE_MAX_OUTPUT_BYTES) {
 		throw(new KeetaAnchorError('Canonical output exceeds size limit in objectToSignable'));
 	}
 

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -4,13 +4,83 @@ import type {
 	ASN1AnyJS as KeetaNetASN1AnyJS
 } from '@keetanetwork/keetanet-client/lib/utils/asn1.js';
 
-import { Buffer, bufferToArrayBuffer } from '../../lib/utils/buffer.js';
+import { Buffer, bufferToArrayBuffer, arrayBufferLikeToBuffer } from '../../lib/utils/buffer.js';
 import crypto from '../../lib/utils/crypto.js';
 import { assertNever } from '../../lib/utils/never.js';
+import { KeetaAnchorUserError } from '../error.js';
 
 export type SignableAccount = ReturnType<InstanceType<typeof KeetaNetLib.Account>['assertAccount']>;
 export type VerifiableAccount = InstanceType<typeof KeetaNetLib.Account>;
 export type Signable = (string | number | bigint | InstanceType<typeof KeetaNetLib.Account>)[];
+
+/**
+ * Structural input to {@link objectToSignable}.
+ */
+export type SignableInput =
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	{ [key: string | number | symbol]: any } |
+	SignableInput[] |
+	Signable[number] |
+	undefined |
+	null |
+	boolean;
+
+/** DoS guard for {@link objectToSignable}. */
+const TO_SIGNABLE_MAX_QUEUE_LENGTH = 250;
+
+/**
+ * Canonicalize a tree into a deterministic {@link Signable}.
+ *
+ * Drops `undefined`/`null`, encodes booleans as 1/0, sorts the flattened
+ * dot/index key path with a stable locale comparator.
+ */
+export function objectToSignable(item: SignableInput): Signable {
+	const queue: [ string, SignableInput ][] = [[ '', item ]];
+	const result: [ string, Signable[number] ][] = [];
+
+	while (queue.length > 0) {
+		const next = queue.shift();
+		if (!next) {
+			continue;
+		}
+
+		const [ prefix, current ] = next;
+		if (current === null || current === undefined) {
+			continue;
+		}
+
+		if (typeof current === 'boolean') {
+			result.push([ prefix, current ? 1 : 0 ]);
+		} else if (Array.isArray(current)) {
+			for (let i = 0; i < current.length; i++) {
+				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+				queue.push([ `${prefix}[${i}]`, current[i] as SignableInput ]);
+			}
+		} else if (typeof current === 'object') {
+			for (const [ key, value ] of Object.entries(current)) {
+				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+				queue.push([ prefix ? `${prefix}.${key}` : key, value as SignableInput ]);
+			}
+		} else {
+			result.push([ prefix, current ]);
+		}
+
+		if (queue.length > TO_SIGNABLE_MAX_QUEUE_LENGTH) {
+			throw(new KeetaAnchorUserError('Too much data to sign in objectToSignable'));
+		}
+	}
+
+	result.sort((a, b) => {
+		return(a[0].localeCompare(b[0], 'en-US', {
+			usage: 'sort',
+			numeric: true,
+			sensitivity: 'case',
+			ignorePunctuation: false
+		}));
+	});
+
+	return(result.map(item => item[1]));
+}
 
 /**
  * Options for signature verification
@@ -72,7 +142,7 @@ export function FormatData(account: VerifiableAccount, data: Signable, nonce?: s
 	return({
 		nonce: nonce,
 		timestamp: timestampString,
-		verificationData: Buffer.from(verificationData.toBER())
+		verificationData: arrayBufferLikeToBuffer(verificationData.toBER())
 	});
 }
 

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -9,13 +9,14 @@ import * as KeetaNet from '@keetanetwork/keetanet-client';
 import { KeetaAnchorUserError } from '../../lib/error.js';
 import type { AssetLocationLike, AssetLocationString, AssetLocationInput, AssetLocationCanonical, ChainLocationString } from './lib/location.js';
 import { convertAssetLocationInputToCanonical } from './lib/location.js';
-import type { BankAccountAddressObfuscated, BankAccountAddressResolved, MobileWalletAddressObfuscated, MobileWalletAddressResolved, MonthYearDateInput, PhysicalAddress } from './lib/data/addresses/types.generated.js';
+import type { BankAccountAddressObfuscated, BankAccountAddressResolved, MobileWalletAddressObfuscated, MobileWalletAddressResolved } from './lib/data/addresses/types.generated.js';
 import type { HexString, KeetaNetAccount, MovableAsset, MovableAssetSearchCanonical, CurrencySearchCanonical, ExternalChainLocationType, ExternalChainAsset } from '../../lib/asset.js';
 import { convertAssetSearchInputToCanonical } from '../../lib/asset.js';
 import { assertKeetaAssetMovementAnchorAdditionalKYCNeededErrorJSONProperties, assertKeetaAssetMovementAnchorKYCShareNeededErrorJSONProperties, assertKeetaAssetMovementAnchorOperationNotSupportedErrorJSONProperties } from './common.generated.js';
 import type { ClientRenderableContent } from '../../lib/metadata.types.js';
 import type { TokenMetadata } from '../../lib/token-metadata.js';
 import type { DistributiveOmit } from '@keetanetwork/keetanet-client/lib/utils/helper.js';
+import { objectToSignable } from '../../lib/utils/signing.js';
 
 export * from './lib/data/addresses/types.generated.js';
 
@@ -223,69 +224,6 @@ export function commonJSONStringify(input: unknown): string {
 	}));
 }
 
-type SignableObjectInput =
-	// PhysicalAddress/MonthYearDateInput/RecipientResolved should not be needed here, but due to a TypeScript issue we need to reference it directly because it cannot satisfy the index signature otherwise.
-	PhysicalAddress | MonthYearDateInput | RecipientResolved |
-	{ [key: string | number | symbol]: SignableObjectInput } |
-	SignableObjectInput[] |
-	Signable[number] |
-	undefined |
-	null |
-	boolean;
-
-/**
- * The maximum queue length for the commonToSignable function to prevent DoS attacks
- */
-const TO_SIGNABLE_MAX_QUEUE_LENGTH = 250;
-
-function commonToSignable(item: SignableObjectInput): Signable {
-	const queue: [ string, SignableObjectInput ][] = [[ '', item ]];
-	const result: [ string, Signable[number] ][] = [];
-
-	while (queue.length > 0) {
-		const next = queue.shift();
-
-		if (!next) {
-			continue;
-		}
-
-		const [ prefix, current ] = next;
-		if (current === null || current === undefined) {
-			continue;
-		}
-
-		if (typeof current === 'boolean') {
-			result.push([ prefix, current ? 1 : 0 ]);
-		} else if (Array.isArray(current)) {
-			for (let i = 0; i < current.length; i++) {
-				queue.push([ `${prefix}[${i}]`, current[i] ]);
-			}
-		} else if (typeof current === 'object') {
-			for (const [ key, value ] of Object.entries(current)) {
-				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-				queue.push([ prefix ? `${prefix}.${key}` : key, value as SignableObjectInput ]);
-			}
-		} else {
-			result.push([ prefix, current ]);
-		}
-
-		if (queue.length > TO_SIGNABLE_MAX_QUEUE_LENGTH) {
-			throw(new KeetaAnchorUserError('Too much data to sign in commonToSignable'));
-		}
-	}
-
-	result.sort((a, b) => {
-		return(a[0].localeCompare(b[0], 'en-US', {
-			usage: 'sort',
-			numeric: true,
-			sensitivity: 'case',
-			ignorePunctuation: false
-		}));
-	});
-
-	return(result.map(item => item[1]));
-}
-
 export type AssetPair<From extends MovableAsset = MovableAsset, To extends MovableAsset = MovableAsset> = { from: From; to: To; };
 export type AssetOrPair = MovableAsset | AssetPair;
 
@@ -402,7 +340,7 @@ export type KeetaAssetMovementAnchorInitiateTransferRequest = ConvertToExternalR
 export type KeetaAssetMovementAnchorSimulateTransferRequest = KeetaAssetMovementAnchorInitiateTransferRequest;
 
 export function getKeetaAssetMovementAnchorInitiateTransferRequestSigningData(input: KeetaAssetMovementAnchorInitiateTransferClientRequest | KeetaAssetMovementAnchorInitiateTransferRequest): Signable {
-	return(commonToSignable({
+	return(objectToSignable({
 		asset: convertAssetOrPairSearchInputToCanonical(input.asset),
 		from: { location: convertAssetLocationInputToCanonical(input.from.location) },
 		to: { location: convertAssetLocationInputToCanonical(input.to.location), recipient: input.to.recipient },
@@ -658,7 +596,7 @@ export interface KeetaAssetMovementAnchorExecuteTransferClientRequest {
 export type KeetaAssetMovementAnchorExecuteTransferRequest = ConvertToExternalRequest<Omit<KeetaAssetMovementAnchorExecuteTransferClientRequest, 'id'>, unknown>;
 
 export function getKeetaAssetMovementAnchorExecuteTransferRequestSigningData(input: (KeetaAssetMovementAnchorExecuteTransferRequest | KeetaAssetMovementAnchorExecuteTransferClientRequest) & { id: string; }): Signable {
-	return(commonToSignable({
+	return(objectToSignable({
 		id: input.id,
 		instruction: input.instruction
 	}));
@@ -816,7 +754,7 @@ export type KeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateR
 
 export function getKeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateRequestSigningData(input: KeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateClientRequest | KeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateRequest): Signable {
 	const pair = toAssetPair(input.asset);
-	return(commonToSignable({
+	return(objectToSignable({
 		asset: { from: convertAssetSearchInputToCanonical(pair.from), to: convertAssetSearchInputToCanonical(pair.to) },
 		location: convertAssetLocationInputToCanonical(input.location)
 	}));
@@ -870,13 +808,13 @@ export type KeetaAssetMovementAnchorCreatePersistentForwardingAddressTemplateReq
 
 export function getKeetaAssetMovementAnchorCreatePersistentForwardingAddressTemplateRequestSigningData(input: KeetaAssetMovementAnchorCreatePersistentForwardingAddressTemplateClientRequest | KeetaAssetMovementAnchorCreatePersistentForwardingAddressTemplateRequest): Signable {
 	if ('data' in input) {
-		return(commonToSignable({
+		return(objectToSignable({
 			id: input.id,
 			data: input.data
 		}));
 	}
 	const pair = toAssetPair(input.asset);
-	return(commonToSignable({
+	return(objectToSignable({
 		asset: { from: convertAssetSearchInputToCanonical(pair.from), to: convertAssetSearchInputToCanonical(pair.to) },
 		location: convertAssetLocationInputToCanonical(input.location),
 		address: input.address
@@ -956,7 +894,7 @@ export type KeetaAssetMovementAnchorCreatePersistentForwardingRequest = {
 });
 
 export function getKeetaAssetMovementAnchorCreatePersistentForwardingRequestSigningData(input: KeetaAssetMovementAnchorCreatePersistentForwardingClientRequest | KeetaAssetMovementAnchorCreatePersistentForwardingRequest): Signable {
-	return(commonToSignable({
+	return(objectToSignable({
 		sourceLocation: convertAssetLocationInputToCanonical(input.sourceLocation),
 		asset: convertAssetOrPairSearchInputToCanonical(input.asset),
 		outgoingRail: input.outgoingRail,

--- a/src/services/asset-movement/server.test.ts
+++ b/src/services/asset-movement/server.test.ts
@@ -1,12 +1,16 @@
 import { expect, test } from 'vitest';
+
+import type { KeetaAnchorAssetMovementServerConfig } from './server.js';
 import { KeetaNetAssetMovementAnchorHTTPServer } from './server.js';
 import { KeetaNet } from '../../client/index.js';
 import { KeetaAnchorUserError } from '../../lib/error.js';
+import { verifyMetadataSignature } from '../../lib/anchor-metadata-server.js';
+import { assertHTTPSignedField } from '../../lib/http-server/common.js';
 
-test('Asset Movement Server Tests', async function() {
+function makeServerConfig(overrides: Partial<KeetaAnchorAssetMovementServerConfig> = {}): KeetaAnchorAssetMovementServerConfig {
 	const asset = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0, KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
 
-	await using server = new KeetaNetAssetMovementAnchorHTTPServer({
+	return({
 		assetMovement: {
 			supportedAssets: [{
 				asset: asset.publicKeyString.get(),
@@ -26,14 +30,36 @@ test('Asset Movement Server Tests', async function() {
 				// TODO
 				throw(new KeetaAnchorUserError('not implemented'));
 			}
-		}
+		},
+		...overrides
 	});
+}
+
+test('Asset Movement Server Tests', async function() {
+	await using server = new KeetaNetAssetMovementAnchorHTTPServer(makeServerConfig());
 
 	await server.start();
 	const url = server.url;
 	expect(url).toBeDefined();
 
-	expect(await server.serviceMetadata()).toBeDefined();
+	const metadata = await server.serviceMetadata();
+	expect(metadata).toBeDefined();
+	expect(metadata.account).toBeUndefined();
+	expect(metadata.signed).toBeUndefined();
 
 	/* XXX:TODO: Tests */
+});
+
+test('Asset Movement Server signs metadata when metadataSigner is configured', async function() {
+	const signer = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0).assertAccount();
+
+	await using server = new KeetaNetAssetMovementAnchorHTTPServer(makeServerConfig({ metadataSigner: signer }));
+	await server.start();
+
+	const metadata = await server.serviceMetadata();
+	expect(metadata.account).toBe(signer.publicKeyString.get());
+
+	const signed = assertHTTPSignedField(metadata.signed);
+	const valid = await verifyMetadataSignature(signer, metadata, signed);
+	expect(valid).toBe(true);
 });

--- a/src/services/asset-movement/server.ts
+++ b/src/services/asset-movement/server.ts
@@ -1,4 +1,6 @@
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
 import { KeetaNet } from '../../client/index.js';
 import {
 	KeetaAnchorUserError
@@ -73,7 +75,7 @@ import type { SharedAnchorMetadataLegalExtension } from '../../lib/metadata.type
 
 type AssetMovementServiceMetadata = NonNullable<ServiceMetadata['services']['assetMovement']>[string];
 
-export interface KeetaAnchorAssetMovementServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorAssetMovementServerConfig extends KeetaAnchorMetadataServerConfig {
 	/**
 	 * The data to use for the index page (optional)
 	 */
@@ -165,7 +167,7 @@ function serializePersistentAddressTemplateResponse(template: ExtractOk<KeetaAss
 	});
 }
 
-export class KeetaNetAssetMovementAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<KeetaAnchorAssetMovementServerConfig> implements Required<KeetaAnchorAssetMovementServerConfig> {
+export class KeetaNetAssetMovementAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['assetMovement']>[string], KeetaAnchorAssetMovementServerConfig> implements Omit<Required<KeetaAnchorAssetMovementServerConfig>, 'metadataSigner'> {
 	readonly homepage: NonNullable<KeetaAnchorAssetMovementServerConfig['homepage']>;
 	readonly assetMovement: NonNullable<KeetaAnchorAssetMovementServerConfig['assetMovement']>;
 
@@ -527,7 +529,7 @@ export class KeetaNetAssetMovementAnchorHTTPServer extends KeetaAnchorHTTPServer
 		return(routes);
 	}
 
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['assetMovement']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['assetMovement']>[string]> {
 		const operations: NonNullable<ServiceMetadata['services']['assetMovement']>[string]['operations'] = {};
 
 		const routes = [

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -1,4 +1,6 @@
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 import { KeetaNet } from '../../client/index.js';
 import {
 	KeetaAnchorError,
@@ -67,7 +69,7 @@ export type GetConversionRateAndFeeContext = {
 	request: KeetaFXAnchorQueueStage1Request;
 }
 
-export interface KeetaAnchorFXServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorFXServerConfig extends KeetaAnchorMetadataServerConfig {
 	/**
 	 * The data to use for the index page (optional)
 	 */
@@ -988,8 +990,8 @@ class KeetaFXAnchorQueuePipeline extends KeetaAnchorQueuePipelineAdvanced<KeetaF
 
 }
 
-type SharedHTTPServerConfigType = Pick<KeetaAnchorFXServerConfig, 'fx' | 'homepage' | keyof KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig>;
-abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServerConfigType> extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<ConfigType> implements Omit<Required<KeetaAnchorFXServerConfig>, 'storage' | 'queueRunnerExtensions' | 'accounts' | 'account' | 'signer' | 'client' | 'quoteSigner' | 'quoteConfiguration'> {
+type SharedHTTPServerConfigType = Pick<KeetaAnchorFXServerConfig, 'fx' | 'homepage' | keyof KeetaAnchorMetadataServerConfig>;
+abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServerConfigType> extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['fx']>[string], ConfigType> implements Omit<Required<KeetaAnchorFXServerConfig>, 'storage' | 'queueRunnerExtensions' | 'accounts' | 'account' | 'signer' | 'client' | 'quoteSigner' | 'quoteConfiguration' | 'metadataSigner'> {
 	readonly homepage: NonNullable<KeetaAnchorFXServerConfig['homepage']>;
 	readonly fx: KeetaAnchorFXServerConfig['fx'];
 	readonly canPerformExchanges: boolean;
@@ -1152,7 +1154,7 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 	/**
 	 * Return the servers endpoints and possible currency conversions metadata
 	 */
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
 		const operations: NonNullable<ServiceMetadata['services']['fx']>[string]['operations'] = {
 			getEstimate: (new URL('/api/getEstimate', this.url)).toString()
 		};
@@ -1186,7 +1188,7 @@ export class KeetaNetFXAnchorEstimateHTTPServer extends BaseKeetaNetFXAnchorHTTP
 	}
 }
 
-export class KeetaNetFXAnchorHTTPServer extends BaseKeetaNetFXAnchorHTTPServer<KeetaAnchorFXServerConfig> implements Omit<Required<KeetaAnchorFXServerConfig>, 'storage' | 'queueRunnerExtensions'> {
+export class KeetaNetFXAnchorHTTPServer extends BaseKeetaNetFXAnchorHTTPServer<KeetaAnchorFXServerConfig> implements Omit<Required<KeetaAnchorFXServerConfig>, 'storage' | 'queueRunnerExtensions' | 'metadataSigner'> {
 	readonly client: KeetaAnchorFXServerConfig['client'];
 	readonly accounts: NonNullable<KeetaAnchorFXServerConfig['accounts']>;
 	readonly account: KeetaAnchorFXServerConfig['account'] = undefined;
@@ -1564,8 +1566,8 @@ export class KeetaNetFXAnchorHTTPServer extends BaseKeetaNetFXAnchorHTTPServer<K
 		return(routes);
 	}
 
-	override async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
-		const baseMetadata = await super.serviceMetadata();
+	protected override async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
+		const baseMetadata = await super.buildServiceMetadata();
 
 		if (this.quoteConfiguration.requiresQuote || this.quoteConfiguration.issueQuotes) {
 			baseMetadata.operations.getQuote = (new URL('/api/getQuote', this.url)).toString();

--- a/src/services/kyc/server.ts
+++ b/src/services/kyc/server.ts
@@ -1,7 +1,8 @@
 import { KeetaNet } from '../../client/index.js';
 import * as CurrencyInfo from '@keetanetwork/currency-info';
 
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
 import {
 	KeetaAnchorUserError
 } from '../../lib/error.js';
@@ -19,6 +20,7 @@ import {
 } from './common.js';
 import type * as Signing from '../../lib/utils/signing.js';
 import type { ServiceMetadata } from '../../lib/resolver.ts';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 
 const kycProviderURLUndefined = 'NO_KYC_PROVIDER_URL:87f0175c-4d0a-4029-a4f3-ba93ef725654';
 
@@ -29,7 +31,7 @@ const kycProviderURLUndefined = 'NO_KYC_PROVIDER_URL:87f0175c-4d0a-4029-a4f3-ba9
  */
 type BaseCertificate = InstanceType<typeof KeetaNet.lib.Utils.Certificate.Certificate>;
 
-export interface KeetaAnchorKYCServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorKYCServerConfig extends KeetaAnchorMetadataServerConfig {
 	/**
 	 * The data to use for the index page (optional)
 	 */
@@ -146,7 +148,7 @@ export interface KeetaAnchorKYCServerConfig extends KeetaAnchorHTTPServer.KeetaA
 	routes?: KeetaAnchorHTTPServer.Routes;
 };
 
-export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<KeetaAnchorKYCServerConfig> implements Required<KeetaAnchorKYCServerConfig> {
+export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['kyc']>[string], KeetaAnchorKYCServerConfig> implements Required<KeetaAnchorKYCServerConfig> {
 	readonly homepage: NonNullable<KeetaAnchorKYCServerConfig['homepage']>;
 	readonly client: KeetaAnchorKYCServerConfig['client'];
 	readonly signer: NonNullable<KeetaAnchorKYCServerConfig['signer']>;
@@ -330,7 +332,7 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetA
 		});
 	}
 
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['kyc']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['kyc']>[string]> {
 		return({
 			ca: this.ca.toPEM(),
 			countryCodes: this.#countryCodes?.map(function(country) {

--- a/src/services/notification/server.ts
+++ b/src/services/notification/server.ts
@@ -1,5 +1,6 @@
 import { KeetaNet } from '../../client/index.js';
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
 import type {
 	KeetaNotificationAnchorRegisterTargetClientRequest,
 	KeetaNotificationAnchorListTargetsClientRequest,
@@ -31,10 +32,11 @@ import {
 } from './common.js';
 import type { ServiceMetadata, ServiceMetadataAuthenticationType } from '../../lib/resolver.js';
 import type { Routes } from '../../lib/http-server/index.js';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 import { KeetaAnchorUserError } from '../../lib/error.js';
 import { verifyBodyAuth, verifyURLAuth } from '../../lib/http-server/common.js';
 
-export interface KeetaAnchorNotificationServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorNotificationServerConfig extends KeetaAnchorMetadataServerConfig {
 	homepage?: string | (() => Promise<string> | string);
 	notification: {
 		registerTarget?: (args: Required<KeetaNotificationAnchorRegisterTargetClientRequest>) => Promise<{ id: string; }>;
@@ -51,7 +53,7 @@ export interface KeetaAnchorNotificationServerConfig extends KeetaAnchorHTTPServ
 	routes?: Routes;
 }
 
-export class KeetaNetNotificationAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<KeetaAnchorNotificationServerConfig> {
+export class KeetaNetNotificationAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['notification']>[string], KeetaAnchorNotificationServerConfig> {
 	readonly homepage: NonNullable<KeetaAnchorNotificationServerConfig['homepage']>;
 	readonly notification: KeetaAnchorNotificationServerConfig['notification'];
 	readonly routes: NonNullable<KeetaAnchorNotificationServerConfig['routes']>;
@@ -223,7 +225,7 @@ export class KeetaNetNotificationAnchorHTTPServer extends KeetaAnchorHTTPServer.
 		return(routes);
 	}
 
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['notification']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['notification']>[string]> {
 		const retval: NonNullable<ServiceMetadata['services']['notification']>[string] = { operations: {}};
 
 		const authentication: ServiceMetadataAuthenticationType = {

--- a/src/services/notification/server.ts
+++ b/src/services/notification/server.ts
@@ -31,7 +31,6 @@ import {
 	getNotificationListSubscriptionsRequestSignable
 } from './common.js';
 import type { ServiceMetadata, ServiceMetadataAuthenticationType } from '../../lib/resolver.js';
-import type { Routes } from '../../lib/http-server/index.js';
 import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 import { KeetaAnchorUserError } from '../../lib/error.js';
 import { verifyBodyAuth, verifyURLAuth } from '../../lib/http-server/common.js';
@@ -50,7 +49,7 @@ export interface KeetaAnchorNotificationServerConfig extends KeetaAnchorMetadata
 		supportedChannels?: SupportedChannelConfigurationMetadata;
 		supportedSubscriptions?: NotificationSubscriptionType[];
 	};
-	routes?: Routes;
+	routes?: KeetaAnchorHTTPServer.Routes;
 }
 
 export class KeetaNetNotificationAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['notification']>[string], KeetaAnchorNotificationServerConfig> {

--- a/src/services/storage/server.ts
+++ b/src/services/storage/server.ts
@@ -2,7 +2,7 @@ import type { ServiceMetadata } from '../../lib/resolver.ts';
 import type { Signable } from '../../lib/utils/signing.js';
 import type { NamespaceValidator } from './lib/validators.js';
 import type { ResolvedCertificateChainRequirement } from '../../lib/utils/certificate-network.js';
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
 import type { KeetaNet } from '../../client/index.js';
 import type {
 	KeetaStorageAnchorDeleteResponse,
@@ -20,6 +20,7 @@ import type {
 	StorageGetResult,
 	SearchPagination
 } from './common.ts';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
 import {
 	assertKeetaStorageAnchorDeleteResponse,
 	assertKeetaStorageAnchorPutResponse,
@@ -41,6 +42,7 @@ import {
 	CONTENT_TYPE_OCTET_STREAM,
 	DEFAULT_SIGNED_URL_TTL_SECONDS
 } from './common.js';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 import { VerifySignedData } from '../../lib/utils/signing.js';
 import { parseSignatureFromURL, verifyBodyAuth, verifyURLAuth } from '../../lib/http-server/common.js';
 import { arrayBufferLikeToBuffer, Buffer } from '../../lib/utils/buffer.js';
@@ -223,7 +225,7 @@ async function authorizeURLAccess(
  *         |                                   | get(), decrypt ----------------->|
  *         |<--------------------------------- | Plaintext content                |
  */
-export interface KeetaAnchorStorageServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorStorageServerConfig extends KeetaAnchorMetadataServerConfig {
 	/**
 	 * The data to use for the index page (optional)
 	 */
@@ -306,7 +308,7 @@ const DEFAULT_TAG_VALIDATION = {
 	pattern: /^[a-zA-Z0-9_-]+$/
 };
 
-export class KeetaNetStorageAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<KeetaAnchorStorageServerConfig> {
+export class KeetaNetStorageAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['storage']>[string], KeetaAnchorStorageServerConfig> {
 	readonly homepage: NonNullable<KeetaAnchorStorageServerConfig['homepage']>;
 	readonly backend: FullStorageBackend;
 	readonly anchorAccount: Account;
@@ -908,7 +910,7 @@ export class KeetaNetStorageAnchorHTTPServer extends KeetaAnchorHTTPServer.Keeta
 		return(routes);
 	}
 
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['storage']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['storage']>[string]> {
 		const authRequired = { options: { authentication: { type: 'required' as const, method: 'keeta-account' as const }}};
 		const acceptedIssuerDNs = this.acceptedIssuerDNs();
 		const operations: NonNullable<ServiceMetadata['services']['storage']>[string]['operations'] = {

--- a/src/services/username/server.ts
+++ b/src/services/username/server.ts
@@ -1,5 +1,6 @@
 import { KeetaNet } from '../../client/index.js';
-import * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
 import type {
 	KeetaUsernameAnchorUsernameResolutionContext,
 	KeetaUsernameAnchorAccountResolutionContext,
@@ -22,6 +23,7 @@ import {
 } from './common.js';
 import type { ServiceMetadata, ServiceMetadataAuthenticationType } from '../../lib/resolver.ts';
 import type { Routes } from '../../lib/http-server/index.ts';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
 import { KeetaAnchorUserError, KeetaAnchorUserValidationError } from '../../lib/error.js';
 import { verifyBodyAuth } from '../../lib/http-server/common.js';
 import * as Signing from '../../lib/utils/signing.js';
@@ -45,7 +47,7 @@ function normalizeUsernamePattern(pattern: string | RegExp): RegExp {
 type ClaimHandlerResponse = { ok: true; } | { ok: false; taken?: false; } | { ok: false; taken: true; };
 type SearchHandlerResponse = { results: KeetaUsernameAnchorUsernameWithAccount[] };
 
-export interface KeetaAnchorUsernameServerConfig extends KeetaAnchorHTTPServer.KeetaAnchorHTTPServerConfig {
+export interface KeetaAnchorUsernameServerConfig extends KeetaAnchorMetadataServerConfig {
 	homepage?: string | (() => Promise<string> | string);
 	usernames: {
 		resolveUsername: (input: KeetaUsernameAnchorUsernameResolutionContext) => Promise<{ account: InstanceType<typeof KeetaNet.lib.Account>; } | null>;
@@ -60,7 +62,7 @@ export interface KeetaAnchorUsernameServerConfig extends KeetaAnchorHTTPServer.K
 	usernamePattern?: string | RegExp;
 }
 
-export class KeetaNetUsernameAnchorHTTPServer extends KeetaAnchorHTTPServer.KeetaNetAnchorHTTPServer<KeetaAnchorUsernameServerConfig> {
+export class KeetaNetUsernameAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['username']>[string], KeetaAnchorUsernameServerConfig> {
 	readonly homepage: NonNullable<KeetaAnchorUsernameServerConfig['homepage']>;
 	readonly usernames: KeetaAnchorUsernameServerConfig['usernames'];
 	readonly routes: NonNullable<KeetaAnchorUsernameServerConfig['routes']>;
@@ -299,7 +301,7 @@ export class KeetaNetUsernameAnchorHTTPServer extends KeetaAnchorHTTPServer.Keet
 		return(routes);
 	}
 
-	async serviceMetadata(): Promise<NonNullable<ServiceMetadata['services']['username']>[string]> {
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['username']>[string]> {
 		const acceptedIssuerDNs = this.acceptedIssuerDNs();
 		const operations: NonNullable<ServiceMetadata['services']['username']>[string]['operations'] = {
 			resolve: (new URL('/api/resolve/{toResolve}', this.url)).toString()


### PR DESCRIPTION
# Summary

- Adds optional `account` + `signed` fields to anchor service metadata.
- Adds `KeetaAnchorMetadataServer` which auto-signs when `metadataSigner` is configured.
- Updates `Resolver` to verify signatures on lookup and drops invalid entries.
- Extracts shared helpers like `objectToSignable`.