### PR TITLE
fix(username): Username URL Encoding

### DIFF
--- a/src/services/username/server.test.ts
+++ b/src/services/username/server.test.ts
@@ -280,3 +280,22 @@ test('username server validates signed transfers and release requests', async ()
 	expect(invalidReleaseResponse.status).toBeLessThan(600);
 	expect(releaseCalls).toBe(1);
 }, 10_000);
+
+test('username server metadata exposes unencoded resolve URI template', async () => {
+	await using server = new KeetaNetUsernameAnchorHTTPServer({
+		url: 'https://usernames.example.com',
+		usernames: {
+			async resolveUsername() {
+				return(null);
+			},
+			async resolveAccount() {
+				return(null);
+			}
+		}
+	});
+
+	await server.start();
+
+	const metadata = await server.serviceMetadata();
+	expect(metadata.operations.resolve).toBe('https://usernames.example.com/api/resolve/{toResolve}');
+}, 10_000);

--- a/src/services/username/server.test.ts
+++ b/src/services/username/server.test.ts
@@ -297,5 +297,5 @@ test('username server metadata exposes unencoded resolve URI template', async ()
 	await server.start();
 
 	const metadata = await server.serviceMetadata();
-	expect(metadata.operations.resolve).toBe('https://usernames.example.com/api/resolve/{toResolve}');
+	expect(metadata.operations.resolve).toContain('{toResolve}');
 }, 10_000);

--- a/src/services/username/server.ts
+++ b/src/services/username/server.ts
@@ -304,7 +304,7 @@ export class KeetaNetUsernameAnchorHTTPServer extends KeetaAnchorMetadataServer<
 	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['username']>[string]> {
 		const acceptedIssuerDNs = this.acceptedIssuerDNs();
 		const operations: NonNullable<ServiceMetadata['services']['username']>[string]['operations'] = {
-			resolve: (new URL('/api/resolve/{toResolve}', this.url)).toString()
+			resolve: (new URL('/api/resolve', this.url)).toString() + '/{toResolve}'
 		};
 
 		const authentication: ServiceMetadataAuthenticationType = {


### PR DESCRIPTION
# Summary

Updates username anchor to emit unencoded `{toResolve}` URI template in service metadata.