### PR TITLE
Add KYB (Know Your Business) service surface

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,9 +2,13 @@ import type {
 	KeetaKYCAnchorClientConfig
 } from '../services/kyc/client.ts';
 import type {
+	KeetaKYBAnchorClientConfig
+} from '../services/kyb/client.ts';
+import type {
 	KeetaFXAnchorClientConfig
 } from '../services/fx/client.ts';
 import KeetaKYCAnchorClient from '../services/kyc/client.js';
+import KeetaKYBAnchorClient from '../services/kyb/client.js';
 import KeetaFXAnchorClient from '../services/fx/client.js';
 import * as lib from '../lib/index.js';
 import * as KeetaNet from '@keetanetwork/keetanet-client';
@@ -26,6 +30,12 @@ import type {
 export namespace KYC {
 	export type ClientConfig = KeetaKYCAnchorClientConfig;
 	export const Client: typeof KeetaKYCAnchorClient = KeetaKYCAnchorClient;
+}
+// TODO: Determine how we want to export the client
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace KYB {
+	export type ClientConfig = KeetaKYBAnchorClientConfig;
+	export const Client: typeof KeetaKYBAnchorClient = KeetaKYBAnchorClient;
 }
 // TODO: Determine how we want to export the client
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -33,6 +33,7 @@ async function getErrorClassMapping(): Promise<{ [key: string]: (input: unknown)
 	// Dynamically import errors to avoid circular dependencies
 	const importPromises: { Errors: { [key: string]: DeserializableErrorClass }}[] = await Promise.all([
 		import('../services/kyc/common.js'),
+		import('../services/kyb/common.js'),
 		import('../services/fx/common.js'),
 		import('../services/asset-movement/common.js'),
 		import('../services/storage/common.js'),

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -112,6 +112,58 @@ type ServiceMetadata = {
 			};
 		};
 		/**
+		 * Know Your Business (KYB) services
+		 *
+		 * This is used to identify service providers which can verify
+		 * the legal existence and standing of a business entity.
+		 *
+		 * Unlike KYC (which redirects an individual to a hosted journey),
+		 * a KYB verification is performed synchronously from the business
+		 * details supplied in the request.  There is no user-facing web
+		 * URL, so the metadata mirrors the KYC shape minus the redirect.
+		 */
+		kyb?: {
+			[id: string]: SharedAnchorMetadataSignedExtension & {
+				operations: {
+					/**
+					 * Check if the KYB provider can
+					 * service a more specific locality
+					 * (optional)
+					 */
+					checkLocality?: string;
+					/**
+					 * Request an estimate for a KYB
+					 * verification (optional)
+					 */
+					getEstimate?: string;
+					/**
+					 * Begin the KYB verification process
+					 * with this KYB provider
+					 */
+					createVerification?: string;
+					/**
+					 * Get the certificate for the
+					 * KYB verification
+					 */
+					getCertificates?: string;
+				};
+				/**
+				 * Country codes which this KYB provider can
+				 * validate businesses in.  If this is not
+				 * specified, then the KYB provider can
+				 * validate businesses in any country.
+				 */
+				countryCodes?: string[];
+				/**
+				 * The Certificate Authority (CA) Certificate
+				 * that this KYB provider uses to sign KYB
+				 * certificates.  This is used to identify the
+				 * KYB provider.
+				 */
+				ca: string;
+			};
+		};
+		/**
 		 * Foreign Exchange (FX) services
 		 *
 		 * This is used to identify service providers which
@@ -348,6 +400,13 @@ type ServiceSearchCriteria<T extends Services> = {
 		 */
 		countryCodes: CountrySearchInput[];
 	};
+	'kyb': {
+		/**
+		 * Search for a KYB provider which can verify businesses in ALL
+		 * of the following countries.
+		 */
+		countryCodes: CountrySearchInput[];
+	};
 	'assetMovement': {
 		asset?: MovableAssetSearchInput | { from: MovableAssetSearchInput; to: MovableAssetSearchInput; };
 		from?: AssetLocationString;
@@ -486,6 +545,11 @@ function assertValidOperationsKYC(input: unknown): asserts input is { operations
 	assertValidOperationsBanking(input);
 }
 
+function assertValidOperationsKYB(input: unknown): asserts input is { operations: ToValuizableObject<NonNullable<ServiceMetadata['services']['kyb']>[string]>['operations'] } {
+	/* XXX:TODO: Validate the specific operations */
+	assertValidOperationsBanking(input);
+}
+
 function assertValidOperationsFX(input: unknown): asserts input is { operations: ToValuizableObject<NonNullable<ServiceMetadata['services']['fx']>[string]>['operations'] } {
 	/* XXX:TODO: Validate the specific operations */
 	assertValidOperationsBanking(input);
@@ -563,6 +627,14 @@ const assertResolverLookupBankingResult = function(input: unknown): ResolverLook
 };
 const assertResolverLookupKYCResult = function(input: unknown): ResolverLookupServiceResults<'kyc'>[string] {
 	assertValidOperationsKYC(input);
+	assertValidOptionalCountryCodes(input);
+	assertValidCA(input);
+
+	return(input);
+};
+
+const assertResolverLookupKYBResult = function(input: unknown): ResolverLookupServiceResults<'kyb'>[string] {
+	assertValidOperationsKYB(input);
 	assertValidOptionalCountryCodes(input);
 	assertValidCA(input);
 
@@ -1544,6 +1616,9 @@ class Resolver {
 		'kyc': {
 			search: this.lookupKYCServices.bind(this)
 		},
+		'kyb': {
+			search: this.lookupKYBServices.bind(this)
+		},
 		'fx': {
 			search: this.lookupFXServices.bind(this)
 		},
@@ -1730,6 +1805,68 @@ class Resolver {
 		if (Object.keys(retval).length === 0) {
 			/*
 			 * If we didn't find any banking services, then we return
+			 * undefined to indicate that no services were found.
+			 */
+			return(undefined);
+		}
+
+		return(retval);
+	}
+
+	private async lookupKYBServices(kybServices: ValuizableObject | undefined, criteria: ServiceSearchCriteria<'kyb'>) {
+		if (kybServices === undefined) {
+			return(undefined);
+		}
+
+		const retval: ResolverLookupServiceResults<'kyb'> = {};
+		for (const checkKYBServiceID in kybServices) {
+			try {
+				const checkKYBService = await kybServices[checkKYBServiceID]?.('object');
+				if (checkKYBService === undefined) {
+					continue;
+				}
+
+				if (!('operations' in checkKYBService)) {
+					continue;
+				}
+
+				if (criteria.countryCodes !== undefined) {
+					let acceptable = true;
+					/*
+					 * If the KYB service does not have a countryCodes
+					 * property, then it can validate businesses in any
+					 * country, so we skip this check.
+					 */
+					if ('countryCodes' in checkKYBService) {
+						const countryCodes = await checkKYBService.countryCodes?.('array') ?? [];
+						const checkKYBServiceCountryCodes = await Promise.all(countryCodes.map(async function(item) {
+							return(await item?.('string'));
+						}));
+						this.#logger?.debug(`Resolver:${this.id}`, 'Checking country codes:', criteria.countryCodes, 'against', checkKYBServiceCountryCodes, 'for', checkKYBServiceID);
+
+						for (const checkCountryCode of criteria.countryCodes) {
+							const checkCountryCodeCanonical = convertToCountrySearchCanonical(checkCountryCode);
+							if (!checkKYBServiceCountryCodes.includes(checkCountryCodeCanonical)) {
+								acceptable = false;
+								break;
+							}
+						}
+					}
+
+					if (!acceptable) {
+						continue;
+					}
+				}
+
+				retval[checkKYBServiceID] = assertResolverLookupKYBResult(checkKYBService);
+			} catch (checkKYBServiceError) {
+				this.#logger?.debug(`Resolver:${this.id}`, 'Error checking KYB service', checkKYBServiceID, ':', checkKYBServiceError, ' -- ignoring');
+			}
+		}
+
+		if (Object.keys(retval).length === 0) {
+			/*
+			 * If we didn't find any KYB services, then we return
 			 * undefined to indicate that no services were found.
 			 */
 			return(undefined);
@@ -2481,6 +2618,78 @@ class Resolver {
 				}
 			} catch (kycServiceError) {
 				this.#logger?.debug(`Resolver:${this.id}`, 'Error processing KYC service', kycServiceID, ':', kycServiceError, ' -- ignoring');
+			}
+		}
+
+		const retval = Array.from(allCountryCodes).map(function(countryCode) {
+			return(new CurrencyInfo.Country(countryCode));
+		});
+
+		return(retval);
+	}
+
+	async listSupportedKYBCountries(): Promise<CurrencyInfo.Country[]> {
+		const rootMetadata = await this.#getRootMetadata();
+
+		/*
+		 * Get the services object
+		 */
+		const definedServicesProperty = rootMetadata.services;
+		if (definedServicesProperty === undefined) {
+			throw(new Error('Root metadata is missing "services" property'));
+		}
+		const definedServices = await definedServicesProperty('object');
+
+		const kybServicesProperty = definedServices.kyb;
+		if (kybServicesProperty === undefined) {
+			return([]);
+		}
+
+		const kybServices = await kybServicesProperty('object');
+
+		this.#logger?.debug(`Resolver:${this.id}`, 'Listing supported KYB countries from', Object.keys(kybServices));
+
+		const allCountryCodes = new Set<CurrencyInfo.ISOCountryCode>();
+		for (const kybServiceID in kybServices) {
+			try {
+				const kybService = await kybServices[kybServiceID]?.('object');
+				if (kybService === undefined) {
+					continue;
+				}
+
+				/*
+				 * If the KYB service does not have a countryCodes
+				 * property, then it can validate businesses in any
+				 * country, so we add all countries and stop processing
+				 * other services since we already have all possible countries.
+				 */
+				if (!('countryCodes' in kybService)) {
+					for (const countryCode of CurrencyInfo.Country.allCountryCodes) {
+						allCountryCodes.add(countryCode);
+					}
+					break;
+				}
+
+				const countryCodes = await kybService.countryCodes?.('array') ?? [];
+				const countryCodesValues = await Promise.all(countryCodes.map(async function(item) {
+					return(await item?.('string'));
+				}));
+
+				for (const countryCode of countryCodesValues) {
+					if (countryCode === undefined) {
+						continue;
+					}
+
+					try {
+						// Validate that it's a valid country code
+						const validatedCountryCode = CurrencyInfo.Country.assertCountryCode(countryCode);
+						allCountryCodes.add(validatedCountryCode);
+					} catch (validationError) {
+						this.#logger?.debug(`Resolver:${this.id}`, 'Invalid country code', countryCode, 'in service', kybServiceID, ':', validationError);
+					}
+				}
+			} catch (kybServiceError) {
+				this.#logger?.debug(`Resolver:${this.id}`, 'Error processing KYB service', kybServiceID, ':', kybServiceError, ' -- ignoring');
 			}
 		}
 

--- a/src/services/kyb/client.test.ts
+++ b/src/services/kyb/client.test.ts
@@ -1,0 +1,291 @@
+import { test, expect } from 'vitest';
+import * as KeetaNetAnchor from '../../client/index.js';
+import KeetaAnchorResolver from '../../lib/resolver.js';
+import { createNodeAndClient } from '../../lib/utils/tests/node.js';
+import {
+	Certificate as KYBCertificate,
+	CertificateBuilder as KYBCertificateBuilder,
+	SensitiveAttribute
+} from '../../lib/certificates.js';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
+import { KeetaNetKYBAnchorHTTPServer } from './server.js';
+import type { KeetaKYBAnchorCreateVerificationRequest } from './common.ts';
+import { Errors as KeetaAnchorKYBErrors } from './common.js';
+import * as util from 'util';
+
+const DEBUG = false;
+
+test('KYB Anchor Client Test', async function() {
+	/*
+	 * Enable Debug logging if requested
+	 */
+	const loggerBase = DEBUG ? console : undefined;
+	const logger = loggerBase ? { logger: loggerBase } : {};
+
+	/*
+	 * Create an account to  use for the node
+	 */
+	const seed = 'B56AA6594977F94A8D40099674ADFACF34E1208ED965E5F7E76EE6D8A2E2744E';
+	const account = KeetaNet.lib.Account.fromSeed(seed, 0);
+
+	/*
+	 * Start a KeetaNet Node and get the UserClient for it
+	 */
+	const { userClient: client } = await createNodeAndClient(account);
+
+	/*
+	 * Create a dummy Root CA
+	 */
+	const rootCAAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const rootCABuilder = new KeetaNet.lib.Utils.Certificate.CertificateBuilder({
+		subjectPublicKey: rootCAAccount,
+		issuerDN: [{ name: 'commonName', value: 'Root CA' }],
+		subjectDN: [{ name: 'commonName', value: 'Root CA' }],
+		issuer: rootCAAccount,
+		serial: 1,
+		validFrom: new Date(Date.now() - 30_000),
+		validTo: new Date(Date.now() + 120_000)
+	});
+	const rootCA = await rootCABuilder.build();
+
+	const kybCAAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const kybCABuilder = new KeetaNet.lib.Utils.Certificate.CertificateBuilder({
+		subjectPublicKey: kybCAAccount,
+		issuerDN: [{ name: 'commonName', value: 'Root CA' }],
+		subjectDN: [{ name: 'commonName', value: 'Intermediate/KYB CA' }],
+		issuer: rootCAAccount,
+		serial: 2,
+		isCA: true,
+		validFrom: new Date(Date.now() - 30_000),
+		validTo: new Date(Date.now() + 120_000)
+	});
+	const kybCA = await kybCABuilder.build();
+
+	/*
+	 * Start a testing KYB Anchor HTTP Server
+	 */
+	const signer = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+
+	const verifications = new Map<string, KeetaKYBAnchorCreateVerificationRequest>;
+	const certificates = new Map<string, string>();
+	await using server = new KeetaNetKYBAnchorHTTPServer({
+		signer: signer,
+		ca: kybCA,
+		client: client,
+		kyb: {
+			countryCodes: ['US'],
+			/*
+			 * KYB is synchronous: the business is verified here from the
+			 * supplied details and the result is stored for the client
+			 * to poll.  There is no hosted journey / web URL.
+			 */
+			verificationStarted: async function(request) {
+				const id = crypto.randomUUID();
+				verifications.set(id, request);
+
+				return({
+					ok: true,
+					id: id,
+					expectedCost: {
+						min: '0',
+						max: '0',
+						token: client.baseToken.publicKeyString.get()
+					}
+				});
+			},
+			getCertificates: async function(verificationID) {
+				const request = verifications.get(verificationID);
+				if (request === undefined) {
+					throw(new KeetaAnchorKYBErrors.VerificationNotFound(`Verification ID ${verificationID} not found`));
+				}
+
+				let certificate = certificates.get(verificationID);
+				if (certificate === undefined) {
+					/*
+					 * Issue a new business certificate for this verification
+					 */
+					const userAccount = KeetaNet.lib.Account.fromPublicKeyString(request.account).assertAccount();
+					const certificateBuilder = new KYBCertificateBuilder({
+						subject: userAccount,
+						subjectDN: [{ name: 'commonName', value: 'KYB Verified Business' }],
+						issuerDN: kybCA.subjectDN,
+						issuer: kybCAAccount,
+						serial: 3,
+						validFrom: new Date(Date.now() - 30_000),
+						validTo: new Date(Date.now() + 120_000)
+					});
+					const businessName = request.business.names[0] ?? 'Acme, Inc.';
+					const legalName = await SensitiveAttribute.create(userAccount, 'fullName', businessName);
+
+					certificateBuilder.setSensitiveAttribute('fullName', legalName);
+
+					const builtCertificate = await certificateBuilder.build();
+					certificate = builtCertificate.toPEM();
+					certificates.set(verificationID, certificate);
+				}
+
+				return([{
+					certificate: certificate,
+					intermediates: [kybCA.toPEM()]
+				}]);
+			}
+		},
+		...logger
+	});
+
+	await server.start();
+
+	const results = await client.setInfo({
+		description: 'KYB Anchor Test Root',
+		name: 'TEST',
+		metadata: KeetaAnchorResolver.Metadata.formatMetadata({
+			version: 1,
+			services: {
+				kyb: {
+					Bad: {
+						countryCodes: ['XX'],
+						ca: 'FOO',
+						operations: {
+							createVerification: 'https://example.com/createVerification.json',
+							getCertificates: 'https://example.com/getCertificates/{id}.json'
+						}
+					},
+					Test: await server.serviceMetadata()
+				}
+			}
+		})
+	});
+	loggerBase?.log('Set info results:', results);
+
+	const kybClient = new KeetaNetAnchor.KYB.Client(client, {
+		root: account,
+		...loggerBase
+	});
+
+	/*
+	 * Test getSupportedCountries method
+	 */
+	const supportedCountries = await kybClient.getSupportedCountries();
+	loggerBase?.log('Supported Countries:', supportedCountries.map(c => c.code));
+	expect(supportedCountries).toBeDefined();
+	expect(Array.isArray(supportedCountries)).toBe(true);
+	expect(supportedCountries.length).toBeGreaterThan(0);
+	// The test service is configured with 'US' country code
+	const usCountry = supportedCountries.find(c => c.code === 'US');
+	expect(usCountry).toBeDefined();
+	expect(usCountry?.code).toBe('US');
+	// Test negative case: verify a country that isn't in test data
+	const absentCountry = supportedCountries.find(c => c.code === 'CA');
+	expect(absentCountry).toBeUndefined();
+
+	const providers = await kybClient.createVerification({
+		countryCodes: ['US'],
+		account: account,
+		business: {
+			names: ['Acme, Inc.'],
+			addresses: [{ streetAddress1: '1 Main St', city: 'Springfield', state: 'IL', postalCode: '62701' }],
+			persons: [{ firstName: 'John', lastName: 'Doe' }]
+		}
+	});
+
+	if (providers.length === 0) {
+		throw(new Error('No providers returned'));
+	}
+
+	/**
+	 * Print out information about the providers
+	 */
+	loggerBase?.log('Providers:');
+	for (const provider of providers) {
+		const providerCA = await provider.ca();
+		const providerName = providerCA.subject;
+		expect(providerName).toBe('commonName=Intermediate/KYB CA');
+
+		loggerBase?.log('  Provider:');
+		loggerBase?.log('    ID:', provider.id);
+		loggerBase?.log('    Name:', providerName);
+	}
+	expect(providers.length).toBeGreaterThan(0);
+
+	/*
+	 * Pick a random provider
+	 */
+	const provider = providers[0];
+	if (provider === undefined) {
+		throw(new Error('internal error: no providers available'));
+	}
+
+	const providerCountryCodes = await provider.countryCodes();
+	expect(providerCountryCodes).toBeDefined();
+	expect(providerCountryCodes?.[0]?.code).toBe('US');
+
+	const verification = await provider.startVerification();
+	loggerBase?.log('Request ID:', verification.id, 'on provider', verification.providerID);
+
+	/**
+	 * Poll for the verification status
+	 */
+	const rootCAObject = new KeetaNet.lib.Utils.Certificate.Certificate(rootCA, {
+		isTrustedRoot: true
+	});
+
+	const checkIssuerCert = await verification.getProviderIssuerCertificate();
+	expect(checkIssuerCert.subject).toEqual('commonName=Intermediate/KYB CA');
+
+	while (true) {
+		const results = await verification.getCertificates();
+		if (!results.ok) {
+			await KeetaNet.lib.Utils.Helper.asleep(results.retryAfter);
+			continue;
+		}
+
+		loggerBase?.log('Certificates:');
+		const output = (await Promise.all(results.results.map(async function(certificateGroup) {
+			let intermediates = certificateGroup.intermediates;
+			if (intermediates === undefined) {
+				intermediates = new Set();
+			}
+			const trustedCertificate = new KYBCertificate(certificateGroup.certificate.toPEM(), {
+				store: {
+					root: new Set([rootCAObject]),
+					intermediate: intermediates
+				},
+				/* If you remove this, you will not be able to retrieve the sensitive attributes */
+				subjectKey: account
+			});
+
+			let legalName: string;
+			if ('fullName' in trustedCertificate.attributes) {
+				if (trustedCertificate.attributes['fullName'].sensitive) {
+					try {
+						const result = await trustedCertificate.attributes['fullName'].value.getValue();
+						legalName = 'SENSITIVE: ' + result;
+					} catch {
+						legalName = 'SENSITIVE (unable to retrieve)';
+					}
+				} else {
+					// XXX:TODO Fix depth issue
+					// @ts-ignore
+					legalName = await trustedCertificate.getAttributeValue('fullName');
+				}
+			} else {
+				legalName = 'Not provided';
+			}
+
+			return(util.inspect({
+				certificate: trustedCertificate.toPEM(),
+				certificateValue: trustedCertificate,
+				intermediates: [...certificateGroup.intermediates?.values() ?? []].map(function(intermediate) {
+					return(intermediate.toPEM());
+				}),
+				chain: trustedCertificate.chain,
+				attributes: trustedCertificate.attributes,
+				legalName: legalName,
+				valid: trustedCertificate.checkValid()
+			}, { depth: null, colors: true }));
+		}))).join('\n\n');
+
+		loggerBase?.log(output);
+		break;
+	}
+}, 30000);

--- a/src/services/kyb/client.ts
+++ b/src/services/kyb/client.ts
@@ -1,0 +1,498 @@
+import { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
+import * as CurrencyInfo from '@keetanetwork/currency-info';
+import { createIs } from 'typia';
+
+import { getDefaultResolver } from '../../config.js';
+import { Certificate as KYBCertificate } from '../../lib/certificates.js';
+
+import type {
+	Client as KeetaNetClient,
+	UserClient as KeetaNetUserClient
+} from '@keetanetwork/keetanet-client';
+import type {
+	KeetaKYBAnchorCreateVerificationRequest,
+	KeetaKYBAnchorCreateVerificationResponse,
+	KeetaKYBAnchorGetCertificateResponse
+} from './common.ts';
+import {
+	verifySignedData,
+	generateSignedData
+} from './common.js';
+import type { Logger } from '../../lib/log/index.ts';
+import type Resolver from '../../lib/resolver.ts';
+import type { ServiceMetadata } from '../../lib/resolver.ts';
+import crypto from '../../lib/utils/crypto.js';
+import { validateURL } from '../../lib/utils/url.js';
+
+const PARANOID = true;
+
+/**
+ * The configuration options for the KYB Anchor client.
+ */
+export type KeetaKYBAnchorClientConfig = {
+	/**
+	 * The ID of the client. This is used to identify the client in logs.
+	 * If not provided, a random ID will be generated.
+	 */
+	id?: string;
+	/**
+	 * The logger to use for logging messages. If not provided, no logging
+	 * will be done.
+	 */
+	logger?: Logger;
+	/**
+	 * The resolver to use for resolving KYB Anchor services. If not
+	 * provided, a default resolver will be created using the provided
+	 * client and network (if the network is also not provided and the
+	 * client is not a UserClient, an error occurs).
+	 */
+	resolver?: Resolver;
+} & Omit<NonNullable<Parameters<typeof getDefaultResolver>[1]>, 'client'>;
+
+/**
+ * Any kind of X.509v3 Certificate.  This may or may not be a KYB certificate.
+ */
+type BaseCertificate = InstanceType<typeof KeetaNetLib.Utils.Certificate.Certificate>;
+
+/**
+ * The response type for the {@link KeetaKYBAnchorClient['getCertificates']()} method of the KYB Anchor client.
+ * It contains the certificate and optionally a set of intermediate certificates.
+ */
+type KeetaKYBAnchorClientGetCertificateResponse = ({
+	ok: true;
+	results: {
+		certificate: KYBCertificate;
+		intermediates?: Set<BaseCertificate> | undefined;
+	}[]
+} | {
+	ok: false;
+	retryAfter: number;
+	reason: string;
+});
+
+type KeetaKYBAnchorClientCreateVerificationRequest = Omit<KeetaKYBAnchorCreateVerificationRequest, 'signed' | 'account'> & {
+	account: InstanceType<typeof KeetaNetLib.Account>;
+};
+
+/**
+ * An opaque type that represents a provider ID.
+ */
+type ProviderID = string & {
+	readonly __providerID: unique symbol;
+};
+
+/**
+ * An opaque type that represents a KYB Anchor request ID
+ */
+type RequestID = string & {
+	readonly __requestID: unique symbol;
+};
+
+/**
+ * A list of operations that can be performed by the KYB Anchor service.
+ */
+type KeetaKYBAnchorOperations = {
+	[operation in keyof NonNullable<ServiceMetadata['services']['kyb']>[string]['operations']]?: (params?: { [key: string]: string; }) => URL;
+};
+
+/**
+ * The service information for a KYB Anchor service.
+ */
+type KeetaKYBVerificationServiceInfo = {
+	operations: {
+		[operation in keyof KeetaKYBAnchorOperations]: Promise<KeetaKYBAnchorOperations[operation]>;
+	};
+	countryCodes?: CurrencyInfo.Country[] | undefined;
+	ca: () => Promise<KYBCertificate>;
+};
+
+/**
+ * For each matching KYB Anchor service, this type describes the
+ * operations available and the country codes that the service supports.
+ */
+type GetEndpointsResult = {
+	[id: ProviderID]: KeetaKYBVerificationServiceInfo;
+};
+
+const isKeetaKYBAnchorCreateVerificationResponse = createIs<KeetaKYBAnchorCreateVerificationResponse>();
+const isKeetaKYBAnchorGetCertificateResponse = createIs<KeetaKYBAnchorGetCertificateResponse>();
+
+async function getEndpoints(resolver: Resolver, request: KeetaKYBAnchorCreateVerificationRequest): Promise<GetEndpointsResult | null> {
+	const response = await resolver.lookup('kyb', {
+		countryCodes: request.countryCodes
+	});
+
+	if (response === undefined) {
+		return(null);
+	}
+
+	const serviceInfoPromises = Object.entries(response).map(async function([id, serviceInfo]): Promise<[ProviderID, KeetaKYBVerificationServiceInfo]> {
+		const countryCodesPromises = (await serviceInfo.countryCodes?.('array'))?.map(async function(countryCode) {
+			return(new CurrencyInfo.Country(CurrencyInfo.Country.assertCountryCode(await countryCode('string'))));
+		});
+
+		let countryCodes: CurrencyInfo.Country[] | undefined;
+		if (countryCodesPromises !== undefined) {
+			const countryCodesResults = await Promise.allSettled(countryCodesPromises);
+			countryCodes = countryCodesResults.map(function(result) {
+				if (result.status === 'fulfilled') {
+					return(result.value);
+				}
+				throw(result.reason);
+			});
+		}
+
+		const operations = await serviceInfo.operations('object');
+		const operationsFunctions: KeetaKYBVerificationServiceInfo['operations'] = {};
+		for (const [key, operation] of Object.entries(operations)) {
+			if (operation === undefined) {
+				continue;
+			}
+
+			Object.defineProperty(operationsFunctions, key, {
+				get: async function() {
+					const url = await operation('string');
+					return(function(params?: { [key: string]: string; }): URL {
+						let substitutedURL = url;
+						for (const [paramKey, paramValue] of Object.entries(params ?? {})) {
+							substitutedURL = substitutedURL.replace(`{${paramKey}}`, encodeURIComponent(paramValue));
+						}
+
+						return(validateURL(substitutedURL));
+					});
+				},
+				enumerable: true,
+				configurable: true
+			});
+		}
+		return([
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			id as ProviderID,
+			{
+				countryCodes: countryCodes,
+				operations: operationsFunctions,
+				ca: async function() {
+					const certificatePEM = await serviceInfo.ca?.('string');
+					const certificate = new KYBCertificate(certificatePEM);
+
+					return(certificate);
+				}
+			}
+		]);
+	});
+
+	const retval = Object.fromEntries(await Promise.all(serviceInfoPromises));
+
+	return(retval);
+}
+
+type KeetaKYBAnchorCommonConfig = {
+	id: ProviderID;
+	serviceInfo: KeetaKYBVerificationServiceInfo;
+	request: KeetaKYBAnchorCreateVerificationRequest;
+	client: KeetaKYBAnchorClient;
+	operations: NonNullable<Pick<KeetaKYBAnchorOperations, 'createVerification' | 'getCertificates'>>;
+	logger?: Logger | undefined;
+};
+
+/**
+ * Represents an in-progress KYB verification request.
+ */
+class KeetaKYBVerification {
+	readonly providerID: KeetaKYBAnchorCommonConfig['id'];
+	readonly id: RequestID;
+	private readonly serviceInfo: KeetaKYBAnchorCommonConfig['serviceInfo'];
+	private readonly request: KeetaKYBAnchorCommonConfig['request'];
+	private readonly logger?: KeetaKYBAnchorCommonConfig['logger'] | undefined;
+	private readonly client: KeetaKYBAnchorCommonConfig['client'];
+	private readonly response: Extract<KeetaKYBAnchorCreateVerificationResponse, { ok: true }>;
+
+	private constructor(args: KeetaKYBAnchorCommonConfig, response: Extract<KeetaKYBAnchorCreateVerificationResponse, { ok: true }>) {
+		this.providerID = args.id;
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		this.id = response.id as RequestID;
+		this.serviceInfo = args.serviceInfo;
+		this.request = args.request;
+		this.client = args.client;
+		this.logger = args.logger;
+		this.response = response;
+
+		this.logger?.debug(`Created KYB verification for provider ID: ${this.providerID}, request: ${JSON.stringify(args.request)}, response: ${JSON.stringify(response)}`);
+	}
+
+	static async start(args: KeetaKYBAnchorCommonConfig): Promise<KeetaKYBVerification> {
+		args.logger?.debug(`Starting KYB verification for provider ID: ${args.id}, request: ${JSON.stringify(args.request)}`);
+
+		const endpoints = args.operations;
+		const createVerification = endpoints.createVerification?.();
+		if (createVerification === undefined) {
+			throw(new Error('KYB verification service does not support createVerification operation'));
+		}
+
+		const requestInformation = await fetch(createVerification, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Accept': 'application/json'
+			},
+			body: JSON.stringify({
+				request: args.request
+			})
+		});
+
+		const requestInformationJSON: unknown = await requestInformation.json();
+		if (!isKeetaKYBAnchorCreateVerificationResponse(requestInformationJSON)) {
+			throw(new Error(`Invalid response from KYB verification service: ${JSON.stringify(requestInformationJSON)}`));
+		}
+
+		if (!requestInformationJSON.ok) {
+			throw(new Error(`KYB verification request failed: ${requestInformationJSON.error}`));
+		}
+
+		args.logger?.debug(`KYB verification request successful, request ID ${requestInformationJSON.id}`);
+
+		return(new KeetaKYBVerification(args, requestInformationJSON));
+
+	}
+
+	get expectedCost(): typeof this.response.expectedCost {
+		return(this.response.expectedCost);
+	}
+
+	async getProviderIssuerCertificate(): Promise<KYBCertificate> {
+		return(await this.serviceInfo.ca());
+	}
+
+	getCertificates(): Promise<KeetaKYBAnchorClientGetCertificateResponse> {
+		return(this.client.getCertificates(this.providerID, {
+			id: this.id,
+			...this.request
+		}));
+	}
+}
+
+/**
+ * Represents the KYB operations for a specific provider
+ */
+class KeetaKYBProvider {
+	readonly id: ProviderID;
+	private readonly serviceInfo: KeetaKYBVerificationServiceInfo;
+	private readonly request: KeetaKYBAnchorCreateVerificationRequest;
+	private readonly logger?: Logger | undefined;
+	private readonly client: KeetaKYBAnchorClient;
+	private readonly operations: NonNullable<Pick<KeetaKYBAnchorOperations, 'createVerification' | 'getCertificates'>>;
+
+	private cachedCA?: KYBCertificate;
+
+	constructor(args: KeetaKYBAnchorCommonConfig) {
+		this.id = args.id;
+		this.serviceInfo = args.serviceInfo;
+		this.request = args.request;
+		this.client = args.client;
+		this.operations = args.operations;
+		this.logger = args.logger;
+
+		this.logger?.debug(`Created KYB verification for provider ID: ${args.id}, request: ${JSON.stringify(args.request)}`);
+	}
+
+	async countryCodes(): Promise<CurrencyInfo.Country[] | undefined> {
+		return(this.serviceInfo.countryCodes);
+	}
+
+	async ca(): Promise<KYBCertificate> {
+		if (this.cachedCA !== undefined) {
+			return(this.cachedCA);
+		}
+
+		this.cachedCA = await this.serviceInfo.ca();
+
+		return(this.cachedCA);
+	}
+
+	async startVerification(): Promise<KeetaKYBVerification> {
+		return(await KeetaKYBVerification.start({
+			id: this.id,
+			serviceInfo: this.serviceInfo,
+			request: this.request,
+			client: this.client,
+			operations: this.operations,
+			logger: this.logger
+		}));
+	}
+}
+
+
+class KeetaKYBAnchorClient {
+	readonly resolver: Resolver;
+	readonly id: string;
+	private readonly logger?: Logger | undefined;
+
+	constructor(client: KeetaNetClient | KeetaNetUserClient, config: KeetaKYBAnchorClientConfig = {}) {
+		this.resolver = config.resolver ?? getDefaultResolver(client, config);
+		this.id = config.id ?? crypto.randomUUID();
+		this.logger = config.logger;
+	}
+
+	async createVerification(request: KeetaKYBAnchorClientCreateVerificationRequest): Promise<KeetaKYBProvider[]> {
+		const signedData = await generateSignedData(request.account.assertAccount());
+
+		if (PARANOID) {
+			const check = await verifySignedData({ account: request.account.publicKeyString.get(), signed: signedData });
+			if (!check) {
+				throw(new Error('Failed to verify signed data'));
+			}
+		}
+
+		const signedRequest: KeetaKYBAnchorCreateVerificationRequest = {
+			...request,
+			account: request.account.publicKeyString.get(),
+			signed: signedData
+		};
+
+		const endpoints = await getEndpoints(this.resolver, signedRequest);
+		if (endpoints === null) {
+			throw(new Error('No KYB endpoints found for the given criteria'));
+		}
+
+		const validEndpoints = await Promise.allSettled(Object.entries(endpoints).map(async ([id, serviceInfo]) => {
+			const endpoints = serviceInfo.operations;
+			/*
+			 * Verify that we have the required operations
+			 * available to perform a KYB verification.
+			 */
+			const createVerification = await endpoints.createVerification;
+			const getCertificates = await endpoints.getCertificates;
+			if (createVerification === undefined || getCertificates === undefined) {
+				this.logger?.warn(`KYB verification provider ${id} does not support required operations (createVerification, getCertificates)`);
+
+				return(null);
+			}
+
+			/*
+			 * We can safely cast the ID to a ProviderID because it's a branded type
+			 * for this specific type
+			 */
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			const providerID = id as ProviderID;
+			return(new KeetaKYBProvider({
+				id: providerID,
+				serviceInfo: serviceInfo,
+				request: signedRequest,
+				client: this,
+				logger: this.logger,
+				operations: {
+					createVerification,
+					getCertificates
+				}
+			}));
+		}));
+
+		/*
+		 * Filter out any endpoints that were not able to be resolved
+		 * or that did not have the required operations.
+		 */
+		const retval = validEndpoints.map(function(result) {
+			if (result.status !== 'fulfilled') {
+				return(null);
+			}
+			if (result.value === null) {
+				return(null);
+			}
+			return(result.value);
+		}).filter(function(result) {
+			return(result !== null);
+		});
+
+		if (retval.length === 0) {
+			throw(new Error('No valid KYB verification endpoints found'));
+		}
+
+		return(retval);
+	}
+
+	async getCertificates(providerID: ProviderID, request: KeetaKYBAnchorCreateVerificationRequest & { id: RequestID; }): Promise<KeetaKYBAnchorClientGetCertificateResponse> {
+		const endpoints = await getEndpoints(this.resolver, request);
+		if (endpoints === null) {
+			throw(new Error('No KYB endpoints found for the given criteria'));
+		}
+		const providerEndpoints = endpoints[providerID];
+		if (providerEndpoints === undefined) {
+			throw(new Error(`No KYB endpoints found for provider ID: ${providerID}`));
+		}
+
+		const requestID = request.id;
+		const operations = providerEndpoints.operations;
+		const getCertificate = (await operations.getCertificates)?.({ id: requestID });
+		if (getCertificate === undefined) {
+			throw(new Error('internal error: KYB verification service does not support getCertificate operation'));
+		}
+
+		const response = await fetch(getCertificate, {
+			method: 'GET',
+			headers: {
+				'Accept': 'application/json'
+			}
+		});
+
+		/*
+		 * Handle retryable errors by passing them up to the caller to
+		 * retry.
+		 */
+		if (response.status === 404) {
+			return({
+				ok: false,
+				retryAfter: 500,
+				reason: 'Certificate not found'
+			});
+		}
+
+		/*
+		 * Handle other errors as fatal errors that should not be retried.
+		 */
+		if (!response.ok) {
+			throw(new Error(`Failed to get certificate: ${response.statusText}`));
+		}
+
+		const responseJSON: unknown = await response.json();
+		if (!isKeetaKYBAnchorGetCertificateResponse(responseJSON)) {
+			throw(new Error(`Invalid response from KYB certificate service: ${JSON.stringify(responseJSON)}`));
+		}
+
+		if (!responseJSON.ok) {
+			throw(new Error(`KYB certificate request failed: ${responseJSON.error}`));
+		}
+
+		return({
+			ok: true,
+			results: responseJSON.results.map(function(result) {
+				const intermediates = result.intermediates?.map(function(intermediate) {
+					return(new KeetaNetLib.Utils.Certificate.Certificate(intermediate));
+				});
+
+				let intermediatesSet;
+				if (intermediates !== undefined && intermediates.length > 0) {
+					intermediatesSet = new Set(intermediates);
+				}
+
+				return({
+					certificate: new KYBCertificate(result.certificate),
+					intermediates: intermediatesSet
+				});
+			})
+		});
+	}
+
+	async getSupportedCountries(): Promise<CurrencyInfo.Country[]> {
+		return(await this.resolver.listSupportedKYBCountries());
+	}
+
+	async getEstimate(..._ignore_args: unknown[]): Promise<never> {
+		throw(new Error('not implemented'));
+	}
+
+	async checkLocality(..._ignore_args: unknown[]): Promise<never> {
+		throw(new Error('not implemented'));
+	}
+}
+
+export default KeetaKYBAnchorClient;

--- a/src/services/kyb/common.generated.ts
+++ b/src/services/kyb/common.generated.ts
@@ -1,0 +1,8 @@
+import { createAssert } from 'typia';
+import type {
+	KeetaKYBAnchorCreateVerificationRequest,
+	KeetaKYBAnchorCreateVerificationResponse
+} from './common.ts';
+
+export const assertCreateVerificationRequest: ReturnType<typeof createAssert<KeetaKYBAnchorCreateVerificationRequest>> = createAssert<KeetaKYBAnchorCreateVerificationRequest>();
+export const assertCreateVerificationResponse: ReturnType<typeof createAssert<KeetaKYBAnchorCreateVerificationResponse>> = createAssert<KeetaKYBAnchorCreateVerificationResponse>();

--- a/src/services/kyb/common.test.ts
+++ b/src/services/kyb/common.test.ts
@@ -1,0 +1,70 @@
+import { test, expect } from 'vitest';
+import { Errors } from './common.js';
+import { KeetaAnchorError, KeetaAnchorUserError } from '../../lib/error.js';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
+
+for (const errorClass of [
+	Errors.VerificationNotFound,
+	Errors.CertificateNotFound
+]) {
+	test(`KYB Error Round-trip Serialization - ${errorClass.name}`, async function() {
+		const error = new errorClass('Custom verification error');
+		const json = JSON.stringify(error.toJSON());
+		const parsed: unknown = JSON.parse(json);
+		const deserialized1 = await KeetaAnchorError.fromJSON(parsed);
+		const deserialized2 = await errorClass.fromJSON(parsed);
+
+		expect(deserialized1).toBeInstanceOf(errorClass);
+		expect(deserialized1.message).toBe(error.message);
+		expect(deserialized1.name).toBe(error.name);
+		expect(deserialized1.name).toBe(errorClass.name);
+
+		expect(deserialized2).toBeInstanceOf(errorClass);
+		expect(deserialized2.message).toBe(error.message);
+		expect(deserialized2.name).toBe(error.name);
+		expect(deserialized2.name).toBe(errorClass.name);
+
+		expect(errorClass.isInstance(deserialized1)).toBe(true);
+		expect(KeetaAnchorError.isInstance(deserialized1)).toBe(true);
+		expect(KeetaAnchorUserError.isInstance(deserialized1)).toBe(true);
+		expect(errorClass.isInstance(deserialized2)).toBe(true);
+		expect(KeetaAnchorError.isInstance(deserialized2)).toBe(true);
+		expect(KeetaAnchorUserError.isInstance(deserialized2)).toBe(true);
+	});
+}
+
+test('KYB Error Round-trip Serialization - PaymentRequired', async function() {
+	// Create a token account for testing
+	const tokenAccount = KeetaNet.lib.Account.fromSeed(
+		Buffer.from('0000000000000000000000000000000000000000000000000000000000000001', 'hex'),
+		0,
+		KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN
+	);
+
+	const error = new Errors.PaymentRequired(
+		{
+			amount: 1000n,
+			token: tokenAccount
+		},
+		'Custom payment message'
+	);
+
+	const json = JSON.stringify(error.toJSON());
+	const parsed: unknown = JSON.parse(json);
+	const deserialized = await Errors.PaymentRequired.fromJSON(parsed);
+
+	expect(deserialized).toBeInstanceOf(Errors.PaymentRequired);
+	expect(deserialized.message).toBe(error.message);
+	expect(deserialized.name).toBe(error.name);
+	expect(Errors.PaymentRequired.isInstance(deserialized)).toBe(true);
+	expect(Errors.CertificateNotFound.isInstance(deserialized)).toBe(false);
+	expect(Errors.VerificationNotFound.isInstance(deserialized)).toBe(false);
+	expect(KeetaAnchorError.isInstance(deserialized)).toBe(true);
+	expect(KeetaAnchorUserError.isInstance(deserialized)).toBe(true);
+
+	// Check that the PaymentRequired-specific properties are restored
+	if (deserialized instanceof Errors.PaymentRequired) {
+		expect(deserialized.amount).toBe(error.amount);
+		expect(deserialized.token.publicKeyString.get()).toBe(error.token.publicKeyString.get());
+	}
+});

--- a/src/services/kyb/common.ts
+++ b/src/services/kyb/common.ts
@@ -1,0 +1,279 @@
+import type {
+	ServiceMetadata,
+	ServiceSearchCriteria
+} from '../../lib/resolver.ts';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
+import * as Signing from '../../lib/utils/signing.js';
+import {
+	KeetaAnchorUserError
+} from '../../lib/error.js';
+import type { HTTPSignedField } from '../../lib/http-server/common.js';
+
+type KeetaNetToken = InstanceType<typeof KeetaNet.lib.Account<typeof KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN>>;
+
+export type CountryCodesSearchCriteria = ServiceSearchCriteria<'kyb'>['countryCodes'];
+
+export type Operations = NonNullable<ServiceMetadata['services']['kyb']>[string]['operations'];
+export type OperationNames = keyof Operations;
+
+/**
+ * A physical address for a business or one of its associated persons.
+ */
+export interface KeetaKYBAnchorBusinessAddress {
+	streetAddress1?: string;
+	streetAddress2?: string;
+	city?: string;
+	state?: string;
+	postalCode?: string;
+	country?: string;
+}
+
+/**
+ * A person associated with the business (officer, director, or beneficial
+ * owner) used to disambiguate the entity during verification.
+ */
+export interface KeetaKYBAnchorBusinessPerson {
+	firstName?: string;
+	lastName?: string;
+}
+
+/**
+ * The business details used to perform a Know Your Business (KYB)
+ * verification.
+ *
+ * Unlike an individual KYC verification (which redirects the user to a
+ * hosted journey), a KYB verification is performed synchronously using
+ * the business details supplied here.  There is no user-facing web URL.
+ */
+export interface KeetaKYBAnchorBusinessDetails {
+	/**
+	 * One or more legal / trade names for the business.  At least one
+	 * name is required.  Additional names improve match accuracy.
+	 */
+	names: string[];
+	/**
+	 * Known addresses for the business (registered office, principal
+	 * place of business, etc.).
+	 */
+	addresses?: KeetaKYBAnchorBusinessAddress[];
+	/**
+	 * Known associated persons (officers, directors, beneficial owners).
+	 */
+	persons?: KeetaKYBAnchorBusinessPerson[];
+	/**
+	 * Known websites for the business.
+	 */
+	websites?: string[];
+}
+
+export interface KeetaKYBAnchorCreateVerificationRequest {
+	countryCodes: CountryCodesSearchCriteria;
+	account: ReturnType<InstanceType<typeof KeetaNet.lib.Account>['publicKeyString']['get']>;
+	signed: HTTPSignedField;
+	/**
+	 * The business to verify.
+	 */
+	business: KeetaKYBAnchorBusinessDetails;
+}
+
+type KeetaNetTokenPublicKeyString = ReturnType<InstanceType<typeof KeetaNet.lib.Account<typeof KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN>>['publicKeyString']['get']>;
+export type KeetaKYBAnchorCreateVerificationResponse = ({
+	ok: true;
+
+	/**
+	 * The ID of the verification request -- this is a unique identifier
+	 * for the verification request that can be used to fetch the
+	 * certificate later
+	 */
+	id: string;
+	/**
+	 * The expected cost of the verification request, in the form of a
+	 * token and a range of minimum and maximum expected costs
+	 */
+	expectedCost: {
+		min: string;
+		max: string;
+		token: KeetaNetTokenPublicKeyString;
+	};
+} | {
+	ok: false;
+	error: string;
+});
+
+export type KeetaKYBAnchorGetCertificateResponse = ({
+	ok: true;
+	/**
+	 * The certificates that were issued by the KYB Anchor service.
+	 * Typically this will just be a single certificate, but
+	 * it could also be multiple certificates if the service
+	 * issues multiple certificates for a single verification.
+	 *
+	 * Each certificate is represented as a PEM-encoded string.
+	 * The `intermediates` field is optional and may contain
+	 * additional intermediate certificates that are required to
+	 * validate the certificate chain.
+	 */
+	results: ({
+		certificate: string;
+		intermediates?: string[];
+	})[];
+} | {
+	ok: false;
+	error: string;
+});
+
+class KeetaKYBAnchorVerificationNotFoundError extends KeetaAnchorUserError {
+	static override readonly name: string = 'KeetaKYBAnchorVerificationNotFoundError';
+	private readonly KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID!: string;
+	private static readonly KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID = '0a9c4d2e-3b7f-4c1a-9d6e-5f2b8c7a1e30';
+	override readonly logLevel = 'DEBUG';
+
+	constructor(message?: string) {
+		super(message ?? 'Verification ID not found');
+		this.statusCode = 400;
+
+		Object.defineProperty(this, 'KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID', {
+			value: KeetaKYBAnchorVerificationNotFoundError.KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID,
+			enumerable: false
+		});
+	}
+
+	static isInstance(input: unknown): input is KeetaKYBAnchorVerificationNotFoundError {
+		return(this.hasPropWithValue(input, 'KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID', KeetaKYBAnchorVerificationNotFoundError.KeetaKYBAnchorVerificationNotFoundErrorObjectTypeID));
+	}
+}
+
+class KeetaKYBAnchorCertificateNotFoundError extends KeetaAnchorUserError {
+	static override readonly name: string = 'KeetaKYBAnchorCertificateNotFoundError';
+	private readonly KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID!: string;
+	private static readonly KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID = '4e1d8f63-2a90-4b7c-8e35-7c9a0d4f6b21';
+
+	constructor(message?: string) {
+		super(message ?? 'Certificate not found (pending)');
+		this.statusCode = 404;
+
+		Object.defineProperty(this, 'KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID', {
+			value: KeetaKYBAnchorCertificateNotFoundError.KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID,
+			enumerable: false
+		});
+	}
+
+	static isInstance(input: unknown): input is KeetaKYBAnchorCertificateNotFoundError {
+		return(this.hasPropWithValue(input, 'KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID', KeetaKYBAnchorCertificateNotFoundError.KeetaKYBAnchorCertificateNotFoundErrorObjectTypeID));
+	}
+}
+
+class KeetaKYBAnchorCertificatePaymentRequired extends KeetaAnchorUserError {
+	static override readonly name: string = 'KeetaKYBAnchorCertificatePaymentRequired';
+	private readonly KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID!: string;
+	private static readonly KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID = '8b3a52ed-c6f1-4d28-bb70-1e9d3c4a5f72';
+	readonly amount: bigint;
+	readonly token: KeetaNetToken;
+
+	constructor(cost: { amount: bigint | string; token: KeetaNetToken | string; }, message?: string) {
+		super(message ?? 'Payment required for certificate');
+		this.statusCode = 402;
+
+		this.amount = BigInt(cost.amount);
+		this.token = KeetaNet.lib.Account.toAccount<typeof KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN>(cost.token);
+
+		Object.defineProperty(this, 'KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID', {
+			value: KeetaKYBAnchorCertificatePaymentRequired.KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID,
+			enumerable: false
+		});
+	}
+
+	static isInstance(input: unknown): input is KeetaKYBAnchorCertificatePaymentRequired {
+		return(this.hasPropWithValue(input, 'KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID', KeetaKYBAnchorCertificatePaymentRequired.KeetaKYBAnchorCertificatePaymentRequiredObjectTypeID));
+	}
+
+	asErrorResponse(contentType: 'text/plain' | 'application/json'): { error: string; statusCode: number; contentType: string } {
+		let message = this.message;
+		if (contentType === 'application/json') {
+			message = JSON.stringify({
+				ok: false,
+				code: 'KEETA_ANCHOR_KYB_PAYMENT_REQUIRED',
+				data: {
+					cost: {
+						amount: `0x${this.amount.toString(16)}`,
+						token: this.token.publicKeyString.get()
+					}
+				},
+				error: this.message
+			});
+		}
+
+		return({
+			error: message,
+			statusCode: this.statusCode,
+			contentType: contentType
+		});
+	}
+
+	toJSON(): { ok: false; retryable: boolean; error: string; name: string; statusCode: number; amount: string; token: string } {
+		return({
+			ok: false,
+			retryable: this.retryable,
+			error: this.message,
+			name: this.name,
+			statusCode: this.statusCode,
+			amount: `0x${this.amount.toString(16)}`,
+			token: this.token.publicKeyString.get()
+		});
+	}
+
+	static async fromJSON(input: unknown): Promise<KeetaKYBAnchorCertificatePaymentRequired> {
+		const { message, other } = this.extractErrorProperties(input, this);
+
+		// Extract required properties specific to PaymentRequired
+		if (!('amount' in other) || typeof other.amount !== 'string') {
+			throw(new Error('Invalid KeetaKYBAnchorCertificatePaymentRequired JSON object: missing or invalid amount'));
+		}
+
+		if (!('token' in other) || typeof other.token !== 'string') {
+			throw(new Error('Invalid KeetaKYBAnchorCertificatePaymentRequired JSON object: missing or invalid token'));
+		}
+
+		const error = new this(
+			{
+				amount: other.amount,
+				token: other.token
+			},
+			message
+		);
+
+		error.restoreFromJSON(other);
+		return(error);
+	}
+}
+
+export const Errors: {
+	VerificationNotFound: typeof KeetaKYBAnchorVerificationNotFoundError;
+	CertificateNotFound: typeof KeetaKYBAnchorCertificateNotFoundError;
+	PaymentRequired: typeof KeetaKYBAnchorCertificatePaymentRequired;
+} = {
+	/**
+	 * The verification ID was not found
+	 */
+	VerificationNotFound: KeetaKYBAnchorVerificationNotFoundError,
+
+	/**
+	 * The certificate for the verification ID was not found
+	 * (typically this means the verification is still pending)
+	 */
+	CertificateNotFound: KeetaKYBAnchorCertificateNotFoundError,
+
+	/**
+	 * Payment is required for the certificate
+	 */
+	PaymentRequired: KeetaKYBAnchorCertificatePaymentRequired
+}
+
+export async function generateSignedData(account: Signing.SignableAccount): Promise<{ nonce: string; timestamp: string; signature: string; }> {
+	return(await Signing.SignData(account, []));
+}
+
+export async function verifySignedData(request: Pick<KeetaKYBAnchorCreateVerificationRequest, 'account' | 'signed'>): Promise<boolean> {
+	const account = KeetaNet.lib.Account.fromPublicKeyString(request.account);
+	return(await Signing.VerifySignedData(account, [], request.signed));
+}

--- a/src/services/kyb/server.test.ts
+++ b/src/services/kyb/server.test.ts
@@ -1,0 +1,106 @@
+import { test, expect } from 'vitest';
+import { KeetaNetKYBAnchorHTTPServer } from './server.js';
+import * as KeetaNet from '@keetanetwork/keetanet-client';
+import { createNodeAndClient } from '../../lib/utils/tests/node.js';
+import Resolver from '../../lib/resolver.js';
+
+test('KYB Anchor HTTP Server', async function() {
+	const signer = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const { userClient }  = await createNodeAndClient(signer);
+
+	/*
+	 * Create a dummy CA for issuing KYB Certificates
+	 */
+	const kybCAAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const kybCABuilder = new KeetaNet.lib.Utils.Certificate.CertificateBuilder({
+		subjectPublicKey: kybCAAccount,
+		issuer: kybCAAccount,
+		serial: 1,
+		validFrom: new Date(Date.now() - 30_000),
+		validTo: new Date(Date.now() + 120_000)
+	});
+	const kybCA = await kybCABuilder.build();
+
+	/*
+	 * Start the Testing KYB Anchor HTTP Server
+	 */
+	await using server = new KeetaNetKYBAnchorHTTPServer({
+		signer: signer,
+		ca: kybCA,
+		client: userClient,
+		homepage: '<html><body>Hello World</body></html>',
+		kyb: {
+			countryCodes: ['US'],
+			verificationStarted: async function(_ignore_request) {
+				return({
+					ok: true,
+					expectedCost: {
+						min: '0',
+						max: '0',
+						token: userClient.baseToken.publicKeyString.get()
+					}
+				});
+			},
+			getCertificates: async function(_ignore_verificationID) {
+				return([{
+					certificate: ''
+				}]);
+			}
+		}
+	});
+
+	await server.start();
+	expect(server.url).toBeDefined();
+
+	/*
+	 * Add the Testing KYB Anchor Service to the user's metadata and create a resolver
+	 */
+	await userClient.setInfo({
+		name: 'USER',
+		description: 'KYB Anchor Test Root',
+		metadata: Resolver.Metadata.formatMetadata({
+			version: 1,
+			currencyMap: {},
+			services: {
+				kyb: {
+					Test: await server.serviceMetadata()
+				}
+			}
+		})
+	});
+
+	const resolver = new Resolver({
+		client: userClient,
+		root: userClient.account,
+		trustedCAs: []
+	});
+
+	/*
+	 * Look up the metadata for the KYB Anchor Service using the resolver, ensuring the
+	 * `serviceMetadata()` method generated valid metadata
+	 */
+	const foundValidMetadata = await resolver.lookup('kyb', {
+		countryCodes: ['US']
+	});
+
+	expect(foundValidMetadata).toBeDefined();
+	if (foundValidMetadata === undefined) {
+		throw(new Error('internal error: foundValidMetadata is undefined'));
+	}
+
+	expect(foundValidMetadata.Test).toBeDefined();
+	if (!('Test' in foundValidMetadata)) {
+		throw(new Error('internal error: KYB service "Test" not found in metadata'));
+	}
+
+	const checkKYBCertificate = await foundValidMetadata.Test.ca('string');
+	expect(checkKYBCertificate).toEqual(kybCA.toPEM());
+
+	/*
+	 * Verify the home page
+	 */
+	const homeResponse = await fetch(server.url);
+	expect(homeResponse.status).toBe(200);
+	const homeText = await homeResponse.text();
+	expect(homeText).toBe('<html><body>Hello World</body></html>');
+});

--- a/src/services/kyb/server.ts
+++ b/src/services/kyb/server.ts
@@ -1,0 +1,278 @@
+import * as KeetaNet from '@keetanetwork/keetanet-client';
+import * as CurrencyInfo from '@keetanetwork/currency-info';
+
+import type * as KeetaAnchorHTTPServer from '../../lib/http-server/index.js';
+import type { KeetaAnchorMetadataServerConfig } from '../../lib/anchor-metadata-server.js';
+import {
+	KeetaAnchorUserError
+} from '../../lib/error.js';
+import type {
+	KeetaKYBAnchorCreateVerificationRequest,
+	KeetaKYBAnchorCreateVerificationResponse,
+	KeetaKYBAnchorGetCertificateResponse
+} from './common.ts';
+import {
+	assertCreateVerificationRequest,
+	assertCreateVerificationResponse
+} from './common.generated.js';
+import {
+	verifySignedData
+} from './common.js';
+import type * as Signing from '../../lib/utils/signing.js';
+import type { ServiceMetadata } from '../../lib/resolver.ts';
+import { KeetaAnchorMetadataServer } from '../../lib/anchor-metadata-server.js';
+
+/**
+ * The Base certificate type, from the KeetaNet Client
+ *
+ * The KYB Certificate type is a subclass of this, so it will also work
+ */
+type BaseCertificate = InstanceType<typeof KeetaNet.lib.Utils.Certificate.Certificate>;
+
+export interface KeetaAnchorKYBServerConfig extends KeetaAnchorMetadataServerConfig {
+	/**
+	 * The data to use for the index page (optional)
+	 */
+	homepage?: string | (() => Promise<string> | string);
+
+	/**
+	 * The network client to use for submitting blocks
+	 */
+	client: { client: KeetaNet.Client; network: bigint; networkAlias: typeof KeetaNet.Client.Config.networksArray[number] } | KeetaNet.UserClient;
+
+	/**
+	 * Configuration for the KYB Anchor
+	 *
+	 * The flow for a KYB Anchor is as follows:
+	 *      1. Client requests a new verification with a country code,
+	 *           account, and business details from the KYB Anchor Server
+	 *      2. KYB Anchor Server performs the business verification
+	 *           synchronously and responds with a verification ID
+	 *      3. Client requests the certificate for the verification ID
+	 *           (polling) from the KYB Anchor Server
+	 *      4. KYB Anchor Server responds with the certificate(s) for the
+	 *           verification ID (if complete, pending if still in
+	 *           progress, an error if failed)
+	 *      5. Client installs the certificate(s) in their wallet using
+	 *           the KeetaNet Client library
+	 *
+	 * Unlike the KYC flow, there is no hosted journey / web URL: a KYB
+	 * verification is completed from the supplied business details, so
+	 * the user is never redirected.
+	 *
+	 *
+	 *   +-------------------+            +---------------------+             +------------------+
+	 *   |       Client      |            |   KYB Anchor Server |             |   KYB Provider   |
+	 *   +-------------------+            +---------------------+             +------------------+
+	 *         |                                   |                                  |
+	 * (1) Create Verification                     |                                  |
+	 * countryCode, account, business ------------>|                                  |
+	 *         |                           (2) Verify business synchronously -------->|
+	 *         |                                   |<-------------------------- result |
+	 *         |<------------------------- verificationID                             |
+	 *         |                                   |
+	 * (3) Poll certificate for verificationID --->|
+	 *         |                                   |
+	 *         |<-------------------------- (4) Pending / Certificate(s) / Error
+	 *         |                    (repeat #3 until complete)
+	 *         |
+	 * (5) Install certificate(s) in wallet using KeetaNet Client library
+	 */
+	kyb: {
+		/**
+		 * Notification that a verification has been started (optional)
+		 *
+		 * This method performs the business verification.  Because KYB
+		 * is synchronous, the provider typically completes the
+		 * verification here and stores the result keyed by the returned
+		 * verification ID, which the client then polls with
+		 * `getCertificates`.
+		 *
+		 * If this method is not provided, the server will generate a
+		 * random verification ID and the provider is expected to resolve
+		 * the verification out of band before `getCertificates` is
+		 * called.
+		 */
+		verificationStarted?: (request: KeetaKYBAnchorCreateVerificationRequest) => Promise<Partial<KeetaKYBAnchorCreateVerificationResponse> | undefined>;
+
+		/**
+		 * Retrieve the certificate for a verification
+		 *
+		 * This should return the certificate(s) for the
+		 * verification ID.  If the verification is still
+		 * in progress, it should throw an `CertificateNotFound`
+		 * error.
+		 * If the verification has failed permanently, it should
+		 * throw a `KeetaAnchorUserError` with an appropriate
+		 * error message or `VerificationNotFound` if the
+		 * verification ID is not found.
+		 */
+		getCertificates: (verificationID: string) => Promise<Extract<KeetaKYBAnchorGetCertificateResponse, { ok: true; }>['results']>;
+
+		/**
+		 * Country codes that this KYB provider can service (default is all country codes)
+		 */
+		countryCodes?: (CurrencyInfo.Country | CurrencyInfo.ISOCountryCode)[];
+	}
+
+	/**
+	 * The certificate to use for signing certificates
+	 */
+	ca: BaseCertificate;
+
+	/**
+	 * The account to use for signing certificates
+	 */
+	signer: Signing.SignableAccount;
+
+	/**
+	 * Additional routes to add to the server (optional)
+	 */
+	routes?: KeetaAnchorHTTPServer.Routes;
+};
+
+export class KeetaNetKYBAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNullable<ServiceMetadata['services']['kyb']>[string], KeetaAnchorKYBServerConfig> implements Required<KeetaAnchorKYBServerConfig> {
+	readonly homepage: NonNullable<KeetaAnchorKYBServerConfig['homepage']>;
+	readonly client: KeetaAnchorKYBServerConfig['client'];
+	readonly signer: NonNullable<KeetaAnchorKYBServerConfig['signer']>;
+	readonly ca: KeetaAnchorKYBServerConfig['ca'];
+	readonly kyb: KeetaAnchorKYBServerConfig['kyb'];
+	readonly routes: NonNullable<KeetaAnchorKYBServerConfig['routes']>;
+	readonly #countryCodes?: CurrencyInfo.Country[] | undefined;
+
+	constructor(config: KeetaAnchorKYBServerConfig) {
+		super(config);
+
+		this.homepage = config.homepage ?? '';
+		this.client = config.client;
+		this.signer = config.signer;
+		this.ca = config.ca;
+		this.kyb = config.kyb;
+		this.routes = config.routes ?? {};
+
+		if (config.kyb.countryCodes) {
+			this.#countryCodes = config.kyb.countryCodes.map(function(inputCode) {
+				if (CurrencyInfo.Country.isCountryCode(inputCode)) {
+					return(new CurrencyInfo.Country(inputCode));
+				}
+
+				return(inputCode);
+			});
+		}
+	}
+
+	protected async initRoutes(config: KeetaAnchorKYBServerConfig): Promise<KeetaAnchorHTTPServer.Routes> {
+		const routes: KeetaAnchorHTTPServer.Routes = {};
+
+		/**
+		 * If a homepage is provided, setup the route for it
+		 */
+		if ('homepage' in config) {
+			routes['GET /'] = async function() {
+				let homepageData: string;
+				if (typeof config.homepage === 'string') {
+					homepageData = config.homepage;
+				} else {
+					if (!config.homepage) {
+						throw(new Error('internal error: No homepage function provided'));
+					}
+
+					homepageData = await config.homepage();
+				}
+
+				return({
+					output: homepageData,
+					contentType: 'text/html'
+				});
+			};
+		}
+
+		/**
+		 * Begin the KYB verification process
+		 * with this KYB provider
+		 */
+		routes['POST /api/createVerification'] = async function(_ignore_params, bodyInput) {
+			if (bodyInput === null || typeof bodyInput !== 'object' || !('request' in bodyInput)) {
+				throw(new KeetaAnchorUserError('Invalid request'));
+			}
+
+			const body = assertCreateVerificationRequest(bodyInput.request);
+			const valid = await verifySignedData(body);
+			if (!valid) {
+				throw(new KeetaAnchorUserError('Invalid signature'));
+			}
+
+			/* XXX:TODO: Validate that the nonce is unique (within a reasonable time frame) */
+
+			let response: Partial<KeetaKYBAnchorCreateVerificationResponse> | undefined = {};
+			if (config.kyb.verificationStarted) {
+				response = await config.kyb.verificationStarted(body);
+			}
+
+			response ??= {};
+
+			if (response?.ok === false) {
+				throw(new KeetaAnchorUserError(response.error ?? 'Unknown error'));
+			}
+
+			response.ok = true;
+			if (!response.ok) {
+				throw(new Error('internal error: invalid response'));
+			}
+			response.id ??= crypto.randomUUID();
+
+			response.expectedCost = {
+				min: '0',
+				max: '0',
+				token: KeetaNet.lib.Account.generateBaseAddresses(config.client.network).baseToken.publicKeyString.get(),
+				...response.expectedCost
+			};
+
+			const responseValidated = assertCreateVerificationResponse(response);
+
+			return({
+				output: JSON.stringify(responseValidated)
+			});
+		};
+
+		/**
+		 * Get the certificate for the
+		 * KYB verification
+		 */
+		routes['GET /api/getCertificates/:verificationID'] = async function(params) {
+			const verificationID = params.get('verificationID');
+			if (verificationID === undefined) {
+				throw(new KeetaAnchorUserError('No verification ID provided'));
+			}
+
+			const certificates = await config.kyb.getCertificates(verificationID);
+
+			const response: KeetaKYBAnchorGetCertificateResponse = {
+				ok: true,
+				results: certificates
+			};
+
+			return({
+				output: JSON.stringify(response)
+			});
+		};
+
+		return({
+			...config.routes,
+			...routes
+		});
+	}
+
+	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['kyb']>[string]> {
+		return({
+			ca: this.ca.toPEM(),
+			countryCodes: this.#countryCodes?.map(function(country) {
+				return(country.code);
+			}) ?? [],
+			operations: {
+				createVerification: (new URL('/api/createVerification', this.url)).toString(),
+				getCertificates: (new URL('/api/getCertificates', this.url)).toString() + '/{id}'
+			}
+		});
+	}
+}


### PR DESCRIPTION
Built in collaboration with @schenkty as part of project Gildor.

## What this adds

A dedicated `kyb` (Know Your Business) service, mirroring the existing `kyc` service, so anchors can run business verification through the standard anchor protocol. Today the SDK has no business surface, so a KYB-capable anchor has nothing to wire into. This closes that gap.

## Why a separate service (not an entityType flag on kyc)

KYC and KYB are different shapes:

- **KYC** is asynchronous with a hosted journey: `createVerification` returns a `webURL`, the user completes verification in a browser, then the client polls `getCertificates`. The KYC server treats a missing `webURL` as a hard error.
- **KYB** is synchronous and has no user-facing redirect. The business is verified from details supplied in the request (names, addresses, associated persons, websites). There is no journey to redirect to.

Bolting an `entityType` onto `kyc` would force the redirect logic to branch on every path. A sibling `kyb` service keeps the working individual KYC flow untouched and mirrors the closest existing pattern instead of inventing a new one.

## Shape

The `kyb` surface mirrors `kyc` minus the webURL:

- `createVerification` carries `business: { names, addresses?, persons?, websites? }` alongside the usual `countryCodes`, `account`, `signed`.
- The server verifies synchronously (provider does the work in `verificationStarted`) and returns a verification id.
- `getCertificates` returns the issued business certificate(s), polled by id, same as KYC.

## Files

- `src/services/kyb/common.ts`: request/response types, business detail types, typed errors (`VerificationNotFound`, `CertificateNotFound`, `PaymentRequired`)
- `src/services/kyb/common.generated.ts`: typia assert validators
- `src/services/kyb/server.ts`: `KeetaNetKYBAnchorHTTPServer`, no mandatory webURL, synchronous `getCertificates`
- `src/services/kyb/client.ts`: `KeetaKYBAnchorClient`, resolves `kyb` providers and runs `createVerification` + `getCertificates`
- `src/lib/resolver.ts`: `kyb` in `ServiceMetadata`, `ServiceSearchCriteria`, lookup dispatch map, `lookupKYBServices`, `listSupportedKYBCountries`, and the assert helpers
- `src/client/index.ts`: export the `KYB` namespace (`KYB.Client`)
- `src/lib/error.ts`: register the `kyb` `Errors` module in the cross-service deserialization mapping
- tests: `common.test.ts` (error round-trip), `server.test.ts` (metadata publish + resolve), `client.test.ts` (full create to certificate round-trip with a business cert)

## Verification

- `npm run tsc -- --noEmit`: clean
- `make do-lint`: clean
- `make test`: 44 files, 555 passed, 0 failures (includes the 5 new KYB tests)

## Notes for review

- The error-registry edit in `src/lib/error.ts` is required: `getErrorClassMapping` imports each service's `Errors` module so any service error can be deserialized anywhere. KYB needed adding there, same as KYC/FX/asset-movement.
- The operations validator `assertValidOperationsKYB` follows the same `XXX:TODO` deep-validation stub as KYC and FX; happy to tighten it if preferred.
- The business detail field set (names, addresses, persons, websites) is the minimal disambiguation set a synchronous KYB lookup needs. If the canonical business request should carry more (registration number, jurisdiction up front), say so and I will extend the request type.
