### PR TITLE
Fix FX Resolver for CurrencyMap

### DIFF
--- a/src/lib/resolver.generated.ts
+++ b/src/lib/resolver.generated.ts
@@ -1,0 +1,15 @@
+import { createAssert, createIs } from "typia";
+import type { CurrencySearchCanonical, CurrencySearchInput, ExternalURL, ServiceMetadata, ToJSONValuizable } from "./resolver.js";
+import type { SignableServiceMetadata } from "./anchor-metadata-server.js";
+
+export const isCurrencySearchCanonical: (input: unknown) => input is CurrencySearchCanonical = createIs<CurrencySearchCanonical>();
+export const isCurrencySearchInput: (input: unknown) => input is CurrencySearchInput = createIs<CurrencySearchInput>();
+
+/**
+ * Check if a value is an ExternalURL
+ */
+export const isExternalURL: (input: unknown) => input is ExternalURL = createIs<ExternalURL>();
+
+export const assertServiceMetadata: (input: unknown) => ToJSONValuizable<ServiceMetadata> = createAssert<ToJSONValuizable<ServiceMetadata>>();
+export const assertSignableServiceMetadataOperations: (input: unknown) => SignableServiceMetadata['operations'] = createAssert<SignableServiceMetadata['operations']>();
+export const assertSignableServiceMetadataLegal: (input: unknown) => NonNullable<SignableServiceMetadata['legal']> = createAssert<NonNullable<SignableServiceMetadata['legal']>>();

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -18,6 +18,7 @@ async function setupForResolverTests() {
 	const testCurrencyUSD = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
 	const testCurrencyMXN = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
 	const testCurrencyBTC = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
+	const testCurrencyETH = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
 
 	const { userClient, fees } = await createNodeAndClient(testAccount);
 
@@ -125,6 +126,17 @@ async function setupForResolverTests() {
 							to: [testCurrencyMXN.publicKeyString.get()],
 							kycProviders: ['']
 						}]
+					},
+					keeta_fx_unmapped: {
+						operations: {
+							getQuote: 'https://fx-unmapped.keeta.com/api/v1/getQuote',
+							createExchange: 'https://fx-unmapped.keeta.com/api/v1/createExchange'
+						},
+						from: [{
+							currencyCodes: [testCurrencyETH.publicKeyString.get()],
+							to: [testCurrencyUSD.publicKeyString.get()],
+							kycProviders: ['']
+						}]
 					}
 				},
 				banking: {
@@ -207,7 +219,8 @@ async function setupForResolverTests() {
 		tokens: {
 			USD: testCurrencyUSD,
 			MXN: testCurrencyMXN,
-			'$BTC': testCurrencyBTC
+			'$BTC': testCurrencyBTC,
+			ETH: testCurrencyETH
 		},
 		/**
 		 * The metadata entries which are expected to be broken and
@@ -291,6 +304,13 @@ test('Basic Tests', async function() {
 				outputCurrencyCode: 'EUR' as const
 			},
 			result: undefined
+		}, {
+			// Test with token public key directly - ETH is NOT in currencyMap
+			input: {
+				inputCurrencyCode: tokens.ETH.publicKeyString.get(),
+				outputCurrencyCode: tokens.USD.publicKeyString.get()
+			},
+			createExchange: ['https://fx-unmapped.keeta.com/api/v1/createExchange']
 		}]
 	} satisfies {
 		[key in keyof NonNullable<ServiceMetadata['services']>]: ({
@@ -617,7 +637,8 @@ test('Basic Tests', async function() {
 	 */
 	const allTokens = await resolver.listTokens();
 	expect(allTokens.length).toBe(3);
-	expect(allTokens.map(t => t.currency).sort()).toEqual(Object.keys(tokens).sort());
+	// ETH is intentionally not in currencyMap to test direct token public key lookup
+	expect(allTokens.map(t => t.currency).sort()).toEqual(Object.keys(tokens).filter(k => k !== 'ETH').sort());
 	for (const { token, currency } of allTokens) {
 		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		expect(token).toBe(tokens[currency as keyof typeof tokens].publicKeyString.get());

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -41,6 +41,7 @@ type CountrySearchInput = CurrencyInfo.ISOCountryCode | CurrencyInfo.ISOCountryN
 type CountrySearchCanonical = CurrencyInfo.ISOCountryCode; /* XXX:TODO */
 
 const isCurrencySearchCanonical = createIs<CurrencySearchCanonical>();
+const isCurrencySearchInput = createIs<CurrencySearchInput>();
 
 // #region Global Service Metadata
 /**
@@ -1743,20 +1744,46 @@ class Resolver {
 			return(undefined);
 		}
 
-		const isCurrencySearchInput = createIs<CurrencySearchInput>();
-		// if currency code is provided then convert to canonical format otherwise token public key string was provided
-		const canonicalInputCurrencyCriteria = isCurrencySearchInput(criteria.inputCurrencyCode) ? convertToCurrencySearchCanonical(criteria.inputCurrencyCode) : criteria.inputCurrencyCode;
-		const canonicalOutputCurrencyCriteria = isCurrencySearchInput(criteria.outputCurrencyCode) ? convertToCurrencySearchCanonical(criteria.outputCurrencyCode) : criteria.outputCurrencyCode;
-		// if search criteria is not provided then set token to undefined
-		const inputToken = canonicalInputCurrencyCriteria !== undefined ? await this.lookupToken(canonicalInputCurrencyCriteria) : undefined;
-		const outputToken = canonicalOutputCurrencyCriteria !== undefined ? await this.lookupToken(canonicalOutputCurrencyCriteria) : undefined;
+		// Helper to resolve token from either currency code or direct token public key
+		const resolveToken = async (currencyOrToken: CurrencySearchInput | KeetaNetAccountTokenPublicKeyString | undefined): Promise<{ token: KeetaNetAccountTokenPublicKeyString; currency: CurrencySearchCanonical; } | null | undefined> => {
+			if (currencyOrToken === undefined) {
+				return(undefined);
+			}
+
+			// Check if it's a currency code that needs lookup
+			if (isCurrencySearchInput(currencyOrToken)) {
+				const canonicalCurrency = convertToCurrencySearchCanonical(currencyOrToken);
+				return(await this.lookupToken(canonicalCurrency));
+			}
+
+			// It's potentially a direct token public key string
+			// Validate it and use directly without requiring currencyMap entry
+			const tokenAccount = KeetaNetAccount.fromPublicKeyString(currencyOrToken);
+			if (tokenAccount.isToken()) {
+				const tokenPublicKeyString = tokenAccount.publicKeyString.get();
+				// Return the token using its public key string as the currency identifier
+				// This allows FX lookups to work with tokens that aren't in the currencyMap
+				return({
+					token: tokenPublicKeyString,
+					// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+					currency: tokenPublicKeyString as CurrencySearchCanonical
+				});
+			}
+
+			return(undefined);
+		};
+
+		// Resolve tokens for input and output
+		const inputToken = await resolveToken(criteria.inputCurrencyCode);
+		const outputToken = await resolveToken(criteria.outputCurrencyCode);
+
 		if (criteria.inputCurrencyCode !== undefined && inputToken === null) {
-			this.#logger?.debug(`Resolver:${this.id}`, 'Input currency code', canonicalInputCurrencyCriteria, 'could not be resolved to a token');
+			this.#logger?.debug(`Resolver:${this.id}`, 'Input currency code', criteria.inputCurrencyCode, 'could not be resolved to a token');
 			return(undefined);
 		}
 
 		if (criteria.outputCurrencyCode !== undefined && outputToken === null) {
-			this.#logger?.debug(`Resolver:${this.id}`, 'Output currency code', canonicalOutputCurrencyCriteria, 'could not be resolved to a token');
+			this.#logger?.debug(`Resolver:${this.id}`, 'Output currency code', criteria.outputCurrencyCode, 'could not be resolved to a token');
 			return(undefined);
 		}
 

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -7,7 +7,6 @@ import type { DeepPartial } from './utils/types.ts';
 import { assertNever } from './utils/never.js';
 import { Buffer } from './utils/buffer.js';
 import crypto from './utils/crypto.js';
-import { createIs, createAssert } from 'typia';
 import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCanonical, assertKeetaSupportedAssetsMetadata } from '../services/asset-movement/common.js';
 import type { AssetLocationString, Rail, SupportedAssetsMetadata, RailOrRailWithExtendedDetails, AssetMovementRailSearchInput, AnchorCustomLocationMetadata } from '../services/asset-movement/common.js';
 import type { MovableAssetSearchInput, KeetaNetTokenPublicKeyString } from './asset.js';
@@ -18,6 +17,7 @@ import type { HTTPSignedField } from './http-server/common.js';
 import type { SignableServiceMetadata } from './anchor-metadata-server.js';
 import { assertHTTPSignedField } from './http-server/common.js';
 import { verifyMetadataSignature } from './anchor-metadata-server.js';
+import { assertServiceMetadata, assertSignableServiceMetadataLegal, assertSignableServiceMetadataOperations, isCurrencySearchCanonical, isCurrencySearchInput, isExternalURL } from './resolver.generated.js';
 
 type ExternalURL = { external: '2b828e33-2692-46e9-817e-9b93d63f28fd'; url: string; };
 
@@ -39,9 +39,6 @@ type CurrencySearchInput = ServiceMetadataCurrencyCodeCanonical | CurrencyInfo.I
 type CurrencySearchCanonical = ServiceMetadataCurrencyCodeCanonical;
 type CountrySearchInput = CurrencyInfo.ISOCountryCode | CurrencyInfo.ISOCountryNumber | CurrencyInfo.Country;
 type CountrySearchCanonical = CurrencyInfo.ISOCountryCode; /* XXX:TODO */
-
-const isCurrencySearchCanonical = createIs<CurrencySearchCanonical>();
-const isCurrencySearchInput = createIs<CurrencySearchInput>();
 
 // #region Global Service Metadata
 /**
@@ -723,11 +720,6 @@ function convertToCountrySearchCanonical(input: CountrySearchInput): CountrySear
 	return(input.code);
 }
 
-/**
- * Check if a value is an ExternalURL
- */
-const isExternalURL = createIs<ExternalURL>();
-
 type JSONSerializablePrimitive = Exclude<JSONSerializable, object>;
 type ValuizeInput = JSONSerializablePrimitive | ValuizableObject | ValuizableArray;
 type ValuizableArray = (ValuizableMethod | undefined)[];
@@ -885,10 +877,6 @@ type MetadataConfig = {
 };
 
 type ValuizableInstance = { value: ValuizableMethod };
-
-const assertServiceMetadata = createAssert<ToJSONValuizable<ServiceMetadata>>();
-const assertSignableServiceMetadataOperations = createAssert<SignableServiceMetadata['operations']>();
-const assertSignableServiceMetadataLegal = createAssert<NonNullable<SignableServiceMetadata['legal']>>();
 
 /**
  * Instance type ID for anonymous Valuizable methods created dynamically
@@ -2765,6 +2753,10 @@ export type {
 	ServiceMetadataExternalizable,
 	ServiceSearchCriteria,
 	Services,
-	SharedLookupCriteria
+	SharedLookupCriteria,
+	CurrencySearchCanonical,
+	CurrencySearchInput,
+	ExternalURL,
+	ToJSONValuizable
 };
 export type { ServiceMetadataEndpoint, ServiceMetadataAuthenticationType } from './metadata.types.js';


### PR DESCRIPTION
This change fixes an issue where the FX lookup was dependent on the currency map.  When a token public key is provided to search for the FX providers it now does not rely on the currency map.  When a token or currency symbol is used it will still use the currency map to lookup the token.