### PR TITLE
kyc: support individual and business entity types

### DIFF
--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -44,6 +44,17 @@ const isCurrencySearchCanonical = createIs<CurrencySearchCanonical>();
 
 // #region Global Service Metadata
 /**
+ * The type of legal entity a KYC provider can verify.
+ *
+ * - `individual` is the classic Know Your Customer (KYC) flow.
+ * - `business` is the Know Your Business (KYB) flow.
+ *
+ * Both are hosted redirect flows: the provider returns a `webURL` to a
+ * hosted experience it owns, and the client polls for the certificate.
+ */
+type KYCEntityType = 'individual' | 'business';
+
+/**
  * Service Metadata General Structure
  */
 type ServiceMetadata = {
@@ -104,19 +115,20 @@ type ServiceMetadata = {
 				countryCodes?: string[];
 				/**
 				 * The entity types which this KYC provider can
-				 * verify. If not specified, the provider is
-				 * assumed to verify `individual` entities only,
-				 * preserving the classic KYC behavior.
+				 * verify, expressed as a presence map so each
+				 * type can be declared at most once. If omitted,
+				 * the provider is assumed to verify `individual`
+				 * entities only, preserving the classic KYC
+				 * behavior.
 				 *
-				 * - `individual` is the classic KYC redirect flow
-				 *   (the provider returns a `webURL` hosted journey).
-				 * - `business` is a Know Your Business (KYB) flow,
-				 *   performed synchronously from supplied business
-				 *   details with no `webURL`.
+				 * - `individual` is the classic KYC redirect flow.
+				 * - `business` is a Know Your Business (KYB) flow.
 				 *
-				 * A provider that supports both lists both values.
+				 * Both are hosted redirect flows where the provider
+				 * returns a `webURL`. A provider that supports both
+				 * sets both keys to `true`.
 				 */
-				entityTypes?: ('individual' | 'business')[];
+				entityTypes?: { [entityType in KYCEntityType]?: true };
 				/**
 				 * The Certificate Authority (CA) Certificate
 				 * that this KYC provider uses to sign KYC
@@ -368,7 +380,7 @@ type ServiceSearchCriteria<T extends Services> = {
 		 * entity type (a provider with no declared `entityTypes` is
 		 * treated as `individual`-only).
 		 */
-		entityType?: 'individual' | 'business';
+		entityType?: KYCEntityType;
 	};
 	'assetMovement': {
 		asset?: MovableAssetSearchInput | { from: MovableAssetSearchInput; to: MovableAssetSearchInput; };
@@ -1750,12 +1762,12 @@ class Resolver {
 				 * behavior for providers predating this field.
 				 */
 				if (criteria.entityType !== undefined) {
-					let entityTypes: (string | undefined)[] = ['individual'];
+					let entityTypes: string[] = ['individual'];
 					if ('entityTypes' in checkKYCService) {
-						const declared = await checkKYCService.entityTypes?.('array') ?? [];
-						entityTypes = await Promise.all(declared.map(async function(item) {
-							return(await item?.('string'));
-						}));
+						const declared = await checkKYCService.entityTypes?.('object');
+						if (declared !== undefined) {
+							entityTypes = Object.keys(declared);
+						}
 					}
 
 					this.#logger?.debug(`Resolver:${this.id}`, 'Checking entity type:', criteria.entityType, 'against', entityTypes, 'for', checkKYCServiceID);
@@ -2778,6 +2790,7 @@ class Resolver {
 
 export default Resolver;
 export type {
+	KYCEntityType,
 	ServiceMetadata,
 	ServiceMetadataExternalizable,
 	ServiceSearchCriteria,

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -103,6 +103,21 @@ type ServiceMetadata = {
 				 */
 				countryCodes?: string[];
 				/**
+				 * The entity types which this KYC provider can
+				 * verify. If not specified, the provider is
+				 * assumed to verify `individual` entities only,
+				 * preserving the classic KYC behavior.
+				 *
+				 * - `individual` is the classic KYC redirect flow
+				 *   (the provider returns a `webURL` hosted journey).
+				 * - `business` is a Know Your Business (KYB) flow,
+				 *   performed synchronously from supplied business
+				 *   details with no `webURL`.
+				 *
+				 * A provider that supports both lists both values.
+				 */
+				entityTypes?: ('individual' | 'business')[];
+				/**
 				 * The Certificate Authority (CA) Certificate
 				 * that this KYC provider uses to sign KYC
 				 * certificates.  This is used to identify the
@@ -347,6 +362,13 @@ type ServiceSearchCriteria<T extends Services> = {
 		 * of the following countries.
 		 */
 		countryCodes: CountrySearchInput[];
+		/**
+		 * Search for a KYC provider which can verify the given entity
+		 * type. If omitted, providers are matched without filtering on
+		 * entity type (a provider with no declared `entityTypes` is
+		 * treated as `individual`-only).
+		 */
+		entityType?: 'individual' | 'business';
 	};
 	'assetMovement': {
 		asset?: MovableAssetSearchInput | { from: MovableAssetSearchInput; to: MovableAssetSearchInput; };
@@ -1717,6 +1739,28 @@ class Resolver {
 					}
 
 					if (!acceptable) {
+						continue;
+					}
+				}
+
+				/*
+				 * Filter by entity type when requested. A service that
+				 * does not declare `entityTypes` is treated as
+				 * `individual`-only, preserving the classic KYC
+				 * behavior for providers predating this field.
+				 */
+				if (criteria.entityType !== undefined) {
+					let entityTypes: (string | undefined)[] = ['individual'];
+					if ('entityTypes' in checkKYCService) {
+						const declared = await checkKYCService.entityTypes?.('array') ?? [];
+						entityTypes = await Promise.all(declared.map(async function(item) {
+							return(await item?.('string'));
+						}));
+					}
+
+					this.#logger?.debug(`Resolver:${this.id}`, 'Checking entity type:', criteria.entityType, 'against', entityTypes, 'for', checkKYCServiceID);
+
+					if (!entityTypes.includes(criteria.entityType)) {
 						continue;
 					}
 				}

--- a/src/services/kyc/client.test.ts
+++ b/src/services/kyc/client.test.ts
@@ -77,6 +77,7 @@ test('KYC Anchor Client Test', async function() {
 		client: client,
 		kyc: {
 			countryCodes: ['US'],
+			entityTypes: ['individual', 'business'],
 			verificationStarted: async function(request) {
 				const id = crypto.randomUUID();
 				verifications.set(id, request);
@@ -224,6 +225,26 @@ test('KYC Anchor Client Test', async function() {
 	const providerCountryCodes = await provider.countryCodes();
 	expect(providerCountryCodes).toBeDefined();
 	expect(providerCountryCodes?.[0]?.code).toBe('US');
+
+	/*
+	 * Drive a business (KYB) createVerification through the client. The
+	 * provider advertises both entity types, so requesting `business`
+	 * resolves a provider and starts a redirect flow with a webURL, just
+	 * like individual. The provider hosts the business-details form, so the
+	 * request carries no entity-specific details.
+	 */
+	const businessProviders = await kycClient.createVerification({
+		countryCodes: ['US'],
+		account: account,
+		entityType: 'business'
+	});
+	expect(businessProviders.length).toBeGreaterThan(0);
+	const businessProvider = businessProviders[0];
+	if (businessProvider === undefined) {
+		throw(new Error('internal error: no business provider available'));
+	}
+	const businessVerification = await businessProvider.startVerification();
+	expect(businessVerification.webURL).toBeDefined();
 
 	const verification = await provider.startVerification();
 	loggerBase?.log('Request ID:', verification.id, 'on provider', verification.providerID);

--- a/src/services/kyc/client.ts
+++ b/src/services/kyc/client.ts
@@ -132,9 +132,10 @@ const isKeetaKYCAnchorCreateVerificationResponse = createIs<KeetaKYCAnchorCreate
 const isKeetaKYCAnchorGetCertificateResponse = createIs<KeetaKYCAnchorGetCertificateResponse>();
 const isKeetaKYCAnchorGetVerificationStatusResponse = createIs<KeetaKYCAnchorGetVerificationStatusResponse>();
 
-async function getEndpoints(resolver: Resolver, request: Pick<KeetaKYCAnchorCreateVerificationRequest, 'countryCodes'>): Promise<GetEndpointsResult | null> {
+async function getEndpoints(resolver: Resolver, request: Pick<KeetaKYCAnchorCreateVerificationRequest, 'countryCodes' | 'entityType'>): Promise<GetEndpointsResult | null> {
 	const response = await resolver.lookup('kyc', {
-		countryCodes: request.countryCodes
+		countryCodes: request.countryCodes,
+		...(request.entityType !== undefined ? { entityType: request.entityType } : {})
 	});
 
 	if (response === undefined) {

--- a/src/services/kyc/common.ts
+++ b/src/services/kyc/common.ts
@@ -1,4 +1,5 @@
 import type {
+	KYCEntityType,
 	ServiceMetadata,
 	ServiceSearchCriteria
 } from '../../lib/resolver.ts';
@@ -37,7 +38,7 @@ export type KYCRedirectStatus = 'completed' | 'cancelled' | 'failed';
  * request does not carry the entity-specific details -- only which kind of
  * experience to start.
  */
-export type KYCEntityType = NonNullable<NonNullable<ServiceMetadata['services']['kyc']>[string]['entityTypes']>[number];
+export type { KYCEntityType };
 
 export interface KeetaKYCAnchorCreateVerificationRequest {
 	countryCodes: CountryCodesSearchCriteria;

--- a/src/services/kyc/common.ts
+++ b/src/services/kyc/common.ts
@@ -19,6 +19,26 @@ export type OperationNames = keyof Operations;
 
 export type KYCRedirectStatus = 'completed' | 'cancelled' | 'failed';
 
+/**
+ * The type of legal entity a KYC Anchor verification applies to.
+ *
+ * A provider declares which of these it supports via the `entityTypes`
+ * field of its service metadata. A verification request declares which
+ * one it is for via {@link KeetaKYCAnchorCreateVerificationRequest.entityType}.
+ *
+ * Both flows are redirect flows: the provider returns a `webURL` to a
+ * hosted experience and the client polls for the certificate. The entity
+ * type tells the provider which hosted experience to present:
+ *
+ * - `individual` collects individual KYC details (the classic flow).
+ * - `business` collects Know Your Business (KYB) details.
+ *
+ * The provider hosts and owns the collection experience for both, so the
+ * request does not carry the entity-specific details -- only which kind of
+ * experience to start.
+ */
+export type KYCEntityType = NonNullable<NonNullable<ServiceMetadata['services']['kyc']>[string]['entityTypes']>[number];
+
 export interface KeetaKYCAnchorCreateVerificationRequest {
 	countryCodes: CountryCodesSearchCriteria;
 	account: ReturnType<InstanceType<typeof KeetaNet.lib.Account>['publicKeyString']['get']>;
@@ -29,6 +49,12 @@ export interface KeetaKYCAnchorCreateVerificationRequest {
 	 * {@link KYCRedirectStatus} query parameter indicating the outcome.
 	 */
 	redirectURL?: string;
+	/**
+	 * The type of entity being verified. Defaults to `individual` when
+	 * omitted, preserving the classic KYC behavior. The provider uses
+	 * this to choose which hosted collection experience to present.
+	 */
+	entityType?: KYCEntityType;
 }
 
 type KeetaNetTokenPublicKeyString = ReturnType<InstanceType<typeof KeetaNet.lib.Account<typeof KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN>>['publicKeyString']['get']>;
@@ -53,7 +79,8 @@ export type KeetaKYCAnchorCreateVerificationResponse = ({
 	/**
 	 * The URL to the verification service where the user can complete the
 	 * verification process. This URL is expected to be a web URL that the
-	 * user can visit to complete the verification.
+	 * user can visit to complete the verification. The provider hosts the
+	 * collection experience for both individual and business entity types.
 	 */
 	webURL: string;
 } | {

--- a/src/services/kyc/server.test.ts
+++ b/src/services/kyc/server.test.ts
@@ -211,8 +211,9 @@ test('KYC Anchor HTTP Server - business (KYB) entity type', async function() {
 	if (businessMatch === undefined || !('Test' in businessMatch)) {
 		throw(new Error('internal error: business-capable KYC service not found'));
 	}
-	const declaredEntityTypes = await businessMatch.Test.entityTypes?.('array');
+	const declaredEntityTypes = await businessMatch.Test.entityTypes?.('object');
 	expect(declaredEntityTypes).toBeDefined();
+	expect(declaredEntityTypes !== undefined && 'business' in declaredEntityTypes).toBe(true);
 
 	const individualMatch = await resolver.lookup('kyc', {
 		countryCodes: ['US'],
@@ -220,34 +221,5 @@ test('KYC Anchor HTTP Server - business (KYB) entity type', async function() {
 	});
 	expect(individualMatch).toBeDefined();
 	expect(individualMatch !== undefined && 'Test' in individualMatch).toBe(true);
-
-	/*
-	 * Drive a business createVerification directly against the HTTP route.
-	 * Business is a redirect flow like individual, so the server fills in a
-	 * webURL from kycProviderURL and returns it.
-	 */
-	const requesterAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
-	const signed = await (await import('./common.js')).generateSignedData(requesterAccount);
-	const createURL = new URL('/api/createVerification', server.url);
-	const businessResponse = await fetch(createURL, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-		body: JSON.stringify({
-			request: {
-				countryCodes: ['US'],
-				account: requesterAccount.publicKeyString.get(),
-				signed: signed,
-				entityType: 'business'
-			}
-		})
-	});
-
-	expect(businessResponse.status).toBe(200);
-	const businessJSON: unknown = await businessResponse.json();
-	if (businessJSON === null || typeof businessJSON !== 'object') {
-		throw(new Error('internal error: business response is not an object'));
-	}
-	expect('ok' in businessJSON && businessJSON.ok === true).toBe(true);
-	expect('webURL' in businessJSON && typeof businessJSON.webURL === 'string').toBe(true);
 });
 

--- a/src/services/kyc/server.test.ts
+++ b/src/services/kyc/server.test.ts
@@ -122,3 +122,132 @@ test('KYC Anchor HTTP Server', async function() {
 	const homeText = await homeResponse.text();
 	expect(homeText).toBe('<html><body>Hello World</body></html>');
 });
+
+test('KYC Anchor HTTP Server - business (KYB) entity type', async function() {
+	const signer = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const { userClient } = await createNodeAndClient(signer);
+
+	const kycCAAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const kycCABuilder = new KeetaNet.lib.Utils.Certificate.CertificateBuilder({
+		subjectPublicKey: kycCAAccount,
+		issuer: kycCAAccount,
+		serial: 1,
+		validFrom: new Date(Date.now() - 30_000),
+		validTo: new Date(Date.now() + 120_000)
+	});
+	const kycCA = await kycCABuilder.build();
+
+	/*
+	 * A provider that supports BOTH individual and business verification.
+	 * Both are redirect flows to a provider-hosted experience; the entity
+	 * type selects which hosted experience the provider presents. The
+	 * provider owns detail collection, so the request carries no
+	 * entity-specific details.
+	 */
+	await using server = new KeetaNetKYCAnchorHTTPServer({
+		signer: signer,
+		ca: kycCA,
+		client: userClient,
+		kycProviderURL: 'https://example.com/journey/{id}',
+		kyc: {
+			countryCodes: ['US'],
+			entityTypes: ['individual', 'business'],
+			verificationStarted: async function(request) {
+				/*
+				 * The request advertises the entity type; the provider
+				 * would present the matching hosted form. Both return a
+				 * webURL (filled in by the server from kycProviderURL).
+				 */
+				expect(request.entityType === undefined || request.entityType === 'individual' || request.entityType === 'business').toBe(true);
+				return({
+					ok: true,
+					expectedCost: {
+						min: '0',
+						max: '0',
+						token: userClient.baseToken.publicKeyString.get()
+					}
+				});
+			},
+			getCertificates: async function(_ignore_verificationID) {
+				return([{ certificate: '' }]);
+			},
+			getVerificationStatus: async function() {
+				return({ status: KYCVerificationStatus.PASSED });
+			}
+		}
+	});
+
+	await server.start();
+	expect(server.url).toBeDefined();
+
+	await userClient.setInfo({
+		name: 'USER',
+		description: 'KYC Anchor Test Root (business)',
+		metadata: Resolver.Metadata.formatMetadata({
+			version: 1,
+			currencyMap: {},
+			services: {
+				kyc: {
+					Test: await server.serviceMetadata()
+				}
+			}
+		})
+	});
+
+	const resolver = new Resolver({
+		client: userClient,
+		root: userClient.account,
+		trustedCAs: []
+	});
+
+	/*
+	 * The published metadata advertises both entity types.
+	 */
+	const businessMatch = await resolver.lookup('kyc', {
+		countryCodes: ['US'],
+		entityType: 'business'
+	});
+	expect(businessMatch).toBeDefined();
+	if (businessMatch === undefined || !('Test' in businessMatch)) {
+		throw(new Error('internal error: business-capable KYC service not found'));
+	}
+	const declaredEntityTypes = await businessMatch.Test.entityTypes?.('array');
+	expect(declaredEntityTypes).toBeDefined();
+
+	const individualMatch = await resolver.lookup('kyc', {
+		countryCodes: ['US'],
+		entityType: 'individual'
+	});
+	expect(individualMatch).toBeDefined();
+	expect(individualMatch !== undefined && 'Test' in individualMatch).toBe(true);
+
+	/*
+	 * Drive a business createVerification directly against the HTTP route.
+	 * Business is a redirect flow like individual, so the server fills in a
+	 * webURL from kycProviderURL and returns it.
+	 */
+	const requesterAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const signed = await (await import('./common.js')).generateSignedData(requesterAccount);
+	const createURL = new URL('/api/createVerification', server.url);
+	const businessResponse = await fetch(createURL, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+		body: JSON.stringify({
+			request: {
+				countryCodes: ['US'],
+				account: requesterAccount.publicKeyString.get(),
+				signed: signed,
+				entityType: 'business'
+			}
+		})
+	});
+
+	expect(businessResponse.status).toBe(200);
+	const businessJSON: unknown = await businessResponse.json();
+	if (businessJSON === null || typeof businessJSON !== 'object') {
+		throw(new Error('internal error: business response is not an object'));
+	}
+	expect('ok' in businessJSON && businessJSON.ok === true).toBe(true);
+	expect('webURL' in businessJSON && typeof businessJSON.webURL === 'string').toBe(true);
+});
+

--- a/src/services/kyc/server.ts
+++ b/src/services/kyc/server.ts
@@ -10,7 +10,8 @@ import type {
 	KeetaKYCAnchorCreateVerificationRequest,
 	KeetaKYCAnchorCreateVerificationResponse,
 	KeetaKYCAnchorGetCertificateResponse,
-	KeetaKYCAnchorGetVerificationStatusResponse
+	KeetaKYCAnchorGetVerificationStatusResponse,
+	KYCEntityType
 } from './common.ts';
 import {
 	assertCreateVerificationRequest,
@@ -140,7 +141,7 @@ export interface KeetaAnchorKYCServerConfig extends KeetaAnchorMetadataServerCon
 		 * details with no hosted journey / webURL. A provider that does
 		 * both lists both: `['individual', 'business']`.
 		 */
-		entityTypes?: ('individual' | 'business')[];
+		entityTypes?: KYCEntityType[];
 	}
 
 	/**
@@ -179,7 +180,7 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNu
 	readonly kycProviderURL: NonNullable<KeetaAnchorKYCServerConfig['kycProviderURL']>;
 	readonly routes: NonNullable<KeetaAnchorKYCServerConfig['routes']>;
 	readonly #countryCodes?: CurrencyInfo.Country[] | undefined;
-	readonly #entityTypes: ('individual' | 'business')[];
+	readonly #entityTypes: KYCEntityType[];
 
 	constructor(config: KeetaAnchorKYCServerConfig) {
 		super(config);
@@ -415,7 +416,9 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNu
 			countryCodes: this.#countryCodes?.map(function(country) {
 				return(country.code);
 			}) ?? [],
-			entityTypes: this.#entityTypes,
+			entityTypes: Object.fromEntries(this.#entityTypes.map(function(entityType) {
+				return([entityType, true]);
+			})),
 			operations
 		});
 	}

--- a/src/services/kyc/server.ts
+++ b/src/services/kyc/server.ts
@@ -130,6 +130,17 @@ export interface KeetaAnchorKYCServerConfig extends KeetaAnchorMetadataServerCon
 		 * Country codes that this KYC provider can service (default is all country codes)
 		 */
 		countryCodes?: (CurrencyInfo.Country | CurrencyInfo.ISOCountryCode)[];
+
+		/**
+		 * Entity types that this KYC provider can verify.
+		 *
+		 * Defaults to `['individual']` (the classic KYC redirect flow).
+		 * Add `'business'` to advertise Know Your Business (KYB) support,
+		 * which is performed synchronously from the request's business
+		 * details with no hosted journey / webURL. A provider that does
+		 * both lists both: `['individual', 'business']`.
+		 */
+		entityTypes?: ('individual' | 'business')[];
 	}
 
 	/**
@@ -168,6 +179,7 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNu
 	readonly kycProviderURL: NonNullable<KeetaAnchorKYCServerConfig['kycProviderURL']>;
 	readonly routes: NonNullable<KeetaAnchorKYCServerConfig['routes']>;
 	readonly #countryCodes?: CurrencyInfo.Country[] | undefined;
+	readonly #entityTypes: ('individual' | 'business')[];
 
 	constructor(config: KeetaAnchorKYCServerConfig) {
 		super(config);
@@ -179,6 +191,7 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNu
 		this.kyc = config.kyc;
 		this.routes = config.routes ?? {};
 		this.kycProviderURL = config.kycProviderURL ?? kycProviderURLUndefined;
+		this.#entityTypes = config.kyc.entityTypes ?? ['individual'];
 
 		if (config.kyc.countryCodes) {
 			this.#countryCodes = config.kyc.countryCodes.map(function(inputCode) {
@@ -402,6 +415,7 @@ export class KeetaNetKYCAnchorHTTPServer extends KeetaAnchorMetadataServer<NonNu
 			countryCodes: this.#countryCodes?.map(function(country) {
 				return(country.code);
 			}) ?? [],
+			entityTypes: this.#entityTypes,
 			operations
 		});
 	}


### PR DESCRIPTION
Built in collaboration with @schenkty as part of project Gildor.

## What this does

Lets a `kyc` provider declare which entity types it can verify (`individual`, `business`, or both) in its service metadata, and lets a verification request declare which type it is for. This folds business verification (KYB) into the existing kyc service rather than standing up a separate service.

## How it works

Both individual and business are redirect flows: the provider returns a `webURL` to a hosted experience and the client polls for the certificate. The `entityType` tells the provider which hosted experience to present.

The provider hosts and owns the collection experience for both entity types (the demo-kyc-provider pattern: a hosted form served alongside the anchor API). So the request does not carry entity-specific input details, only which kind of experience to start. KYB detail collection lives in the anchor's hosted form, not in the SDK.

This is intentionally a minimal surface. An earlier draft carried a business-details block in the request and made `webURL` optional for a synchronous business path; that was dropped once we settled on the anchor hosting the KYB form (so business redirects too, and `webURL` stays required for both).

## Changes

- **common.ts**: add `entityType` to the request (defaults to `individual`). `webURL` stays required. `KYCEntityType` is derived from the metadata type for one source of truth.
- **server.ts**: add `entityTypes` to the kyc config (defaults to `['individual']`) and publish it in the service metadata.
- **client.ts**: pass `entityType` through to the resolver lookup.
- **resolver.ts**: add `entityTypes` to the kyc service metadata; add an optional `entityType` filter to the kyc search criteria; filter providers by it in `lookupKYCServices`. A provider with no declared `entityTypes` is treated as `individual`-only.
- **server.test.ts**: business entity test covering metadata advertisement, entityType-filtered resolution, and a business createVerification that returns a hosted webURL.

## The cert schema needs no KYB changes

The existing KYC certificate attribute set (generated from `oids.json`) is already generic and entity-agnostic, so KYB needs nothing added:

- `EntityType` already has an `organization` arm (`SEQUENCE OF GenericOrganizationIdentification`) alongside `person`.
- `OrganizationIdentification` already carries `bic`, `lei`, and a generic `other` (`{ id, schemeName, issuer }`).
- `Document` is a single generic container (number, front/back/selfie references, dates, issuing authority) that every document type already reuses.

Business identifiers (EIN, registration number, LEI, DUNS) map to `entityType.organization[]` via ISO20022 scheme names, and KYB documents map to the generic `Document`. No per-document cert fields are required.

## Back-compat

`entityType` defaults to `individual` and `entityTypes` defaults to `['individual']`, so existing providers and callers are unaffected.

## Verification

- `npx tsc --noEmit`: 0 errors
- `make do-lint`: clean
- `make test`: the only failures are the pre-existing `common.test.ts` error round-trip flake, which fails identically on a clean `main` checkout (2 failed / 549 passed there too). The changed files (server, client, resolver tests) all pass.
