### PR TITLE
feat(utils): External Field Signing

### DIFF
--- a/src/lib/anchor-external.generated.ts
+++ b/src/lib/anchor-external.generated.ts
@@ -1,0 +1,4 @@
+import { createAssertEquals } from 'typia';
+import type { EncodedAnchorExternalEnvelopeV1 } from './anchor-external.js';
+
+export const assertEncodedAnchorExternalEnvelopeV1: (input: unknown) => EncodedAnchorExternalEnvelopeV1 = createAssertEquals<EncodedAnchorExternalEnvelopeV1>();

--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -1,0 +1,412 @@
+import { test, expect } from 'vitest';
+import { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
+
+import type {
+	AnchorExternalEntry,
+	AnchorExternalErrorCode,
+	EncodedAnchorExternalEnvelopeV1
+} from './anchor-external.js';
+import {
+	AnchorExternal,
+	AnchorExternalBuilder,
+	AnchorExternalError,
+	ANCHOR_EXTERNAL_VERSION
+} from './anchor-external.js';
+import { EncryptedContainer } from './encrypted-container.js';
+import { KeetaAnchorError } from './error.js';
+import { canonicalizeJson } from './utils/signing.js';
+import { Buffer, arrayBufferToBuffer } from './utils/buffer.js';
+
+const Account: typeof KeetaNetLib.Account = KeetaNetLib.Account;
+type Account = InstanceType<typeof KeetaNetLib.Account>;
+
+/*
+ * Fixed-seed accounts: deterministic across test runs and across all
+ * round-trip variants.
+ */
+const anchor1 = Account.fromSeed('A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1', 0);
+const anchor2 = Account.fromSeed('B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2', 0);
+const stranger = Account.fromSeed('C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3', 0);
+
+/*
+ * Anchor 1's public key string.
+ */
+const anchor1Key = anchor1.publicKeyString.get();
+
+/*
+ * Fixed binding values used wherever a test requires a signed envelope.
+ */
+const TEST_BINDING_PREVIOUS_BLOCK_HASH = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TEST_BINDING_OPERATION_INDEX = 3;
+
+type ModeSpec = {
+	name: string;
+	configure: (builder: AnchorExternalBuilder) => void;
+	decode: (external: string) => Promise<AnchorExternal>;
+	expectedEncrypted: boolean;
+	expectedSigned: boolean;
+};
+
+const modeSpecs: ModeSpec[] = [
+	{
+		name: 'plain-unsigned',
+		configure: function() {},
+		decode: async function(external) { return(await AnchorExternal.fromPlainExternal(external)); },
+		expectedEncrypted: false,
+		expectedSigned: false
+	},
+	{
+		name: 'plain-signed',
+		configure: function(builder) {
+			builder.withSigner(anchor1).withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
+		},
+		decode: async function(external) { return(await AnchorExternal.fromPlainExternal(external)); },
+		expectedEncrypted: false,
+		expectedSigned: true
+	},
+	{
+		name: 'encrypted-unsigned',
+		configure: function(builder) { builder.withPrincipals([anchor2]); },
+		decode: async function(external) { return(await AnchorExternal.fromEncryptedExternal(external, [anchor2])); },
+		expectedEncrypted: true,
+		expectedSigned: false
+	},
+	{
+		name: 'encrypted-signed',
+		configure: function(builder) {
+			builder.withSigner(anchor1).withPrincipals([anchor1]).withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
+		},
+		decode: async function(external) { return(await AnchorExternal.fromEncryptedExternal(external, [anchor1])); },
+		expectedEncrypted: true,
+		expectedSigned: true
+	}
+];
+
+const entryCases: { name: string; entry: AnchorExternalEntry }[] = [
+	{ name: 'transactionId', entry: { transactionId: 'tx-12345' }},
+	{ name: 'persistentForwardingId', entry: { persistentForwardingId: 'fwd-67890' }},
+	{ name: 'destination', entry: { destination: '0x0000000000000000000000000000000000000000' }}
+];
+
+type RoundTripCase = {
+	name: string;
+	entry: AnchorExternalEntry;
+	mode: ModeSpec;
+};
+
+const roundTripCases: RoundTripCase[] = entryCases.flatMap(function(entryCase) {
+	return(modeSpecs.map(function(mode) {
+		return({
+			name: `${entryCase.name} / ${mode.name}`,
+			entry: entryCase.entry,
+			mode
+		});
+	}));
+});
+
+test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
+	const builder = new AnchorExternalBuilder().setAnchor(anchor1, entry);
+	mode.configure(builder);
+
+	const external = await builder.build();
+	const decoded = await mode.decode(external);
+	expect(decoded.envelope).toEqual(builder.toEnvelope());
+	expect(decoded.encrypted).toBe(mode.expectedEncrypted);
+	expect(decoded.signed?.signer.comparePublicKey(anchor1) ?? false).toBe(mode.expectedSigned);
+
+	const peeked = await AnchorExternal.peek(external);
+	expect(peeked).toEqual({ encrypted: mode.expectedEncrypted, signed: mode.expectedSigned });
+});
+
+test('round-trip preserves multiple anchors with mixed entry kinds', async function() {
+	const builder = new AnchorExternalBuilder()
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.setAnchor(anchor2, { persistentForwardingId: 'fwd-2' })
+		.withSigner(anchor2)
+		.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
+
+	const external = await builder.build();
+	const decoded = await AnchorExternal.fromPlainExternal(external);
+	expect(decoded.envelope).toEqual(builder.toEnvelope());
+	expect(decoded.envelope.binding).toEqual({ previousBlockHash: TEST_BINDING_PREVIOUS_BLOCK_HASH, operationIndex: TEST_BINDING_OPERATION_INDEX });
+	expect(decoded.signed?.signer.comparePublicKey(anchor2)).toBe(true);
+});
+
+type MisuseCase = {
+	name: string;
+	act: () => unknown;
+};
+
+const misuseCases: MisuseCase[] = [
+	{
+		name: 'signer not listed in envelope.anchors',
+		act: function() {
+			return(new AnchorExternalBuilder()
+				.setAnchor(anchor1, { transactionId: 'x' })
+				.withSigner(stranger)
+				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
+				.build());
+		}
+	},
+	{
+		name: 'signer set without binding',
+		act: function() {
+			return(new AnchorExternalBuilder()
+				.setAnchor(anchor1, { transactionId: 'x' })
+				.withSigner(anchor1)
+				.build());
+		}
+	},
+	{
+		name: 'binding set without signer',
+		act: function() {
+			return(new AnchorExternalBuilder()
+				.setAnchor(anchor1, { transactionId: 'x' })
+				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
+				.build());
+		}
+	},
+	{
+		name: 'withBinding rejects empty previous eagerly',
+		act: function() { return(new AnchorExternalBuilder().withBinding('', 0)); }
+	},
+	{
+		name: 'withBinding rejects negative operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, -1)); }
+	},
+	{
+		name: 'withBinding rejects non-integer operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, 1.5)); }
+	},
+	{
+		name: 'maxLength too tight for a signed payload',
+		act: function() {
+			return(new AnchorExternalBuilder()
+				.setAnchor(anchor1, { transactionId: 'x' })
+				.withSigner(anchor1)
+				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
+				.withMaxLength(64)
+				.build());
+		}
+	},
+	{
+		name: 'withMaxLength rejects non-positive eagerly',
+		act: function() { return(new AnchorExternalBuilder().withMaxLength(0)); }
+	},
+	{
+		name: 'withMaxLength rejects non-integer eagerly',
+		act: function() { return(new AnchorExternalBuilder().withMaxLength(1.5)); }
+	},
+	{
+		name: 'fromEncryptedExternal with empty principals list',
+		act: async function() {
+			const external = await new AnchorExternalBuilder()
+				.setAnchor(anchor1, { transactionId: 'x' })
+				.withPrincipals([anchor1])
+				.build();
+			return(await AnchorExternal.fromEncryptedExternal(external, []));
+		}
+	}
+];
+
+test.each(misuseCases)('builder/decoder misuse throws KeetaAnchorError: $name', async function({ act }) {
+	const result = (async function() { return(await act()); })();
+	const error = await result.catch(function(caught: unknown) { return(caught); });
+	expect(KeetaAnchorError.isInstance(error)).toBe(true);
+	expect(AnchorExternalError.isInstance(error)).toBe(false);
+});
+
+type DecoderKind = 'plain' | 'encrypted-self' | 'encrypted-stranger';
+
+type DecodeRejectionCase = {
+	name: string;
+	makeExternal: () => Promise<string>;
+	decoder: DecoderKind;
+	expectedCode: AnchorExternalErrorCode;
+};
+
+async function repackContainer(plaintext: Buffer, signer: Account | undefined): Promise<string> {
+	const options: { signer?: Account } = {};
+	if (signer !== undefined) {
+		options.signer = signer;
+	}
+
+	const container = EncryptedContainer.fromPlaintext(plaintext, null, options);
+	const encoded = arrayBufferToBuffer(await container.getEncodedBuffer());
+	const external = encoded.toString('base64');
+	return(external);
+}
+
+async function buildPlain(entry: AnchorExternalEntry): Promise<string> {
+	const builder = new AnchorExternalBuilder().setAnchor(anchor1, entry);
+	const external = await builder.build();
+	return(external);
+}
+
+async function buildEncrypted(entry: AnchorExternalEntry, principals: Account[]): Promise<string> {
+	const builder = new AnchorExternalBuilder().setAnchor(anchor1, entry).withPrincipals(principals);
+	const external = await builder.build();
+	return(external);
+}
+
+async function packEncoded(encoded: object, signer: Account | undefined): Promise<string> {
+	const plaintext = Buffer.from(canonicalizeJson(encoded), 'utf-8');
+	const external = await repackContainer(plaintext, signer);
+	return(external);
+}
+
+const decoderImplementations: { [key in DecoderKind]: (external: string) => Promise<AnchorExternal> } = {
+	'plain': async function(external: string) { return(await AnchorExternal.fromPlainExternal(external)); },
+	'encrypted-self': async function(external: string) { return(await AnchorExternal.fromEncryptedExternal(external, [anchor1])); },
+	'encrypted-stranger': async function(external: string) { return(await AnchorExternal.fromEncryptedExternal(external, [stranger])); }
+};
+
+const decodeRejectionCases: DecodeRejectionCase[] = [
+	{
+		name: 'bad base64',
+		makeExternal: async function() { return('not base64!'); },
+		decoder: 'plain',
+		expectedCode: 'BAD_BASE64'
+	},
+	{
+		name: 'truncated DER',
+		makeExternal: async function() {
+			const valid = await buildPlain({ transactionId: 'x' });
+			const decoded = Buffer.from(valid, 'base64');
+			const truncated = decoded.subarray(0, Math.max(1, decoded.length - 8));
+			return(Buffer.from(truncated).toString('base64'));
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'plaintext blob decoded with the encrypted decoder',
+		makeExternal: async function() {
+			const result = await buildPlain({ transactionId: 'x' });
+			return(result);
+		},
+		decoder: 'encrypted-self',
+		expectedCode: 'EXPECTED_ENCRYPTED'
+	},
+	{
+		name: 'encrypted blob decoded with the plain decoder',
+		makeExternal: async function() {
+			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'EXPECTED_PLAIN'
+	},
+	{
+		name: 'unknown envelope version inside container plaintext',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: 2, a: { [anchor1Key]: { t: 'x' }}}, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'UNSUPPORTED_VERSION'
+	},
+	{
+		name: 'envelope with extra top-level key',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}, extra: 1 }, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'entry with extra key',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x', extra: 'y' }}}, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'non-canonical JSON inside container plaintext',
+		makeExternal: async function() {
+			const valid: EncodedAnchorExternalEnvelopeV1 = { v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}};
+
+			/*
+			 * Inject a single space after each comma to break canonical
+			 * form without altering structural meaning.
+			 */
+			const reshaped = canonicalizeJson(valid).replace(/,/g, ', ');
+			const result = await repackContainer(Buffer.from(reshaped, 'utf-8'), undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NON_CANONICAL'
+	},
+	{
+		name: 'signed but signer is not listed in envelope.anchors',
+		makeExternal: async function() {
+			/*
+			 * Sign with stranger but list only anchor1 in
+			 * envelope.anchors. The builder rejects this combination,
+			 * so we synthesize the encoded plaintext directly.
+			 */
+			const encoded: EncodedAnchorExternalEnvelopeV1 = {
+				v: ANCHOR_EXTERNAL_VERSION,
+				a: { [anchor1Key]: { t: 'x' }},
+				b: { p: TEST_BINDING_PREVIOUS_BLOCK_HASH, o: TEST_BINDING_OPERATION_INDEX }
+			};
+			const result = await packEncoded(encoded, stranger);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'SIGNER_NOT_LISTED'
+	},
+	{
+		name: 'signed envelope missing binding',
+		makeExternal: async function() {
+			const encoded: EncodedAnchorExternalEnvelopeV1 = { v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}};
+			const result = await packEncoded(encoded, anchor1);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'MISSING_BINDING'
+	},
+	{
+		name: 'unsigned envelope carries a binding',
+		makeExternal: async function() {
+			const encoded: EncodedAnchorExternalEnvelopeV1 = {
+				v: ANCHOR_EXTERNAL_VERSION,
+				a: { [anchor1Key]: { t: 'x' }},
+				b: { p: TEST_BINDING_PREVIOUS_BLOCK_HASH, o: TEST_BINDING_OPERATION_INDEX }
+			};
+			const result = await packEncoded(encoded, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'UNEXPECTED_BINDING'
+	},
+	{
+		name: 'encrypted decode with a wrong principal',
+		makeExternal: async function() {
+			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
+			return(result);
+		},
+		decoder: 'encrypted-stranger',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	}
+];
+
+test.each(decodeRejectionCases)('fromXExternal rejects malformed input with $expectedCode: $name', async function({ makeExternal, decoder, expectedCode }) {
+	const external = await makeExternal();
+
+	const error = await decoderImplementations[decoder](external).catch(function(caught: unknown) { return(caught); });
+	expect(AnchorExternalError.isInstance(error)).toBe(true);
+
+	if (AnchorExternalError.isInstance(error)) {
+		expect(error.code).toBe(expectedCode);
+	}
+});
+
+test('AnchorExternalError preserves its code through to/fromJSON', async function() {
+	const original = new AnchorExternalError('NON_CANONICAL', 'sample');
+	const restored = await AnchorExternalError.fromJSON(original.toJSON());
+	expect(AnchorExternalError.isInstance(restored) && restored.code).toBe('NON_CANONICAL');
+});

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -1,0 +1,722 @@
+import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
+
+import { assertEncodedAnchorExternalEnvelopeV1 } from './anchor-external.generated.js';
+import { EncryptedContainer, EncryptedContainerError } from './encrypted-container.js';
+import { KeetaAnchorError, KeetaAnchorUserError, KeetaAnchorUserValidationError } from './error.js';
+import { canonicalizeJson } from './utils/signing.js';
+import { Buffer, arrayBufferToBuffer, decodeBase64Strict } from './utils/buffer.js';
+
+type Account = InstanceType<typeof KeetaNetLib.Account>;
+
+/**
+ * Upper bound on inflated container plaintext, before JSON parsing.
+ *
+ * Prevents an attacker from forcing a large allocation via a
+ * high-ratio gzip payload.
+ */
+const MAX_PLAINTEXT_BYTES = 4096;
+
+/**
+ * Current envelope format version.
+ */
+export const ANCHOR_EXTERNAL_VERSION = 1;
+
+// #region Public types
+
+/**
+ * Per-anchor entry.
+ */
+export type AnchorExternalEntry =
+	| {
+		/**
+		 * Transaction id at the anchor.
+		 */
+		transactionId: string;
+	}
+	| {
+		/**
+		 * Persistent forwarding id at the anchor.
+		 */
+		persistentForwardingId: string;
+	}
+	| {
+		/**
+		 * Opaque destination data interpreted by the anchor (e.g. an EVM
+		 * address for an EVM anchor).
+		 */
+		destination: string;
+	};
+
+/**
+ * Replay-protection binding for a signed envelope.
+ *
+ * Pins the signature to a specific position on the signer's account
+ * chain so the same signed envelope cannot be reused on a different
+ * operation or block.
+ */
+export type AnchorExternalBinding = {
+	/**
+	 * Block hash that the signer's account had as its head when the
+	 * SEND carrying this envelope was constructed.
+	 */
+	previousBlockHash: string;
+	/**
+	 * Index of the SEND operation within its block.
+	 */
+	operationIndex: number;
+};
+
+/**
+ * Decoded anchor-external envelope as exposed to callers.
+ */
+export type AnchorExternalEnvelope = {
+	/**
+	 * Envelope format version.
+	 */
+	version: typeof ANCHOR_EXTERNAL_VERSION;
+	/**
+	 * Per-anchor entries keyed by `Account.publicKeyString.get()`.
+	 */
+	anchors: { [anchorPublicKey: string]: AnchorExternalEntry };
+	/**
+	 * Signature binding. Present if the envelope is signed.
+	 */
+	binding?: AnchorExternalBinding;
+};
+
+/**
+ * Authenticity record attached to a verified signed envelope. Present only
+ * when the signature was verified and the signer appears in
+ * {@link AnchorExternalEnvelope.anchors}.
+ */
+export type AnchorExternalSigned = {
+	signer: Account;
+};
+
+/**
+ * Shape inspection result from {@link AnchorExternal.peek}.
+ */
+export type AnchorExternalPeekResult = {
+	encrypted: boolean;
+	signed: boolean;
+};
+
+// #endregion
+
+// #region Encoded form types (module-internal, exported for tests)
+
+/**
+ * Per-anchor entry as it appears in the encoded envelope.
+ *
+ * `t` = transaction id, `p` = persistent forwarding id, `d` = destination.
+ *
+ * Note: Single-letter keys keep the envelope smaller.
+ */
+export type EncodedAnchorExternalEntryV1 =
+	| { t: string }
+	| { p: string }
+	| { d: string };
+
+/**
+ * Replay-protection binding as it appears in the encoded envelope.
+ *
+ * `p` = previous block hash, `o` = operation index.
+ */
+export type EncodedAnchorExternalBindingV1 = {
+	p: string;
+	o: number;
+};
+
+/**
+ * Anchor-external envelope as it appears inside the encoded blob.
+ *
+ * `v` = envelope version, `a` = anchors, `b` = binding.
+ */
+export type EncodedAnchorExternalEnvelopeV1 = {
+	v: typeof ANCHOR_EXTERNAL_VERSION;
+	a: { [anchorPublicKey: string]: EncodedAnchorExternalEntryV1 };
+	b?: EncodedAnchorExternalBindingV1;
+};
+
+// #endregion
+
+// #region Error Handling
+
+/**
+ * Error codes for anchor-external envelope operations.
+ */
+export const AnchorExternalErrorCodes = [
+	/*
+	 * Parsing
+	 */
+	'BAD_BASE64',
+	'NOT_AN_ENVELOPE',
+	'UNSUPPORTED_VERSION',
+	'NON_CANONICAL',
+	'PLAINTEXT_TOO_LARGE',
+
+	/*
+	 * Non-repudiation
+	 */
+	'BAD_SIGNATURE',
+	'SIGNER_NOT_LISTED',
+	'MISSING_BINDING',
+	'UNEXPECTED_BINDING',
+
+	/*
+	 * Confidentiality
+	 */
+	'EXPECTED_PLAIN',
+	'EXPECTED_ENCRYPTED',
+
+	/*
+	 * Caller-declared budget
+	 */
+	'OUTPUT_TOO_LARGE'
+] as const;
+
+export type AnchorExternalErrorCode = typeof AnchorExternalErrorCodes[number];
+
+const anchorExternalErrorCodeSet: ReadonlySet<string> = new Set(AnchorExternalErrorCodes);
+
+/**
+ * Error raised by anchor-external decode failures.
+ */
+export class AnchorExternalError extends KeetaAnchorUserError {
+	static override readonly name: string = 'AnchorExternalError';
+
+	private readonly anchorExternalErrorObjectTypeID!: string;
+	private static readonly anchorExternalErrorObjectTypeID = '2db22831-216b-4b3e-952a-5f9860f0790b';
+
+	readonly code: AnchorExternalErrorCode;
+
+	/**
+	 * Type-narrow an arbitrary string to {@link AnchorExternalErrorCode}.
+	 */
+	static isValidCode(code: string): code is AnchorExternalErrorCode {
+		return(anchorExternalErrorCodeSet.has(code));
+	}
+
+	constructor(code: AnchorExternalErrorCode, message: string) {
+		super(message);
+		this.code = code;
+
+		Object.defineProperty(this, 'anchorExternalErrorObjectTypeID', {
+			value: AnchorExternalError.anchorExternalErrorObjectTypeID,
+			enumerable: false
+		});
+	}
+
+	static override isInstance(input: unknown): input is AnchorExternalError {
+		return(this.hasPropWithValue(input, 'anchorExternalErrorObjectTypeID', AnchorExternalError.anchorExternalErrorObjectTypeID));
+	}
+
+	override toJSON(): ReturnType<KeetaAnchorUserError['toJSON']> & { code: AnchorExternalErrorCode } {
+		return({
+			...super.toJSON(),
+			code: this.code
+		});
+	}
+
+	static override async fromJSON(input: unknown): Promise<AnchorExternalError> {
+		const { message, other } = this.extractErrorProperties(input, this);
+
+		if (!('code' in other) || typeof other.code !== 'string') {
+			throw(new Error('Invalid AnchorExternalError JSON: missing code property'));
+		}
+
+		const code = other.code;
+		if (!this.isValidCode(code)) {
+			throw(new Error(`Invalid AnchorExternalError JSON: unknown code ${code}`));
+		}
+
+		const error = new this(code, message);
+		error.restoreFromJSON(other);
+		return(error);
+	}
+}
+
+// #endregion
+
+// #region Encoded <-> Public mappers
+
+/**
+ * Convert a public entry to an encoded entry.
+ */
+function entryToEncoded(entry: AnchorExternalEntry): EncodedAnchorExternalEntryV1 {
+	if ('transactionId' in entry) {
+		return({ t: entry.transactionId });
+	}
+	if ('persistentForwardingId' in entry) {
+		return({ p: entry.persistentForwardingId });
+	}
+
+	return({ d: entry.destination });
+}
+
+/**
+ * Convert an encoded entry to a public entry.
+ */
+function entryFromEncoded(entry: EncodedAnchorExternalEntryV1): AnchorExternalEntry {
+	if ('t' in entry) {
+		return({ transactionId: entry.t });
+	}
+	if ('p' in entry) {
+		return({ persistentForwardingId: entry.p });
+	}
+
+	return({ destination: entry.d });
+}
+
+/**
+ * Convert a public envelope to an encoded envelope.
+ */
+function envelopeToEncoded(envelope: AnchorExternalEnvelope): EncodedAnchorExternalEnvelopeV1 {
+	const encodedAnchors: { [anchorPublicKey: string]: EncodedAnchorExternalEntryV1 } = {};
+	for (const [pk, entry] of Object.entries(envelope.anchors)) {
+		encodedAnchors[pk] = entryToEncoded(entry);
+	}
+
+	const result: EncodedAnchorExternalEnvelopeV1 = {
+		v: ANCHOR_EXTERNAL_VERSION,
+		a: encodedAnchors
+	};
+	if (envelope.binding !== undefined) {
+		result.b = { p: envelope.binding.previousBlockHash, o: envelope.binding.operationIndex };
+	}
+
+	return(result);
+}
+
+/**
+ * Convert an encoded envelope to a public envelope.
+ */
+function envelopeFromEncoded(encoded: EncodedAnchorExternalEnvelopeV1): AnchorExternalEnvelope {
+	const anchors: { [anchorPublicKey: string]: AnchorExternalEntry } = {};
+	for (const [pk, entry] of Object.entries(encoded.a)) {
+		anchors[pk] = entryFromEncoded(entry);
+	}
+
+	const result: AnchorExternalEnvelope = {
+		version: ANCHOR_EXTERNAL_VERSION,
+		anchors
+	};
+	if (encoded.b !== undefined) {
+		result.binding = { previousBlockHash: encoded.b.p, operationIndex: encoded.b.o };
+	}
+
+	return(result);
+}
+
+/**
+ * Parse an encoded envelope.
+ */
+function parseEncodedEnvelope(value: unknown): EncodedAnchorExternalEnvelopeV1 {
+	try {
+		return(assertEncodedAnchorExternalEnvelopeV1(value));
+	} catch (error) {
+		if (KeetaAnchorUserValidationError.isTypeGuardErrorLike(error)) {
+			if (error.path === '$input.v') {
+				throw(new AnchorExternalError('UNSUPPORTED_VERSION', `Unsupported envelope version at ${error.path}: ${String(error.value)}`));
+			}
+
+			throw(new AnchorExternalError('NOT_AN_ENVELOPE', `Envelope failed shape check at ${error.path ?? '$input'}: expected ${error.expected}`));
+		}
+
+		throw(error);
+	}
+}
+
+/**
+ * Check if a signer is listed in the envelope.anchors.
+ */
+function signerListed(envelope: AnchorExternalEnvelope, signer: Account): boolean {
+	const signerKey = signer.publicKeyString.get();
+	return(signerKey in envelope.anchors);
+}
+
+/**
+ * Validate the shape of a {@link AnchorExternalBinding}.
+ *
+ * @returns `undefined` if valid, or an error message.
+ */
+function validateBindingShape(binding: AnchorExternalBinding): string | undefined {
+	if (typeof binding.previousBlockHash !== 'string' || binding.previousBlockHash.length === 0) {
+		return('binding.previousBlockHash must be a non-empty string');
+	}
+	if (!Number.isInteger(binding.operationIndex) || binding.operationIndex < 0) {
+		return(`binding.operationIndex must be a non-negative integer, got ${binding.operationIndex}`);
+	}
+
+	return(undefined);
+}
+
+/**
+ * Decode the base64-encoded string.
+ */
+function decodeExternal(external: string): Buffer {
+	const decoded = decodeBase64Strict(external);
+	if (decoded === undefined) {
+		throw(new AnchorExternalError('BAD_BASE64', 'External string is not valid base64 or decoded to zero bytes'));
+	}
+
+	return(decoded);
+}
+
+// #endregion
+
+// #region AnchorExternalBuilder
+
+/**
+ * Fluent builder for constructing an anchor-external envelope and producing
+ * its encoded SEND.external string.
+ */
+export class AnchorExternalBuilder {
+	readonly #anchors: { [anchorPublicKey: string]: AnchorExternalEntry } = {};
+	#signer: Account | undefined;
+	#principals: Account[] | undefined;
+	#maxLength: number | undefined;
+	#binding: AnchorExternalBinding | undefined;
+
+	/**
+	 * Set the entry for a given anchor, replacing any prior entry
+	 * for the same anchor.
+	 */
+	setAnchor(anchor: Account, entry: AnchorExternalEntry): this {
+		this.#anchors[anchor.publicKeyString.get()] = entry;
+		return(this);
+	}
+
+	/**
+	 * Sign the produced envelope with the given account.
+	 */
+	withSigner(signer: Account): this {
+		this.#signer = signer;
+		return(this);
+	}
+
+	/**
+	 * Encrypt the produced envelope so each listed principal can decrypt
+	 * it. Omit to leave the envelope as plaintext.
+	 */
+	withPrincipals(principals: Account[]): this {
+		this.#principals = principals;
+		return(this);
+	}
+
+	/**
+	 * Bind the produced signature to a position on the signer's
+	 * account chain. Required whenever {@link withSigner} is used.
+	 *
+	 * @param previousBlockHash Block hash of the signer's current head.
+	 * @param operationIndex    Index of the SEND operation within its block.
+	 */
+	withBinding(previousBlockHash: string, operationIndex: number): this {
+		const candidate: AnchorExternalBinding = { previousBlockHash, operationIndex };
+		const error = validateBindingShape(candidate);
+		if (error !== undefined) {
+			throw(new KeetaAnchorError(`withBinding: ${error}`));
+		}
+
+		this.#binding = candidate;
+		return(this);
+	}
+
+	/**
+	 * Set an upper bound on the encoded output length. {@link build}
+	 * throws if the produced string would exceed this length.
+	 */
+	withMaxLength(maxLength: number): this {
+		if (!Number.isInteger(maxLength) || maxLength <= 0) {
+			throw(new KeetaAnchorError(`withMaxLength requires a positive integer, got ${maxLength}`));
+		}
+
+		this.#maxLength = maxLength;
+		return(this);
+	}
+
+	/**
+	 * Snapshot of the envelope as it would be encoded right now.
+	 */
+	toEnvelope(): AnchorExternalEnvelope {
+		const result: AnchorExternalEnvelope = {
+			version: ANCHOR_EXTERNAL_VERSION,
+			anchors: { ...this.#anchors }
+		};
+
+		if (this.#binding !== undefined) {
+			result.binding = { ...this.#binding };
+		}
+
+		return(result);
+	}
+
+	/**
+	 * Produce the encoded SEND.external string.
+	 *
+	 * @throws {@link KeetaAnchorError} on caller misuse.
+	 */
+	async build(): Promise<string> {
+		const envelope = this.toEnvelope();
+
+		if (this.#signer !== undefined && !signerListed(envelope, this.#signer)) {
+			throw(new KeetaAnchorError('Signer is not listed in envelope.anchors'));
+		}
+		if (this.#signer !== undefined && this.#binding === undefined) {
+			throw(new KeetaAnchorError('Signed envelopes require withBinding(previousBlockHash, operationIndex) for replay protection'));
+		}
+		if (this.#signer === undefined && this.#binding !== undefined) {
+			throw(new KeetaAnchorError('withBinding is only valid for signed envelopes'));
+		}
+
+		const encoded = envelopeToEncoded(envelope);
+		const canonical = canonicalizeJson(encoded);
+		const plaintext = Buffer.from(canonical, 'utf-8');
+
+		const principals = this.#principals ?? null;
+		let containerOptions: { signer: Account } | undefined;
+		if (this.#signer !== undefined) {
+			containerOptions = { signer: this.#signer };
+		}
+
+		const container = EncryptedContainer.fromPlaintext(plaintext, principals, containerOptions);
+		const containerBuffer = arrayBufferToBuffer(await container.getEncodedBuffer());
+		const external = containerBuffer.toString('base64');
+
+		if (this.#maxLength !== undefined && external.length > this.#maxLength) {
+			throw(new KeetaAnchorError(`Encoded external length ${external.length} exceeds caller maxLength ${this.#maxLength}`));
+		}
+
+		return(external);
+	}
+}
+
+// #endregion
+
+// #region AnchorExternal
+
+/**
+ * Immutable, verified view of a parsed SEND.external envelope.
+ */
+export class AnchorExternal {
+	static readonly Builder: typeof AnchorExternalBuilder = AnchorExternalBuilder;
+
+	readonly #envelope: AnchorExternalEnvelope;
+	readonly #encrypted: boolean;
+	readonly #signed: AnchorExternalSigned | undefined;
+
+	private constructor(envelope: AnchorExternalEnvelope, encrypted: boolean, signed: AnchorExternalSigned | undefined) {
+		this.#envelope = envelope;
+		this.#encrypted = encrypted;
+		this.#signed = signed;
+	}
+
+	/**
+	 * Decoded envelope.
+	 */
+	get envelope(): AnchorExternalEnvelope {
+		return(this.#envelope);
+	}
+
+	/**
+	 * `true` if the source blob was encrypted.
+	 */
+	get encrypted(): boolean {
+		return(this.#encrypted);
+	}
+
+	/**
+	 * Authenticity record for a verified signed envelope, or `undefined`
+	 * if the envelope was not signed.
+	 */
+	get signed(): AnchorExternalSigned | undefined {
+		return(this.#signed);
+	}
+
+	/**
+	 * Decode an external string asserted to be plaintext.
+	 *
+	 * @throws {@link AnchorExternalError} `EXPECTED_PLAIN` if the source blob is encrypted.
+	 */
+	static async fromPlainExternal(external: string): Promise<AnchorExternal> {
+		const buffer = decodeExternal(external);
+
+		let container: EncryptedContainer;
+		try {
+			container = EncryptedContainer.fromEncodedBuffer(buffer, null);
+		} catch (error) {
+			if (EncryptedContainerError.isInstance(error)) {
+				if (error.code === 'INVALID_PRINCIPALS') {
+					throw(new AnchorExternalError('EXPECTED_PLAIN', 'Blob is encrypted but plaintext was expected'));
+				}
+				throw(new AnchorExternalError('NOT_AN_ENVELOPE', `Container parse failed: ${error.code}`));
+			}
+			throw(error);
+		}
+
+		if (container.encrypted) {
+			throw(new AnchorExternalError('EXPECTED_PLAIN', 'Blob is encrypted but plaintext was expected'));
+		}
+
+		const result = await AnchorExternal.fromContainer(container, false);
+		return(result);
+	}
+
+	/**
+	 * Decode an external string asserted to be encrypted under one of the
+	 * supplied principals.
+	 *
+	 * @throws {@link AnchorExternalError} `EXPECTED_ENCRYPTED` if the source blob is plaintext.
+	 * @throws {@link KeetaAnchorError} if `principals` is empty.
+	 */
+	static async fromEncryptedExternal(external: string, principals: Account[]): Promise<AnchorExternal> {
+		if (principals.length === 0) {
+			throw(new KeetaAnchorError('AnchorExternal.fromEncryptedExternal requires at least one principal'));
+		}
+
+		const buffer = decodeExternal(external);
+		let container: EncryptedContainer;
+		try {
+			container = EncryptedContainer.fromEncryptedBuffer(buffer, principals);
+		} catch (error) {
+			if (EncryptedContainerError.isInstance(error)) {
+				if (error.code === 'ENCRYPTION_REQUIRED') {
+					throw(new AnchorExternalError('EXPECTED_ENCRYPTED', 'Blob is plaintext but encrypted was expected'));
+				}
+
+				throw(new AnchorExternalError('NOT_AN_ENVELOPE', `Container parse failed: ${error.code}`));
+			}
+
+			throw(error);
+		}
+
+		if (!container.encrypted) {
+			throw(new AnchorExternalError('EXPECTED_ENCRYPTED', 'Blob is plaintext but encrypted was expected'));
+		}
+
+		const result = await AnchorExternal.fromContainer(container, true);
+		return(result);
+	}
+
+	/**
+	 * Inspect encrypted/signed flags of a candidate external string
+	 * without reading plaintext or requiring a decryption key.
+	 */
+	static async peek(external: string): Promise<AnchorExternalPeekResult> {
+		const buffer = decodeExternal(external);
+		let container: EncryptedContainer;
+		try {
+			container = EncryptedContainer.fromEncodedBuffer(buffer, []);
+		} catch (error) {
+			if (EncryptedContainerError.isInstance(error)) {
+				throw(new AnchorExternalError('NOT_AN_ENVELOPE', `Container parse failed: ${error.code}`));
+			}
+
+			throw(error);
+		}
+
+		return({
+			encrypted: container.encrypted,
+			signed: container.isSigned
+		});
+	}
+
+	/**
+	 * Create an {@link AnchorExternal} from a container.
+	 */
+	private static async fromContainer(container: EncryptedContainer, encrypted: boolean): Promise<AnchorExternal> {
+		const envelope = await AnchorExternal.readEnvelope(container);
+		const signed = await AnchorExternal.readSigned(container, envelope);
+		const result = new AnchorExternal(envelope, encrypted, signed);
+		return(result);
+	}
+
+	/**
+	 * Read the envelope from a container.
+	 */
+	private static async readEnvelope(container: EncryptedContainer): Promise<AnchorExternalEnvelope> {
+		let plaintextArrayBuffer: ArrayBuffer;
+		try {
+			plaintextArrayBuffer = await container.getPlaintext();
+		} catch (error) {
+			if (EncryptedContainerError.isInstance(error)) {
+				throw(new AnchorExternalError('NOT_AN_ENVELOPE', `Container plaintext unavailable: ${error.code}`));
+			}
+			throw(error);
+		}
+
+		if (plaintextArrayBuffer.byteLength > MAX_PLAINTEXT_BYTES) {
+			throw(new AnchorExternalError('PLAINTEXT_TOO_LARGE', `Container plaintext exceeds ${MAX_PLAINTEXT_BYTES} bytes`));
+		}
+
+		const plaintextBuffer = arrayBufferToBuffer(plaintextArrayBuffer);
+		const plaintextString = plaintextBuffer.toString('utf-8');
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(plaintextString);
+		} catch {
+			throw(new AnchorExternalError('NOT_AN_ENVELOPE', 'Container plaintext is not valid JSON'));
+		}
+
+		const encoded = parseEncodedEnvelope(parsed);
+
+		/*
+		 * Reject non-canonical encodings: an attacker could otherwise
+		 * mutate the JSON shape under a still-valid signature on the
+		 * original bytes.
+		 */
+		const reCanonical = canonicalizeJson(encoded);
+		if (reCanonical !== plaintextString) {
+			throw(new AnchorExternalError('NON_CANONICAL', 'Container plaintext is not JCS-canonical'));
+		}
+
+		const result = envelopeFromEncoded(encoded);
+		return(result);
+	}
+
+	/**
+	 * Read the signed record from a container.
+	 */
+	private static async readSigned(container: EncryptedContainer, envelope: AnchorExternalEnvelope): Promise<AnchorExternalSigned | undefined> {
+		if (!container.isSigned) {
+			if (envelope.binding !== undefined) {
+				throw(new AnchorExternalError('UNEXPECTED_BINDING', 'Unsigned envelope carries a binding'));
+			}
+
+			return(undefined);
+		}
+
+		if (envelope.binding === undefined) {
+			throw(new AnchorExternalError('MISSING_BINDING', 'Signed envelope is missing required binding'));
+		}
+
+		let valid: boolean;
+		try {
+			valid = await container.verifySignature();
+		} catch (error) {
+			if (EncryptedContainerError.isInstance(error)) {
+				throw(new AnchorExternalError('BAD_SIGNATURE', `Signature verification failed: ${error.code}`));
+			}
+
+			throw(error);
+		}
+
+		if (!valid) {
+			throw(new AnchorExternalError('BAD_SIGNATURE', 'Signature did not verify against the contained plaintext'));
+		}
+
+		const signer = container.getSigningAccount();
+		if (signer === undefined) {
+			throw(new AnchorExternalError('BAD_SIGNATURE', 'Container is signed but the signing account is unavailable'));
+		}
+
+		if (!signerListed(envelope, signer)) {
+			throw(new AnchorExternalError('SIGNER_NOT_LISTED', 'Signing account is not listed in envelope.anchors'));
+		}
+
+		return({ signer });
+	}
+}
+
+// #endregion

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,9 +1,11 @@
+import { AnchorExternal } from './anchor-external.js';
 import * as Certificates from './certificates.js';
 import { EncryptedContainer } from './encrypted-container.js';
 import * as URI from './uri.js';
 
 import Resolver from './resolver.js';
 export {
+	AnchorExternal,
 	Certificates,
 	EncryptedContainer,
 	Resolver,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,11 +1,10 @@
-import { AnchorExternal } from './anchor-external.js';
 import * as Certificates from './certificates.js';
 import { EncryptedContainer } from './encrypted-container.js';
 import * as URI from './uri.js';
 
 import Resolver from './resolver.js';
+export { AnchorExternal } from './anchor-external.js';
 export {
-	AnchorExternal,
 	Certificates,
 	EncryptedContainer,
 	Resolver,

--- a/src/lib/utils/buffer.ts
+++ b/src/lib/utils/buffer.ts
@@ -39,3 +39,24 @@ export function arrayBufferLikeToBuffer(buffer: ArrayBufferLike | ArrayBufferVie
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 	return(toBuffer(buffer as ArrayBuffer));
 }
+
+/**
+ * Regular expression to match base64 input.
+ */
+const BASE64_INPUT_REGEX = /^[-_A-Za-z0-9+/=\s]*$/;
+
+/**
+ * Decode a base64 string into a {@link Buffer}.
+ */
+export function decodeBase64Strict(input: string): Buffer | undefined {
+	if (!BASE64_INPUT_REGEX.test(input)) {
+		return(undefined);
+	}
+
+	const decoded = Buffer.from(input, 'base64');
+	if (decoded.length === 0) {
+		return(undefined);
+	}
+
+	return(decoded);
+}

--- a/src/lib/utils/signing.ts
+++ b/src/lib/utils/signing.ts
@@ -38,7 +38,7 @@ const LONE_SURROGATE_PATTERN = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\
  * Serialize a JSON-shaped value following JCS
  * ({@link https://www.rfc-editor.org/rfc/rfc8785 RFC 8785}).
  */
-function canonicalizeJson(value: unknown): string {
+export function canonicalizeJson(value: unknown): string {
 	/**
 	 * Literal serialization (Section 3.2.2.1).
 	 */


### PR DESCRIPTION
# Summary

- Adds `AnchorExternal` codec for the SEND external field, supporting optional signing with replay-protection binding, and optional encrypted-container payloads.