### PR TITLE
Feature / Add legal disclaimers to anchor chaining

### DIFF
--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -12,6 +12,7 @@ import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, Anchor
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
 import { BlockListener } from './block-listener.js';
+import type { AnchorMetadataLegalField } from './metadata.types.js';
 
 const DEBUG = false;
 const logger = DEBUG ? console : undefined;
@@ -642,10 +643,44 @@ async function createChainingTestHarness() {
 	const fxLPOne  = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
 	const fxLPTwo  = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
 
+	const [usBankProviderID, euBankProviderID] = ['BankUS', 'BankEU'] as const;
+	const bankProviderDisclaimers: {
+		[bankProviderID in typeof usBankProviderID | typeof euBankProviderID]: Exclude<AnchorMetadataLegalField['disclaimers'], undefined>
+	} = {
+		[usBankProviderID]: [
+			{
+				purpose: 'general',
+				content: {
+					type: 'plaintext',
+					content: 'This is a legal disclaimer for the US bank server'
+				}
+			}
+		],
+		[euBankProviderID]: [
+			{
+				purpose: 'general',
+				content: {
+					type: 'plaintext',
+					content: 'This is a legal disclaimer for the EU bank server'
+				}
+			},
+			{
+				purpose: 'general',
+				content: {
+					type: 'markdown',
+					content: 'This is another legal disclaimer for the EU bank server'
+				}
+			}
+		]
+	};
+
 	const bankServerUS = new TestBankServer({
 		...(DEBUG ? { logger } : {}),
 		client,
 		assetMovement: {
+			legal: {
+				disclaimers: bankProviderDisclaimers['BankUS']
+			},
 			supportedAssets: [{
 				asset: [ tokens.USDC.publicKeyString.get(), 'USD' ],
 				paths: [{ pair: [
@@ -660,6 +695,9 @@ async function createChainingTestHarness() {
 		...(DEBUG ? { logger } : {}),
 		client,
 		assetMovement: {
+			legal: {
+				disclaimers: bankProviderDisclaimers['BankEU']
+			},
 			supportedAssets: [{
 				asset: [ tokens.EURC.publicKeyString.get(), 'EUR' ],
 				paths: [{ pair: [
@@ -717,8 +755,8 @@ async function createChainingTestHarness() {
 					FXTwo: await fxServerTwo.serviceMetadata()
 				},
 				assetMovement: {
-					BankUS: await bankServerUS.serviceMetadata(),
-					BankEU: await bankServerEU.serviceMetadata()
+					[usBankProviderID]: await bankServerUS.serviceMetadata(),
+					[euBankProviderID]: await bankServerEU.serviceMetadata()
 				}
 			}
 		} satisfies ServiceMetadataExternalizable)
@@ -766,6 +804,9 @@ async function createChainingTestHarness() {
 		fxServerOne,
 		fxServerTwo,
 		anchorChaining,
+		bankProviderDisclaimers,
+		euBankProviderID,
+		usBankProviderID,
 		giveTokens,
 		getPlanVia,
 		getPathVia,
@@ -2122,5 +2163,75 @@ describe('AnchorChainingAssetInfo metadata', function() {
 		);
 
 		expect(providers).toBeNull();
+	});
+});
+
+describe('AnchorChainingPlan disclaimers', function() {
+	test('anchorChaining paths should return the correct legal disclaimers', async function() {
+		await using h = await createChainingTestHarness();
+
+		// EU Bank Paths
+
+		const euBankPaths = await h.anchorChaining.getPaths({
+			source: { asset: h.tokens.USDC, location: h.keetaLocation, rail: 'KEETA_SEND', value: 100n },
+			destination: { asset: 'EUR', location: 'bank-account:iban-swift', recipient: h.client.account.publicKeyString.get(), rail: 'SEPA_PUSH' }
+		});
+
+		if (!euBankPaths || euBankPaths.length === 0) {
+			throw(new Error('Expected at least one valid path'));
+		}
+
+		const euBankDisclaimers = await h.anchorChaining.graph.getProviderDisclaimers(h.euBankProviderID);
+		expect(euBankDisclaimers).toEqual({
+			providerID: h.euBankProviderID,
+			disclaimers: h.bankProviderDisclaimers[h.euBankProviderID]
+		});
+
+		for (const euBankPath of (euBankPaths ?? [])) {
+			const disclaimers = await euBankPath.getDisclaimers();
+			expect(disclaimers.length).toEqual(1);
+			expect(disclaimers).toEqual([euBankDisclaimers]);
+		}
+
+		// US Bank Paths
+
+		const usBankPaths = await h.anchorChaining.getPaths({
+			source: { asset: h.tokens.EURC, location: h.keetaLocation, rail: 'KEETA_SEND', value: 100n },
+			destination: { asset: 'USD', location: 'bank-account:us', recipient: h.client.account.publicKeyString.get(), rail: 'ACH' }
+		});
+
+		if (!usBankPaths || usBankPaths.length === 0) {
+			throw(new Error('Expected at least one valid path'));
+		}
+
+		const usBankDisclaimers = await h.anchorChaining.graph.getProviderDisclaimers(h.usBankProviderID);
+		expect(usBankDisclaimers).toEqual({
+			providerID: h.usBankProviderID,
+			disclaimers: h.bankProviderDisclaimers[h.usBankProviderID]
+		});
+
+		for (const usBankPath of (usBankPaths ?? [])) {
+			const disclaimers = await usBankPath.getDisclaimers();
+			expect(disclaimers.length).toEqual(1);
+			expect(disclaimers).toEqual([usBankDisclaimers]);
+		}
+
+		// Keeta Paths excluding asset movement steps
+
+		const networkPaths = (await h.anchorChaining.getPaths({
+			source: { asset: h.tokens.EURC, location: h.keetaLocation, rail: 'KEETA_SEND', value: 100n },
+			destination: { asset: h.tokens.USDC, location: h.keetaLocation, recipient: h.client.account.publicKeyString.get(), rail: 'KEETA_SEND' }
+		}))?.filter(function(networkPath) {
+			return(networkPath.path.every(step => step.type !== 'assetMovement'));
+		});
+
+		if (!networkPaths || networkPaths.length === 0) {
+			throw(new Error('Expected at least one valid path'));
+		}
+
+		for (const networkPath of (networkPaths ?? [])) {
+			const disclaimers = await networkPath.getDisclaimers();
+			expect(disclaimers.length).toEqual(0);
+		}
 	});
 });

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -2188,7 +2188,7 @@ describe('AnchorChainingPlan disclaimers', function() {
 		});
 
 		for (const euBankPath of (euBankPaths ?? [])) {
-			const disclaimers = await euBankPath.getDisclaimers();
+			const disclaimers = await euBankPath.getProviderLegalDisclaimers();
 			expect(disclaimers.length).toEqual(1);
 			expect(disclaimers).toEqual([euBankDisclaimers]);
 		}
@@ -2211,7 +2211,7 @@ describe('AnchorChainingPlan disclaimers', function() {
 		});
 
 		for (const usBankPath of (usBankPaths ?? [])) {
-			const disclaimers = await usBankPath.getDisclaimers();
+			const disclaimers = await usBankPath.getProviderLegalDisclaimers();
 			expect(disclaimers.length).toEqual(1);
 			expect(disclaimers).toEqual([usBankDisclaimers]);
 		}
@@ -2230,7 +2230,7 @@ describe('AnchorChainingPlan disclaimers', function() {
 		}
 
 		for (const networkPath of (networkPaths ?? [])) {
-			const disclaimers = await networkPath.getDisclaimers();
+			const disclaimers = await networkPath.getProviderLegalDisclaimers();
 			expect(disclaimers.length).toEqual(0);
 		}
 	});

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -8,7 +8,7 @@ import type { ConversionInputCanonicalJSON } from '../services/fx/common.js';
 import { Resolver } from './index.js';
 import type { ServiceMetadataExternalizable } from './resolver.js';
 import { AnchorChaining, AnchorChainingPlan } from './chaining.js';
-import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, ComputePlanOptions } from './chaining.js';
+import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, ComputePlanOptions, Disclaimer } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
 import { BlockListener } from './block-listener.js';
@@ -255,7 +255,7 @@ class TestBankServer extends KeetaNetAssetMovementAnchorHTTPServer {
 }
 
 type TestFXServerConfig = Omit<KeetaAnchorFXServerConfig, 'fx'> & {
-	fx: Pick<KeetaAnchorFXServerConfig['fx'], 'from'>;
+	fx: Pick<KeetaAnchorFXServerConfig['fx'], 'from' | 'legal'>;
 	giveTokens: (to: GenericAccount, amount: bigint, token: TokenAddress) => Promise<void>;
 	/** Must be a UserClient so we can read LP balances and mint tokens on demand. */
 	client: KeetaNet.UserClient;
@@ -708,6 +708,27 @@ async function createChainingTestHarness() {
 		}
 	});
 
+	const [fxOneProviderID, fxTwoProviderID] = ['FXOne', 'FXTwo'] as const;
+	const fxProviderDisclaimers: {
+		[fxProviderID in typeof fxOneProviderID | typeof fxTwoProviderID]: Exclude<AnchorMetadataLegalField['disclaimers'], undefined>
+	} = {
+		[fxOneProviderID]: [
+			{
+				purpose: 'general',
+				content: { type: 'plaintext', content: 'This is a legal disclaimer for FX provider One' }
+			}
+		],
+		[fxTwoProviderID]: [
+			{
+				purpose: 'general',
+				content: { type: 'plaintext', content: 'This is a legal disclaimer for FX provider Two' }
+			},
+			{
+				purpose: 'general',
+				content: { type: 'markdown', content: 'This is another legal disclaimer for FX provider Two' }
+			}
+		]
+	};
 	// fxServerOne: 0.88 rate (primary)
 	const fxServerOne = new TestFXServer({
 		...(DEBUG ? { logger } : {}),
@@ -717,6 +738,7 @@ async function createChainingTestHarness() {
 		client,
 		giveTokens,
 		fx: {
+			legal: { disclaimers: fxProviderDisclaimers[fxOneProviderID] },
 			from: [{ currencyCodes: [ tokens.USDC.publicKeyString.get(), tokens.EURC.publicKeyString.get() ], to: [ tokens.USDC.publicKeyString.get(), tokens.EURC.publicKeyString.get() ] }]
 		}
 	});
@@ -730,6 +752,7 @@ async function createChainingTestHarness() {
 		client,
 		giveTokens,
 		fx: {
+			legal: { disclaimers: fxProviderDisclaimers[fxTwoProviderID] },
 			from: [{ currencyCodes: [ tokens.USDC.publicKeyString.get(), tokens.EURC.publicKeyString.get() ], to: [ tokens.USDC.publicKeyString.get(), tokens.EURC.publicKeyString.get() ] }]
 		}
 	}).setRate(0.85);
@@ -807,6 +830,9 @@ async function createChainingTestHarness() {
 		bankProviderDisclaimers,
 		euBankProviderID,
 		usBankProviderID,
+		fxProviderDisclaimers,
+		fxOneProviderID,
+		fxTwoProviderID,
 		giveTokens,
 		getPlanVia,
 		getPathVia,
@@ -2181,13 +2207,23 @@ describe('AnchorChainingPlan disclaimers', function() {
 			throw(new Error('Expected at least one valid path'));
 		}
 
-		for (const euBankPath of (euBankPaths ?? [])) {
+		for (const euBankPath of euBankPaths) {
+			const expectedProviderDisclaimers = euBankPath.path.map((step) => {
+				if (!step.providerID) {
+					throw(new Error('Expected step to have a provider ID'));
+				}
+
+				const expectedDisclaimersMap: { [key: string]: Disclaimer[] } = step.type === 'assetMovement' ? h.bankProviderDisclaimers : h.fxProviderDisclaimers;
+
+				return({
+					providerID: step.providerID,
+					disclaimers: expectedDisclaimersMap[step.providerID]
+				})
+			})
+
 			const disclaimers = await euBankPath.getProviderLegalDisclaimers();
-			expect(disclaimers.length).toEqual(1);
-			expect(disclaimers).toEqual([{
-				providerID: h.euBankProviderID,
-				disclaimers: h.bankProviderDisclaimers[h.euBankProviderID]
-			}]);
+			expect(disclaimers?.length).toEqual(euBankPath.path.length);
+			expect(disclaimers).toEqual(expectedProviderDisclaimers);
 		}
 
 		// US Bank Paths
@@ -2201,31 +2237,48 @@ describe('AnchorChainingPlan disclaimers', function() {
 			throw(new Error('Expected at least one valid path'));
 		}
 
-		for (const usBankPath of (usBankPaths ?? [])) {
+		for (const usBankPath of usBankPaths) {
+			const expectedProviderDisclaimers = usBankPath.path.map((step) => {
+				if (!step.providerID) {
+					throw(new Error('Expected step to have a provider ID'));
+				}
+				const expectedDisclaimersMap: { [key: string]: Disclaimer[] } = step.type === 'assetMovement' ? h.bankProviderDisclaimers : h.fxProviderDisclaimers;
+				return({
+					providerID: step.providerID,
+					disclaimers: expectedDisclaimersMap[step.providerID]
+				})
+			})
+
 			const disclaimers = await usBankPath.getProviderLegalDisclaimers();
-			expect(disclaimers.length).toEqual(1);
-			expect(disclaimers).toEqual([{
-				providerID: h.usBankProviderID,
-				disclaimers: h.bankProviderDisclaimers[h.usBankProviderID]
-			}]);
+			expect(disclaimers?.length).toEqual(usBankPath.path.length);
+			expect(disclaimers).toEqual(expectedProviderDisclaimers);
 		}
 
-		// Keeta Paths excluding asset movement steps
+		// Keeta Paths
 
-		const networkPaths = (await h.anchorChaining.getPaths({
+		const networkPaths = await h.anchorChaining.getPaths({
 			source: { asset: h.tokens.EURC, location: h.keetaLocation, rail: 'KEETA_SEND', value: 100n },
 			destination: { asset: h.tokens.USDC, location: h.keetaLocation, recipient: h.client.account.publicKeyString.get(), rail: 'KEETA_SEND' }
-		}))?.filter(function(networkPath) {
-			return(networkPath.path.every(step => step.type !== 'assetMovement'));
 		});
 
 		if (!networkPaths || networkPaths.length === 0) {
 			throw(new Error('Expected at least one valid path'));
 		}
 
-		for (const networkPath of (networkPaths ?? [])) {
+		for (const networkPath of networkPaths) {
+			const expectedProviderDisclaimers = networkPath.path.slice(0, 2).map((step) => {
+				if (!step.providerID) {
+					throw(new Error('Expected step to have a provider ID'));
+				}
+				const expectedDisclaimersMap: { [key: string]: Disclaimer[] } = step.type === 'assetMovement' ? h.bankProviderDisclaimers : h.fxProviderDisclaimers;
+				return({
+					providerID: step.providerID,
+					disclaimers: expectedDisclaimersMap[step.providerID]
+				})
+			})
 			const disclaimers = await networkPath.getProviderLegalDisclaimers();
-			expect(disclaimers.length).toEqual(0);
+			expect(disclaimers?.length).toEqual(expectedProviderDisclaimers.length);
+			expect(disclaimers).toEqual(expectedProviderDisclaimers);
 		}
 	});
 });

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -2181,16 +2181,13 @@ describe('AnchorChainingPlan disclaimers', function() {
 			throw(new Error('Expected at least one valid path'));
 		}
 
-		const euBankDisclaimers = await h.anchorChaining.graph.getProviderDisclaimers(h.euBankProviderID);
-		expect(euBankDisclaimers).toEqual({
-			providerID: h.euBankProviderID,
-			disclaimers: h.bankProviderDisclaimers[h.euBankProviderID]
-		});
-
 		for (const euBankPath of (euBankPaths ?? [])) {
 			const disclaimers = await euBankPath.getProviderLegalDisclaimers();
 			expect(disclaimers.length).toEqual(1);
-			expect(disclaimers).toEqual([euBankDisclaimers]);
+			expect(disclaimers).toEqual([{
+				providerID: h.euBankProviderID,
+				disclaimers: h.bankProviderDisclaimers[h.euBankProviderID]
+			}]);
 		}
 
 		// US Bank Paths
@@ -2204,16 +2201,13 @@ describe('AnchorChainingPlan disclaimers', function() {
 			throw(new Error('Expected at least one valid path'));
 		}
 
-		const usBankDisclaimers = await h.anchorChaining.graph.getProviderDisclaimers(h.usBankProviderID);
-		expect(usBankDisclaimers).toEqual({
-			providerID: h.usBankProviderID,
-			disclaimers: h.bankProviderDisclaimers[h.usBankProviderID]
-		});
-
 		for (const usBankPath of (usBankPaths ?? [])) {
 			const disclaimers = await usBankPath.getProviderLegalDisclaimers();
 			expect(disclaimers.length).toEqual(1);
-			expect(disclaimers).toEqual([usBankDisclaimers]);
+			expect(disclaimers).toEqual([{
+				providerID: h.usBankProviderID,
+				disclaimers: h.bankProviderDisclaimers[h.usBankProviderID]
+			}]);
 		}
 
 		// Keeta Paths excluding asset movement steps

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1093,7 +1093,7 @@ export class AnchorChainingPath {
 		return({ signer, account });
 	}
 
-	async getDisclaimers(): Promise<PlanDisclaimers> {
+	async getProviderLegalDisclaimers(): Promise<PlanDisclaimers> {
 		const assetMovementProviderIds = new Set(
 			this.path.filter(function(step) {
 				return(step.type === 'assetMovement');

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -49,7 +49,7 @@ interface ChainStepResolutionKeetaSend extends ChainStepResolutionBase<'keetaSen
 	usingInstruction: Extract<AssetTransferInstructions, { type: 'KEETA_SEND' }>;
 };
 
-type Disclaimer = Exclude<AnchorMetadataLegalField['disclaimers'], undefined>[number];
+export type Disclaimer = Exclude<AnchorMetadataLegalField['disclaimers'], undefined>[number];
 type ProviderDisclaimers = {
 	providerID: string;
 	disclaimers: Disclaimer[];
@@ -317,6 +317,7 @@ class AnchorGraph {
 	logger?: Logger | undefined;
 
 	readonly assetMovementClient: KeetaAssetMovementAnchorClient;
+	readonly fxClient: KeetaFXAnchorClient;
 	readonly #assetMovementProviderCache = new Map<string, AssetMovementProvider | null>();
 	readonly #assetNameCache = new Map<MovableAssetSearchCanonical, ISOCurrencyCode | TokenAddress | ExternalChainAsset>();
 	#graphNodePromise: Promise<GraphNodeLike[]> | null = null;
@@ -329,13 +330,17 @@ class AnchorGraph {
 			resolver: this.resolver,
 			...(this.logger ? { logger: this.logger } : {})
 		});
+		this.fxClient = new KeetaFXAnchorClient(this.client, {
+			resolver: this.resolver,
+			...(this.logger ? { logger: this.logger } : {})
+		});
 	}
 
 	#assetLocationKey = (side: { asset: AnchorChainingAsset; location: AssetLocationLike }) => {
 		return(`${convertAssetSearchInputToCanonical(side.asset)}@${convertAssetLocationToString(side.location)}`);
 	};
 
-	async #getAssetMovementProviderById(providerID: string): Promise<AssetMovementProvider | null> {
+	async getAssetMovementProviderById(providerID: string): Promise<AssetMovementProvider | null> {
 		let provider: KeetaAssetMovementAnchorProvider | undefined | null = this.#assetMovementProviderCache.get(providerID);
 		if (provider === undefined) {
 			provider = await this.assetMovementClient.getProviderByID(providerID);
@@ -364,7 +369,7 @@ class AnchorGraph {
 				}
 
 				if (!retval[node.providerID]) {
-					const provider = await this.#getAssetMovementProviderById(node.providerID);
+					const provider = await this.getAssetMovementProviderById(node.providerID);
 					if (!provider) {
 						this.logger?.debug('AnchorGraph::getAssetMovementProvidersForAsset', `No provider found for providerID ${node.providerID}, although provider was previously known to exist in the graph nodes`);
 						continue;
@@ -1047,10 +1052,6 @@ export class AnchorChainingPath {
 		return(this.parent['logger']);
 	}
 
-	get assetMovementClient(): KeetaAssetMovementAnchorClient{
-		return(this.parent.graph.assetMovementClient)
-	}
-
 	protected async getAccountLike(action: GetAccountForActionPayload, override?: AccountLike): Promise<InstanceType<typeof KeetaNetLib.Account>> {
 		let found: InstanceType<typeof KeetaNetLib.Account> | undefined = undefined;
 
@@ -1084,33 +1085,51 @@ export class AnchorChainingPath {
 		return({ signer, account });
 	}
 
-	async getProviderLegalDisclaimers(): Promise<PlanDisclaimers> {
-		const assetMovementProviderIds = new Set<string>();
+	async getProviderLegalDisclaimers(): Promise<PlanDisclaimers | null> {
+		const legalDisclaimerPromises: { key: string; promise: () => Promise<ProviderDisclaimers | null> }[] = [];
+
 		for (const step of this.path) {
-			if (step.type === 'assetMovement') {
-				assetMovementProviderIds.add(step.providerID);
+			if (step.type === 'keetaSend') {
+				continue
 			}
+
+			const key = `${step.type}:${step.providerID}`;
+			if (legalDisclaimerPromises.find(entry => entry.key === key)) {
+				continue
+			}
+
+			const promise = async () => {
+				try {
+					let disclaimers: ProviderDisclaimers['disclaimers'] | null | undefined = null;
+					if (step.type === 'assetMovement') {
+						const provider = await this.parent.graph.getAssetMovementProviderById(step.providerID);
+						disclaimers = provider?.getLegalDisclaimers();
+					} else {
+						disclaimers = await this.parent.graph.fxClient.getLegalDisclaimersById(step.providerID);
+					}
+
+					if (!disclaimers) {
+						return(null);
+					}
+
+					return({ providerID: step.providerID, disclaimers });
+				} catch (error) {
+					this.logger?.debug(`AnchorChainingPath::getProviderLegalDisclaimers`, `Error getting provider disclaimers for providerId: ${step.providerID}`, error);
+					throw(error)
+				}
+			}
+
+			legalDisclaimerPromises.push({ key, promise });
 		}
 
-		const disclaimers = (await Promise.allSettled([...assetMovementProviderIds].map(async (providerID) => {
-			try {
-				const disclaimers = await this.assetMovementClient.getProviderLegalDisclaimersByID(providerID);
-				if (disclaimers === null) {
-					throw(new Error('No disclaimers found for provider'));
-				}
-
-				return({ providerID, disclaimers })
-			} catch (error) {
-				this.logger?.debug(`AnchorChainingPath::getProviderLegalDisclaimers`, `Error getting provider disclaimers for providerId: ${providerID}`, error);
-				throw(error);
-			}
-		}))).filter(function(result) {
-			return(result.status === 'fulfilled')
-		}).map(function(fulfilledResult) {
-			return(fulfilledResult.value);
-		});
-
-		return(disclaimers);
+		try {
+			const disclaimersOrNull = await Promise.all(legalDisclaimerPromises.map((entry) => entry.promise()));
+			const disclaimers = disclaimersOrNull.filter((entry) => entry !== null);
+			return(disclaimers);
+		} catch (error) {
+			this.logger?.debug(`AnchorChainingPath::getProviderLegalDisclaimers`, 'Error getting legal disclaimers for path', error);
+			return(null);
+		}
 	}
 }
 

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -316,7 +316,7 @@ class AnchorGraph {
 	resolver: Resolver;
 	logger?: Logger | undefined;
 
-	readonly #assetMovementClient: KeetaAssetMovementAnchorClient;
+	readonly assetMovementClient: KeetaAssetMovementAnchorClient;
 	readonly #assetMovementProviderCache = new Map<string, AssetMovementProvider | null>();
 	readonly #assetNameCache = new Map<MovableAssetSearchCanonical, ISOCurrencyCode | TokenAddress | ExternalChainAsset>();
 	#graphNodePromise: Promise<GraphNodeLike[]> | null = null;
@@ -325,7 +325,7 @@ class AnchorGraph {
 		this.resolver = args.resolver;
 		this.client = args.client;
 		this.logger = args.logger;
-		this.#assetMovementClient = new KeetaAssetMovementAnchorClient(this.client, {
+		this.assetMovementClient = new KeetaAssetMovementAnchorClient(this.client, {
 			resolver: this.resolver,
 			...(this.logger ? { logger: this.logger } : {})
 		});
@@ -338,7 +338,7 @@ class AnchorGraph {
 	async #getAssetMovementProviderById(providerID: string): Promise<AssetMovementProvider | null> {
 		let provider: KeetaAssetMovementAnchorProvider | undefined | null = this.#assetMovementProviderCache.get(providerID);
 		if (provider === undefined) {
-			provider = await this.#assetMovementClient.getProviderByID(providerID);
+			provider = await this.assetMovementClient.getProviderByID(providerID);
 		}
 
 		this.#assetMovementProviderCache.set(providerID, provider);
@@ -376,23 +376,6 @@ class AnchorGraph {
 		}
 
 		return(retval);
-	}
-
-	async getProviderDisclaimers(providerID: string): Promise<ProviderDisclaimers | null> {
-		const provider = await this.#getAssetMovementProviderById(providerID);
-		if (!provider) {
-			return(null);
-		}
-		const disclaimers = provider.serviceInfo.legal?.disclaimers;
-
-		if (!disclaimers || disclaimers.length === 0) {
-			return(null);
-		}
-
-		return({
-			providerID,
-			disclaimers
-		});
 	}
 
 	async #computeFXNodes() {
@@ -1060,6 +1043,14 @@ export class AnchorChainingPath {
 		this.parent = input.parent;
 	}
 
+	get logger(): Logger | undefined {
+		return(this.parent['logger']);
+	}
+
+	get assetMovementClient(): KeetaAssetMovementAnchorClient{
+		return(this.parent.graph.assetMovementClient)
+	}
+
 	protected async getAccountLike(action: GetAccountForActionPayload, override?: AccountLike): Promise<InstanceType<typeof KeetaNetLib.Account>> {
 		let found: InstanceType<typeof KeetaNetLib.Account> | undefined = undefined;
 
@@ -1094,21 +1085,25 @@ export class AnchorChainingPath {
 	}
 
 	async getProviderLegalDisclaimers(): Promise<PlanDisclaimers> {
-		const assetMovementProviderIds = new Set(
-			this.path.filter(function(step) {
-				return(step.type === 'assetMovement');
-			}).map(function(stepWithProvider) {
-				return(stepWithProvider.providerID)
-			})
-		);
-
-		const disclaimers = (await Promise.allSettled([...assetMovementProviderIds].map(async (providerId) => {
-			const providerDisclaimers = await this.parent.graph.getProviderDisclaimers(providerId);
-			if (providerDisclaimers === null) {
-				throw(new Error("No provider disclaimer"));
+		const assetMovementProviderIds = new Set<string>();
+		for (const step of this.path) {
+			if (step.type === 'assetMovement') {
+				assetMovementProviderIds.add(step.providerID);
 			}
+		}
 
-			return(providerDisclaimers)
+		const disclaimers = (await Promise.allSettled([...assetMovementProviderIds].map(async (providerID) => {
+			try {
+				const disclaimers = await this.assetMovementClient.getProviderLegalDisclaimersByID(providerID);
+				if (disclaimers === null) {
+					throw(new Error('No disclaimers found for provider'));
+				}
+
+				return({ providerID, disclaimers })
+			} catch (error) {
+				this.logger?.debug(`AnchorChainingPath::getProviderLegalDisclaimers`, `Error getting provider disclaimers for providerId: ${providerID}`, error);
+				throw(error);
+			}
 		}))).filter(function(result) {
 			return(result.status === 'fulfilled')
 		}).map(function(fulfilledResult) {

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -18,6 +18,7 @@ import type { ExternalChainAsset } from './asset.js';
 import { isExternalChainAsset } from './asset.js';
 import type { Logger } from './log/index.js';
 import type { BlockHash } from '@keetanetwork/keetanet-client/lib/block/index.js';
+import type { AnchorMetadataLegalField } from './metadata.types.js';
 
 type FXQuoteOrEstimate = NonNullable<Awaited<ReturnType<KeetaFXAnchorClient['getQuotesOrEstimates']>>>[number];
 type AssetMovementProvider = NonNullable<Awaited<ReturnType<KeetaAssetMovementAnchorClient['getProvidersForTransfer']>>>[number];
@@ -47,6 +48,13 @@ interface ChainStepResolutionAssetMovement extends ChainStepResolutionBase<'asse
 interface ChainStepResolutionKeetaSend extends ChainStepResolutionBase<'keetaSend'> {
 	usingInstruction: Extract<AssetTransferInstructions, { type: 'KEETA_SEND' }>;
 };
+
+type Disclaimer = Exclude<AnchorMetadataLegalField['disclaimers'], undefined>[number];
+type ProviderDisclaimers = {
+	providerID: string;
+	disclaimers: Disclaimer[];
+}
+type PlanDisclaimers = ProviderDisclaimers[];
 
 export type ChainStepResolution = ChainStepResolutionFX | ChainStepResolutionAssetMovement | ChainStepResolutionKeetaSend;
 
@@ -368,6 +376,23 @@ class AnchorGraph {
 		}
 
 		return(retval);
+	}
+
+	async getProviderDisclaimers(providerID: string): Promise<ProviderDisclaimers | null> {
+		const provider = await this.#getAssetMovementProviderById(providerID);
+		if (!provider) {
+			return(null);
+		}
+		const disclaimers = provider.serviceInfo.legal?.disclaimers;
+
+		if (!disclaimers || disclaimers.length === 0) {
+			return(null);
+		}
+
+		return({
+			providerID,
+			disclaimers
+		});
 	}
 
 	async #computeFXNodes() {
@@ -1066,6 +1091,31 @@ export class AnchorChainingPath {
 		]);
 
 		return({ signer, account });
+	}
+
+	async getDisclaimers(): Promise<PlanDisclaimers> {
+		const assetMovementProviderIds = new Set(
+			this.path.filter(function(step) {
+				return(step.type === 'assetMovement');
+			}).map(function(stepWithProvider) {
+				return(stepWithProvider.providerID)
+			})
+		);
+
+		const disclaimers = (await Promise.allSettled([...assetMovementProviderIds].map(async (providerId) => {
+			const providerDisclaimers = await this.parent.graph.getProviderDisclaimers(providerId);
+			if (providerDisclaimers === null) {
+				throw(new Error("No provider disclaimer"));
+			}
+
+			return(providerDisclaimers)
+		}))).filter(function(result) {
+			return(result.status === 'fulfilled')
+		}).map(function(fulfilledResult) {
+			return(fulfilledResult.value);
+		});
+
+		return(disclaimers);
 	}
 }
 

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -449,12 +449,7 @@ test('Asset Movement Anchor Client Test', async function() {
 
 		/* Expect legal field to be parsed properly on the client side */
 		expect(testProvider?.serviceInfo.legal).toEqual(testLegalField);
-
-		/* Expect disclaimers on legal field to resolve correctly from the client */
-		const testDisclaimers = await assetTransferClient.getProviderLegalDisclaimersByID('Test');
-		expect(testDisclaimers).toEqual(testLegalField.disclaimers);
-		const test2Disclaimers = await assetTransferClient.getProviderLegalDisclaimersByID('Test2');
-		expect(test2Disclaimers).toBeNull();
+		expect(testProvider.getLegalDisclaimers()).toEqual(testLegalField);
 
 		/* Expect custom token metadata to be resolved correctly */
 		expect(testProvider.serviceInfo.locationMetadata).toEqual(validLocationMetadata);

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -449,7 +449,7 @@ test('Asset Movement Anchor Client Test', async function() {
 
 		/* Expect legal field to be parsed properly on the client side */
 		expect(testProvider?.serviceInfo.legal).toEqual(testLegalField);
-		expect(testProvider.getLegalDisclaimers()).toEqual(testLegalField);
+		expect(testProvider.getLegalDisclaimers()).toEqual(testLegalField.disclaimers);
 
 		/* Expect custom token metadata to be resolved correctly */
 		expect(testProvider.serviceInfo.locationMetadata).toEqual(validLocationMetadata);

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -450,6 +450,12 @@ test('Asset Movement Anchor Client Test', async function() {
 		/* Expect legal field to be parsed properly on the client side */
 		expect(testProvider?.serviceInfo.legal).toEqual(testLegalField);
 
+		/* Expect disclaimers on legal field to resolve correctly from the client */
+		const testDisclaimers = await assetTransferClient.getProviderLegalDisclaimersByID('Test');
+		expect(testDisclaimers).toEqual(testLegalField.disclaimers);
+		const test2Disclaimers = await assetTransferClient.getProviderLegalDisclaimersByID('Test2');
+		expect(test2Disclaimers).toBeNull();
+
 		/* Expect custom token metadata to be resolved correctly */
 		expect(testProvider.serviceInfo.locationMetadata).toEqual(validLocationMetadata);
 

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -1136,6 +1136,15 @@ export class KeetaAssetMovementAnchorProvider extends KeetaAssetMovementAnchorBa
 
 		return(assetMetadata);
 	}
+
+	getLegalDisclaimers(): NonNullable<AnchorMetadataLegalField['disclaimers']> | null {
+		const disclaimers = this.serviceInfo.legal?.disclaimers;
+		if (!disclaimers) {
+			return(null);
+		}
+
+		return(disclaimers);
+	}
 }
 
 class KeetaAssetMovementAnchorClient extends KeetaAssetMovementAnchorBase {
@@ -1204,6 +1213,11 @@ class KeetaAssetMovementAnchorClient extends KeetaAssetMovementAnchorBase {
 		}
 
 		return(disclaimers);
+	}
+
+	async getProviderByAccount(account: NonNullable<SharedLookupCriteria['accounts']>[number]): Promise<KeetaAssetMovementAnchorProvider | null> {
+		const providers = await this.#lookup({}, { accounts: [account] });
+		return(providers?.[0] ?? null);
 	}
 
 	/** @internal */

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -87,7 +87,7 @@ import type { Signable } from '../../lib/utils/signing.js';
 import { SignData } from '../../lib/utils/signing.js';
 import { KeetaAnchorError } from '../../lib/error.js';
 import { KeetaNet } from '../../client/index.js';
-import { resolveSharedAnchorMetadataLegalExtension, type SharedAnchorMetadataLegalExtension } from '../../lib/metadata.types.js';
+import { resolveSharedAnchorMetadataLegalExtension, type SharedAnchorMetadataLegalExtension, type AnchorMetadataLegalField } from '../../lib/metadata.types.js';
 import type { ExternalChainAsset, ExternalChainLocationType } from '../../lib/asset.js';
 
 // const PARANOID = true;
@@ -1190,6 +1190,20 @@ class KeetaAssetMovementAnchorClient extends KeetaAssetMovementAnchorBase {
 	async getProviderByID(providerID: string): Promise<KeetaAssetMovementAnchorProvider | null> {
 		const providers = await this.#lookup({}, { providerIDs: [providerID] });
 		return(providers?.[0] ?? null);
+	}
+
+	async getProviderLegalDisclaimersByID(providerID: string): Promise<Exclude<AnchorMetadataLegalField['disclaimers'], undefined> | null> {
+		const provider = await this.getProviderByID(providerID);
+		if (!provider) {
+			return(null);
+		}
+
+		const disclaimers = provider.serviceInfo.legal?.disclaimers;
+		if (!disclaimers) {
+			return(null);
+		}
+
+		return(disclaimers);
 	}
 
 	/** @internal */

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -425,6 +425,13 @@ for (const useDeprecated of [false, true]) {
 
 			expect(providers?.length).toEqual(1);
 			expect(providers?.[0]?.serviceInfo.legal).toEqual(testingLegalField.legal);
+
+			const disclaimersFromClient = await fxClient.getLegalDisclaimersById('Test');
+			expect(disclaimersFromClient).toEqual(testingLegalField.legal)
+			expect(disclaimersFromClient).toEqual(providers?.[0]?.serviceInfo.legal)
+
+			const disclaimersFromClientFromTest2 = await fxClient.getLegalDisclaimersById('Test2');
+			expect(disclaimersFromClientFromTest2).toEqual(null)
 		}
 
 		/* Get Estimate from Currency Codes */

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -429,8 +429,8 @@ for (const useDeprecated of [false, true]) {
 			expect(providers?.[0]?.serviceInfo.legal).toEqual(testingLegalField.legal);
 
 			const disclaimersFromClient = await fxClient.getLegalDisclaimersById('Test');
-			expect(disclaimersFromClient).toEqual(testingLegalField.legal)
-			expect(disclaimersFromClient).toEqual(providers?.[0]?.serviceInfo.legal)
+			expect(disclaimersFromClient).toEqual(testingLegalField.legal?.disclaimers)
+			expect(disclaimersFromClient).toEqual(providers?.[0]?.serviceInfo.legal?.disclaimers)
 
 			const disclaimersFromClientFromTest2 = await fxClient.getLegalDisclaimersById('Test2');
 			expect(disclaimersFromClientFromTest2).toEqual(null)

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -28,7 +28,7 @@ import type {
 } from './common.ts';
 import { KeetaAnchorError, KeetaAnchorUserError } from '../../lib/error.js';
 import { resolveSharedAnchorMetadataLegalExtension } from '../../lib/metadata.types.js';
-import type { SharedAnchorMetadataLegalExtension } from '../../lib/metadata.types.js';
+import type { AnchorMetadataLegalField, SharedAnchorMetadataLegalExtension } from '../../lib/metadata.types.js';
 
 /**
  * An opaque type that represents a provider ID.
@@ -227,7 +227,7 @@ class KeetaFXAnchorBase {
 	}
 }
 
-class KeetaFXAnchorProviderBase extends KeetaFXAnchorBase {
+export class KeetaFXAnchorProviderBase extends KeetaFXAnchorBase {
 	readonly serviceInfo: KeetaFXServiceInfo;
 	readonly providerID: ProviderID;
 	readonly conversion: ConversionInputCanonical;
@@ -974,6 +974,25 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 		}));
 
 		return(retval);
+	}
+
+	async getLegalDisclaimersById(providerID: string): Promise<NonNullable<AnchorMetadataLegalField['disclaimers']> | null>{
+		const endpoints = await getEndpoints(this.resolver, {}, this.#account, { providerIDs: [providerID] }, { logger: this.logger });
+		if (endpoints === null) {
+			return(null);
+		}
+
+		const serviceEntry = typedFxServiceEntries(endpoints)[0];
+		if (!serviceEntry) {
+			return(null);
+		}
+
+		const disclaimers = serviceEntry[1].legal?.disclaimers;
+		if (!disclaimers || disclaimers.length === 0) {
+			return(null)
+		}
+
+		return(disclaimers);
 	}
 
 	/** @internal */


### PR DESCRIPTION
Exposes `getDisclaimers` on `AnchorChainingPath` which returns a list of legal disclaimers for each provider within that path.