### PR TITLE
feat(rails)!: rename UAE accountType to ISO-2 'ae'

### DIFF
--- a/src/services/asset-movement/lib/data/addresses/bank-account/ae.ts
+++ b/src/services/asset-movement/lib/data/addresses/bank-account/ae.ts
@@ -1,6 +1,6 @@
 import { sharedSchemaReferences, type AccountAddressSchema } from "../../types.js";
 
-const uaeBankAccountSchema: AccountAddressSchema = {
+const aeBankAccountSchema: AccountAddressSchema = {
 	type: 'bank-account',
 
 	includeFields: {
@@ -45,4 +45,4 @@ const uaeBankAccountSchema: AccountAddressSchema = {
 	}
 }
 
-export default uaeBankAccountSchema;
+export default aeBankAccountSchema;


### PR DESCRIPTION
BREAKING: pre-launch rename for consistency with other ISO-2 rail codes. Sibling PRs in bivo-anchor and web-wallet land alongside.