### PR TITLE
Feature: Add Inputs to External Field

### DIFF
--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -39,6 +39,12 @@ const anchor1Key = anchor1.publicKeyString.get();
 const TEST_BINDING_PREVIOUS_BLOCK_HASH = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const TEST_BINDING_OPERATION_INDEX = 3;
 
+/*
+ * Fixed input references used wherever a test carries inputs.
+ */
+const TEST_INPUT_BLOCK_HASH_1 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const TEST_INPUT_BLOCK_HASH_2 = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
 type ModeSpec = {
 	name: string;
 	configure: (builder: AnchorExternalBuilder) => void;
@@ -118,6 +124,31 @@ test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
 	expect(peeked).toEqual({ encrypted: mode.expectedEncrypted, signed: mode.expectedSigned });
 });
 
+test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
+	const builder = new AnchorExternalBuilder()
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.addInput(TEST_INPUT_BLOCK_HASH_1, 0)
+		.addInput(TEST_INPUT_BLOCK_HASH_2);
+	mode.configure(builder);
+
+	const external = await builder.build();
+	const decoded = await mode.decode(external);
+	expect(decoded.envelope).toEqual(builder.toEnvelope());
+	expect(decoded.envelope.inputs).toEqual([
+		{ blockHash: TEST_INPUT_BLOCK_HASH_1, operationIndex: 0 },
+		{ blockHash: TEST_INPUT_BLOCK_HASH_2 }
+	]);
+});
+
+test('an envelope without inputs decodes with the inputs field absent', async function() {
+	const external = await new AnchorExternalBuilder()
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.build();
+
+	const decoded = await AnchorExternal.fromPlainExternal(external);
+	expect(decoded.envelope.inputs).toBeUndefined();
+});
+
 test('round-trip preserves multiple anchors with mixed entry kinds', async function() {
 	const builder = new AnchorExternalBuilder()
 		.setAnchor(anchor1, { transactionId: 'tx-1' })
@@ -169,6 +200,18 @@ const misuseCases: MisuseCase[] = [
 	{
 		name: 'withBinding rejects empty previous eagerly',
 		act: function() { return(new AnchorExternalBuilder().withBinding('', 0)); }
+	},
+	{
+		name: 'addInput rejects empty blockHash eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput('')); }
+	},
+	{
+		name: 'addInput rejects negative operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, -1)); }
+	},
+	{
+		name: 'addInput rejects non-integer operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, 1.5)); }
 	},
 	{
 		name: 'withBinding rejects negative operationIndex eagerly',
@@ -319,6 +362,33 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 		name: 'entry with extra key',
 		makeExternal: async function() {
 			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x', extra: 'y' }}}, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'input with extra key',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}, i: [{ h: TEST_INPUT_BLOCK_HASH_1, extra: 'y' }] }, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'inputs as a non-array',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}, i: { h: TEST_INPUT_BLOCK_HASH_1 }}, undefined);
+			return(result);
+		},
+		decoder: 'plain',
+		expectedCode: 'NOT_AN_ENVELOPE'
+	},
+	{
+		name: 'input missing its block hash',
+		makeExternal: async function() {
+			const result = await packEncoded({ v: ANCHOR_EXTERNAL_VERSION, a: { [anchor1Key]: { t: 'x' }}, i: [{ o: 0 }] }, undefined);
 			return(result);
 		},
 		decoder: 'plain',

--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -4,13 +4,15 @@ import { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import type {
 	AnchorExternalEntry,
 	AnchorExternalErrorCode,
+	AnchorExternalInput,
 	EncodedAnchorExternalEnvelopeV1
 } from './anchor-external.js';
 import {
 	AnchorExternal,
 	AnchorExternalBuilder,
 	AnchorExternalError,
-	ANCHOR_EXTERNAL_VERSION
+	ANCHOR_EXTERNAL_VERSION,
+	buildSignedAnchorExternal
 } from './anchor-external.js';
 import { EncryptedContainer } from './encrypted-container.js';
 import { KeetaAnchorError } from './error.js';
@@ -125,10 +127,11 @@ test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
 });
 
 test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
-	const builder = new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionId: 'tx-1' })
-		.addInput(TEST_INPUT_BLOCK_HASH_1, 0)
-		.addInput(TEST_INPUT_BLOCK_HASH_2);
+	const builder = new AnchorExternalBuilder();
+	builder.setAnchor(anchor1, { transactionId: 'tx-1' });
+	builder.addInput(TEST_INPUT_BLOCK_HASH_1, 0);
+	builder.addInput(TEST_INPUT_BLOCK_HASH_2);
+
 	mode.configure(builder);
 
 	const external = await builder.build();
@@ -212,6 +215,18 @@ const misuseCases: MisuseCase[] = [
 	{
 		name: 'addInput rejects non-integer operationIndex eagerly',
 		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, 1.5)); }
+	},
+	{
+		name: 'addInput rejects NaN operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, NaN)); }
+	},
+	{
+		name: 'addInput rejects Infinity operationIndex eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, Infinity)); }
+	},
+	{
+		name: 'addInput rejects operationIndex above 2^32 - 1 eagerly',
+		act: function() { return(new AnchorExternalBuilder().addInput(TEST_INPUT_BLOCK_HASH_1, 2 ** 32 + 1)); }
 	},
 	{
 		name: 'withBinding rejects negative operationIndex eagerly',
@@ -473,6 +488,84 @@ test.each(decodeRejectionCases)('fromXExternal rejects malformed input with $exp
 	if (AnchorExternalError.isInstance(error)) {
 		expect(error.code).toBe(expectedCode);
 	}
+});
+
+/*
+ * Fixed inputs and binding shared by the buildSignedAnchorExternal cases.
+ */
+const SIGNED_HELPER_TRANSACTION_ID = 'tx-payout-1';
+const SIGNED_HELPER_BINDING = { previousBlockHash: TEST_BINDING_PREVIOUS_BLOCK_HASH, operationIndex: TEST_BINDING_OPERATION_INDEX };
+const SIGNED_HELPER_INPUTS: AnchorExternalInput[] = [
+	{ blockHash: TEST_INPUT_BLOCK_HASH_1, operationIndex: 0 },
+	{ blockHash: TEST_INPUT_BLOCK_HASH_2 }
+];
+
+type SignedHelperCase = {
+	name: string;
+	inputs: AnchorExternalInput[] | undefined;
+	encryptTo: Account[] | undefined;
+	decode: (external: string) => Promise<AnchorExternal>;
+	expectedEncrypted: boolean;
+	expectedInputs: AnchorExternalInput[] | undefined;
+};
+
+const signedHelperCases: SignedHelperCase[] = [
+	{
+		name: 'plain, no inputs',
+		inputs: undefined,
+		encryptTo: undefined,
+		decode: async function(external) { return(await AnchorExternal.fromPlainExternal(external)); },
+		expectedEncrypted: false,
+		expectedInputs: undefined
+	},
+	{
+		name: 'plain, with inputs',
+		inputs: SIGNED_HELPER_INPUTS,
+		encryptTo: undefined,
+		decode: async function(external) { return(await AnchorExternal.fromPlainExternal(external)); },
+		expectedEncrypted: false,
+		expectedInputs: SIGNED_HELPER_INPUTS
+	},
+	{
+		name: 'encrypted to the recipient, with inputs',
+		inputs: SIGNED_HELPER_INPUTS,
+		encryptTo: [stranger],
+		decode: async function(external) { return(await AnchorExternal.fromEncryptedExternal(external, [stranger])); },
+		expectedEncrypted: true,
+		expectedInputs: SIGNED_HELPER_INPUTS
+	}
+];
+
+test.each(signedHelperCases)('buildSignedAnchorExternal produces a verified signed envelope: $name', async function({ inputs, encryptTo, decode, expectedEncrypted, expectedInputs }) {
+	const external = await buildSignedAnchorExternal({
+		anchor: anchor1,
+		transactionId: SIGNED_HELPER_TRANSACTION_ID,
+		binding: SIGNED_HELPER_BINDING,
+		...(inputs !== undefined && { inputs }),
+		...(encryptTo !== undefined && { encryptTo })
+	});
+
+	const decoded = await decode(external);
+	expect(decoded.encrypted).toBe(expectedEncrypted);
+	expect(decoded.signed?.signer.comparePublicKey(anchor1)).toBe(true);
+	expect(decoded.envelope.anchors).toEqual({ [anchor1Key]: { transactionId: SIGNED_HELPER_TRANSACTION_ID }});
+	expect(decoded.envelope.binding).toEqual(SIGNED_HELPER_BINDING);
+	expect(decoded.envelope.inputs).toEqual(expectedInputs);
+
+	const peeked = await AnchorExternal.peek(external);
+	expect(peeked).toEqual({ encrypted: expectedEncrypted, signed: true });
+});
+
+test('buildSignedAnchorExternal without decryption keys is unreadable by the plain decoder', async function() {
+	const external = await buildSignedAnchorExternal({
+		anchor: anchor1,
+		transactionId: SIGNED_HELPER_TRANSACTION_ID,
+		binding: SIGNED_HELPER_BINDING,
+		encryptTo: [stranger]
+	});
+
+	const error = await AnchorExternal.fromPlainExternal(external).catch(function(caught: unknown) { return(caught); });
+	expect(AnchorExternalError.isInstance(error) && error.code).toBe('EXPECTED_PLAIN');
 });
 
 test('AnchorExternalError preserves its code through to/fromJSON', async function() {

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -21,6 +21,12 @@ const MAX_PLAINTEXT_BYTES = 4096;
  */
 export const ANCHOR_EXTERNAL_VERSION = 1;
 
+/**
+ * Largest valid operation index, matching the 32-bit bound used for
+ * operation indexes elsewhere in the protocol.
+ */
+const MAX_OPERATION_INDEX = 2 ** 32 - 1;
+
 // #region Public types
 
 /**
@@ -62,6 +68,8 @@ export type AnchorExternalBinding = {
 	previousBlockHash: string;
 	/**
 	 * Index of the SEND operation within its block.
+	 *
+	 * Valid range: `0` to `2^32 - 1` inclusive.
 	 */
 	operationIndex: number;
 };
@@ -85,6 +93,8 @@ export type AnchorExternalInput = {
 	/**
 	 * Index of the referenced operation within its block. Omit to
 	 * reference the block as a whole.
+	 *
+	 * Valid range: `0` to `2^32 - 1` inclusive.
 	 */
 	operationIndex?: number;
 };
@@ -407,6 +417,28 @@ function signerListed(envelope: AnchorExternalEnvelope, signer: Account): boolea
 }
 
 /**
+ * Validate an operation index against its valid range of `0` to
+ * `2^32 - 1` inclusive.
+ *
+ * @returns `undefined` if valid, or an error message.
+ */
+function validateOperationIndex(label: string, value: number): string | undefined {
+	if (!Number.isSafeInteger(value)) {
+		return(`${label} must be an integer, got ${value}`);
+	}
+
+	if (value < 0) {
+		return(`${label} must not be negative, got ${value}`);
+	}
+
+	if (value > MAX_OPERATION_INDEX) {
+		return(`${label} must not exceed ${MAX_OPERATION_INDEX}, got ${value}`);
+	}
+
+	return(undefined);
+}
+
+/**
  * Validate the shape of a {@link AnchorExternalBinding}.
  *
  * @returns `undefined` if valid, or an error message.
@@ -415,11 +447,8 @@ function validateBindingShape(binding: AnchorExternalBinding): string | undefine
 	if (typeof binding.previousBlockHash !== 'string' || binding.previousBlockHash.length === 0) {
 		return('binding.previousBlockHash must be a non-empty string');
 	}
-	if (!Number.isInteger(binding.operationIndex) || binding.operationIndex < 0) {
-		return(`binding.operationIndex must be a non-negative integer, got ${binding.operationIndex}`);
-	}
 
-	return(undefined);
+	return(validateOperationIndex('binding.operationIndex', binding.operationIndex));
 }
 
 /**
@@ -431,11 +460,12 @@ function validateInputShape(input: AnchorExternalInput): string | undefined {
 	if (typeof input.blockHash !== 'string' || input.blockHash.length === 0) {
 		return('input.blockHash must be a non-empty string');
 	}
-	if (input.operationIndex !== undefined && (!Number.isInteger(input.operationIndex) || input.operationIndex < 0)) {
-		return(`input.operationIndex must be a non-negative integer, got ${input.operationIndex}`);
+
+	if (input.operationIndex === undefined) {
+		return(undefined);
 	}
 
-	return(undefined);
+	return(validateOperationIndex('input.operationIndex', input.operationIndex));
 }
 
 /**
@@ -606,6 +636,60 @@ export class AnchorExternalBuilder {
 
 		return(external);
 	}
+}
+
+// #endregion
+
+// #region Signed external helper
+
+/**
+ * Inputs to {@link buildSignedAnchorExternal}.
+ */
+export type AnchorPayoutExternalOptions = {
+	/**
+	 * Anchor signing account; also the envelope's anchor entry key.
+	 */
+	anchor: Account;
+	/**
+	 * Service-scoped transfer/transaction id to correlate.
+	 */
+	transactionId: string;
+	/**
+	 * On-chain operations feeding this payout in relevance order.
+	 */
+	inputs?: AnchorExternalInput[];
+	/**
+	 * Binding coordinates of the block about to be published.
+	 */
+	binding: AnchorExternalBinding;
+	/**
+	 * Encrypt the envelope to these recipients.
+	 */
+	encryptTo?: Account[];
+};
+
+/**
+ * Build the signed, encoded SEND.external string an anchor attaches to a
+ * payout (anchor-to-user) SEND.
+ *
+ * @throws {@link KeetaAnchorError} on caller misuse (invalid binding or inputs).
+ */
+export async function buildSignedAnchorExternal(options: AnchorPayoutExternalOptions): Promise<string> {
+	const builder = new AnchorExternalBuilder();
+	builder.setAnchor(options.anchor, { transactionId: options.transactionId });
+	builder.withSigner(options.anchor);
+	builder.withBinding(options.binding.previousBlockHash, options.binding.operationIndex);
+
+	for (const input of options.inputs ?? []) {
+		builder.addInput(input.blockHash, input.operationIndex);
+	}
+
+	if (options.encryptTo !== undefined) {
+		builder.withPrincipals(options.encryptTo);
+	}
+
+	const external = await builder.build();
+	return(external);
 }
 
 // #endregion

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -67,6 +67,29 @@ export type AnchorExternalBinding = {
 };
 
 /**
+ * Reference to a prior on-chain operation that is relevant to the
+ * transfer this envelope describes.
+ *
+ * Inputs are backward links: an envelope can only reference operations
+ * whose block hashes are already known when the carrying SEND is
+ * constructed.
+ *
+ * When the envelope is signed, inputs are part of the signed plaintext
+ * and the signer cannot later repudiate the claimed relevance.
+ */
+export type AnchorExternalInput = {
+	/**
+	 * Hash of the block carrying the referenced operation.
+	 */
+	blockHash: string;
+	/**
+	 * Index of the referenced operation within its block. Omit to
+	 * reference the block as a whole.
+	 */
+	operationIndex?: number;
+};
+
+/**
  * Decoded anchor-external envelope as exposed to callers.
  */
 export type AnchorExternalEnvelope = {
@@ -82,6 +105,11 @@ export type AnchorExternalEnvelope = {
 	 * Signature binding. Present if the envelope is signed.
 	 */
 	binding?: AnchorExternalBinding;
+	/**
+	 * References to prior on-chain operations relevant to this transfer,
+	 * in the order they were added. Present only when non-empty.
+	 */
+	inputs?: AnchorExternalInput[];
 };
 
 /**
@@ -128,14 +156,25 @@ export type EncodedAnchorExternalBindingV1 = {
 };
 
 /**
+ * Input reference as it appears in the encoded envelope.
+ *
+ * `h` = block hash, `o` = operation index.
+ */
+export type EncodedAnchorExternalInputV1 = {
+	h: string;
+	o?: number;
+};
+
+/**
  * Anchor-external envelope as it appears inside the encoded blob.
  *
- * `v` = envelope version, `a` = anchors, `b` = binding.
+ * `v` = envelope version, `a` = anchors, `b` = binding, `i` = inputs.
  */
 export type EncodedAnchorExternalEnvelopeV1 = {
 	v: typeof ANCHOR_EXTERNAL_VERSION;
 	a: { [anchorPublicKey: string]: EncodedAnchorExternalEntryV1 };
 	b?: EncodedAnchorExternalBindingV1;
+	i?: EncodedAnchorExternalInputV1[];
 };
 
 // #endregion
@@ -269,6 +308,30 @@ function entryFromEncoded(entry: EncodedAnchorExternalEntryV1): AnchorExternalEn
 }
 
 /**
+ * Convert a public input reference to an encoded input reference.
+ */
+function inputToEncoded(input: AnchorExternalInput): EncodedAnchorExternalInputV1 {
+	const result: EncodedAnchorExternalInputV1 = { h: input.blockHash };
+	if (input.operationIndex !== undefined) {
+		result.o = input.operationIndex;
+	}
+
+	return(result);
+}
+
+/**
+ * Convert an encoded input reference to a public input reference.
+ */
+function inputFromEncoded(input: EncodedAnchorExternalInputV1): AnchorExternalInput {
+	const result: AnchorExternalInput = { blockHash: input.h };
+	if (input.o !== undefined) {
+		result.operationIndex = input.o;
+	}
+
+	return(result);
+}
+
+/**
  * Convert a public envelope to an encoded envelope.
  */
 function envelopeToEncoded(envelope: AnchorExternalEnvelope): EncodedAnchorExternalEnvelopeV1 {
@@ -283,6 +346,10 @@ function envelopeToEncoded(envelope: AnchorExternalEnvelope): EncodedAnchorExter
 	};
 	if (envelope.binding !== undefined) {
 		result.b = { p: envelope.binding.previousBlockHash, o: envelope.binding.operationIndex };
+	}
+
+	if (envelope.inputs !== undefined) {
+		result.i = envelope.inputs.map(inputToEncoded);
 	}
 
 	return(result);
@@ -303,6 +370,10 @@ function envelopeFromEncoded(encoded: EncodedAnchorExternalEnvelopeV1): AnchorEx
 	};
 	if (encoded.b !== undefined) {
 		result.binding = { previousBlockHash: encoded.b.p, operationIndex: encoded.b.o };
+	}
+
+	if (encoded.i !== undefined) {
+		result.inputs = encoded.i.map(inputFromEncoded);
 	}
 
 	return(result);
@@ -352,6 +423,22 @@ function validateBindingShape(binding: AnchorExternalBinding): string | undefine
 }
 
 /**
+ * Validate the shape of an {@link AnchorExternalInput}.
+ *
+ * @returns `undefined` if valid, or an error message.
+ */
+function validateInputShape(input: AnchorExternalInput): string | undefined {
+	if (typeof input.blockHash !== 'string' || input.blockHash.length === 0) {
+		return('input.blockHash must be a non-empty string');
+	}
+	if (input.operationIndex !== undefined && (!Number.isInteger(input.operationIndex) || input.operationIndex < 0)) {
+		return(`input.operationIndex must be a non-negative integer, got ${input.operationIndex}`);
+	}
+
+	return(undefined);
+}
+
+/**
  * Decode the base64-encoded string.
  */
 function decodeExternal(external: string): Buffer {
@@ -373,6 +460,7 @@ function decodeExternal(external: string): Buffer {
  */
 export class AnchorExternalBuilder {
 	readonly #anchors: { [anchorPublicKey: string]: AnchorExternalEntry } = {};
+	readonly #inputs: AnchorExternalInput[] = [];
 	#signer: Account | undefined;
 	#principals: Account[] | undefined;
 	#maxLength: number | undefined;
@@ -384,6 +472,29 @@ export class AnchorExternalBuilder {
 	 */
 	setAnchor(anchor: Account, entry: AnchorExternalEntry): this {
 		this.#anchors[anchor.publicKeyString.get()] = entry;
+		return(this);
+	}
+
+	/**
+	 * Append a reference to a prior on-chain operation relevant to this
+	 * transfer. Order of addition is preserved in the envelope.
+	 *
+	 * @param blockHash      Hash of the block carrying the referenced operation.
+	 * @param operationIndex Index of the operation within its block. Omit to
+	 *                       reference the block as a whole.
+	 */
+	addInput(blockHash: string, operationIndex?: number): this {
+		const candidate: AnchorExternalInput = { blockHash };
+		if (operationIndex !== undefined) {
+			candidate.operationIndex = operationIndex;
+		}
+
+		const error = validateInputShape(candidate);
+		if (error !== undefined) {
+			throw(new KeetaAnchorError(`addInput: ${error}`));
+		}
+
+		this.#inputs.push(candidate);
 		return(this);
 	}
 
@@ -446,6 +557,12 @@ export class AnchorExternalBuilder {
 
 		if (this.#binding !== undefined) {
 			result.binding = { ...this.#binding };
+		}
+
+		if (this.#inputs.length > 0) {
+			result.inputs = this.#inputs.map(function(input) {
+				return({ ...input });
+			});
 		}
 
 		return(result);

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -11,6 +11,7 @@ import { AnchorChaining, AnchorChainingPlan } from './chaining.js';
 import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, ComputePlanOptions, Disclaimer } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
+import { AnchorExternal } from './anchor-external.js';
 import { BlockListener } from './block-listener.js';
 import type { AnchorMetadataLegalField } from './metadata.types.js';
 
@@ -24,6 +25,52 @@ type RateFn = (request: ConversionInputCanonicalJSON, context: GetConversionRate
 
 const EMPTY_FROM_TRANSACTIONS = { deposit: null, persistentForwarding: null, finalization: null } as const;
 const EMPTY_TO_TRANSACTIONS = { withdraw: null } as const;
+
+/**
+ * `true` when a SEND's external field references the given transfer, either
+ * as the raw transfer id (anchor-provided external) or as an entry in a
+ * decodable plaintext envelope (client-constructed external).
+ */
+async function externalReferencesTransfer(external: unknown, txId: string): Promise<boolean> {
+	if (external === txId) {
+		return(true);
+	}
+	if (typeof external !== 'string' || external === '') {
+		return(false);
+	}
+
+	let decoded;
+	try {
+		decoded = await AnchorExternal.fromPlainExternal(external);
+	} catch {
+		return(false);
+	}
+
+	return(Object.values(decoded.envelope.anchors).some(function(entry) {
+		return('transactionId' in entry && entry.transactionId === txId);
+	}));
+}
+
+/**
+ * Initiate-transfer wrapper simulating an anchor under the construction
+ * model: KEETA_SEND instructions carry no external, so the client must
+ * build the correlation envelope itself.
+ */
+async function stripKeetaSendExternal(request: Parameters<InitiateTransferFn>[0], next: InitiateTransferFn): ReturnType<InitiateTransferFn> {
+	const response = await next(request);
+	return({
+		...response,
+		instructionChoices: response.instructionChoices.map(function(choice) {
+			if (choice.type === 'KEETA_SEND') {
+				const rest = { ...choice };
+				delete rest.external;
+				return(rest);
+			}
+
+			return(choice);
+		})
+	});
+}
 
 /**
  * Build a `KeetaAssetMovementTransaction` record for in-memory test bridges.
@@ -95,7 +142,7 @@ class TestBankServer extends KeetaNetAssetMovementAnchorHTTPServer {
 					listenerHandle = blockListener.on('block', {
 						callback: async ({ block }) => {
 							for (const op of block.operations) {
-								if (op.type === KeetaNet.lib.Block.OperationType.SEND && op.external === txId) {
+								if (op.type === KeetaNet.lib.Block.OperationType.SEND && await externalReferencesTransfer(op.external, txId)) {
 									if (op.amount !== value) {
 										throw(new KeetaAnchorUserError(`Invalid transfer amount: expected ${value}, got ${op.amount}`));
 									}
@@ -956,7 +1003,7 @@ test('Asset Movement Chaining Test', async function({ expect }) {
 	])).toEqual(toJSONSerializable(path.path));
 });
 
-async function createChainingTestHarness() {
+async function createChainingTestHarness(options: { includeSwapAnchor?: boolean } = {}) {
 	const account = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
 	const { userClient: client, fees } = await createNodeAndClient(account);
 
@@ -1010,9 +1057,18 @@ async function createChainingTestHarness() {
 		]
 	};
 
+	/*
+	 * Bank entries are signed so providers resolve with a service-entry
+	 * account, which client-side external construction files entries under.
+	 */
+	const bankSignerUS = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const bankSignerEU = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	const swapSigner = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+
 	const bankServerUS = new TestBankServer({
 		...(DEBUG ? { logger } : {}),
 		client,
+		metadataSigner: bankSignerUS,
 		assetMovement: {
 			legal: {
 				disclaimers: bankProviderDisclaimers['BankUS']
@@ -1030,6 +1086,7 @@ async function createChainingTestHarness() {
 	const bankServerEU = new TestBankServer({
 		...(DEBUG ? { logger } : {}),
 		client,
+		metadataSigner: bankSignerEU,
 		assetMovement: {
 			legal: {
 				disclaimers: bankProviderDisclaimers['BankEU']
@@ -1038,6 +1095,26 @@ async function createChainingTestHarness() {
 				asset: [ tokens.EURC.publicKeyString.get(), 'EUR' ],
 				paths: [{ pair: [
 					{ location: 'bank-account:iban-swift', id: 'EUR', rails: { common: [ 'SEPA_PUSH' ] }},
+					{ location: keetaLocation, id: tokens.EURC.publicKeyString.get(), rails: { common: [ 'KEETA_SEND' ] }}
+				] }]
+			}]
+		}
+	});
+
+	/*
+	 * Keeta-to-Keeta token swap anchor (USDC -> EURC). Both rails are
+	 * KEETA_SEND, so chaining it before a bank withdrawal produces two
+	 * user-funded sends in one execution.
+	 */
+	const swapServer = new TestBankServer({
+		...(DEBUG ? { logger } : {}),
+		client,
+		metadataSigner: swapSigner,
+		assetMovement: {
+			supportedAssets: [{
+				asset: [ tokens.USDC.publicKeyString.get(), tokens.EURC.publicKeyString.get() ],
+				paths: [{ pair: [
+					{ location: keetaLocation, id: tokens.USDC.publicKeyString.get(), rails: { common: [ 'KEETA_SEND' ] }},
 					{ location: keetaLocation, id: tokens.EURC.publicKeyString.get(), rails: { common: [ 'KEETA_SEND' ] }}
 				] }]
 			}]
@@ -1095,12 +1172,25 @@ async function createChainingTestHarness() {
 
 	await bankServerUS.start();
 	await bankServerEU.start();
+	await swapServer.start();
 	await fxServerOne.start();
 	await fxServerTwo.start();
 
 	// Make FX LPs fee-free so they don't need KTA to execute exchanges
 	fees.addFeeFreeAccount(fxLPOne);
 	fees.addFeeFreeAccount(fxLPTwo);
+
+	/*
+	 * The swap anchor is opt-in: its keeta-to-keeta pair adds round-trip
+	 * paths that would change path counts in unrelated tests.
+	 */
+	const assetMovementServices: { [providerID: string]: Awaited<ReturnType<typeof swapServer.serviceMetadata>> } = {
+		[usBankProviderID]: await bankServerUS.serviceMetadata(),
+		[euBankProviderID]: await bankServerEU.serviceMetadata()
+	};
+	if (options.includeSwapAnchor === true) {
+		assetMovementServices['SwapKeeta'] = await swapServer.serviceMetadata();
+	}
 
 	await client.setInfo({
 		description: 'Chaining Test',
@@ -1113,10 +1203,7 @@ async function createChainingTestHarness() {
 					FXOne: await fxServerOne.serviceMetadata(),
 					FXTwo: await fxServerTwo.serviceMetadata()
 				},
-				assetMovement: {
-					[usBankProviderID]: await bankServerUS.serviceMetadata(),
-					[euBankProviderID]: await bankServerEU.serviceMetadata()
-				}
+				assetMovement: assetMovementServices
 			}
 		} satisfies ServiceMetadataExternalizable)
 	});
@@ -1160,6 +1247,10 @@ async function createChainingTestHarness() {
 		keetaLocation,
 		bankServerUS,
 		bankServerEU,
+		swapServer,
+		bankSignerUS,
+		bankSignerEU,
+		swapSigner,
 		fxServerOne,
 		fxServerTwo,
 		anchorChaining,
@@ -1175,6 +1266,7 @@ async function createChainingTestHarness() {
 		[Symbol.asyncDispose]: async function() {
 			await bankServerUS[Symbol.asyncDispose]?.();
 			await bankServerEU[Symbol.asyncDispose]?.();
+			await swapServer[Symbol.asyncDispose]?.();
 			await fxServerOne[Symbol.asyncDispose]?.();
 			await fxServerTwo[Symbol.asyncDispose]?.();
 		}
@@ -1921,6 +2013,133 @@ describe('AnchorChainingPath keetaSendAuthRequired', function() {
 		// FX step (index 0) completed; rejection happened at AM step (index 1)
 		expect(failedEvent.index).toBe(1);
 		expect(failedEvent.completedSteps[0]?.type).toBe('fx');
+	});
+
+	test('anchor omitting external: client constructs the unsigned correlation envelope', async function() {
+		await using h = await createChainingTestHarness();
+		await h.giveTokens(h.client.account, 1000n, h.tokens.USDC);
+
+		// Anchor under the construction model: instructions carry no external.
+		h.bankServerEU.wrapInitiateTransfer(stripKeetaSendExternal);
+
+		const path = await h.getPlanVia('FXOne');
+
+		const capturedActions: { sendToAddress: GenericAccount; value: bigint; token: TokenAddress; external?: string }[] = [];
+		path.on('stepNeedsAction', (payload) => {
+			if (payload.type === 'keetaSendAuthRequired') {
+				capturedActions.push(payload.action);
+				payload.markCompleted({ sent: true });
+			} else {
+				payload.markCompleted();
+			}
+		});
+
+		/*
+		 * Completion proves the fixture correlated the SEND by decoding the
+		 * client-built envelope rather than matching a raw transfer id.
+		 */
+		const result = await path.execute({ requireSendAuth: true });
+		expect(result.steps).toHaveLength(2);
+
+		const step1 = result.steps[1];
+		if (step1?.type !== 'assetMovement') {
+			throw(new Error('Expected asset movement step'));
+		}
+
+		const action = capturedActions[0];
+		if (action?.external === undefined) {
+			throw(new Error('Expected client-built external on the send action'));
+		}
+
+		const decoded = await AnchorExternal.fromPlainExternal(action.external);
+		expect(decoded.signed).toBeUndefined();
+		expect(decoded.envelope.inputs).toBeUndefined();
+		expect(decoded.envelope.anchors).toEqual({
+			[h.bankSignerEU.publicKeyString.get()]: { transactionId: step1.plan.transfer.transferId }
+		});
+	});
+
+	test('chained keeta sends: the second envelope references the first send as an input', async function() {
+		await using h = await createChainingTestHarness({ includeSwapAnchor: true });
+		await h.giveTokens(h.client.account, 1000n, h.tokens.USDC);
+		/*
+		 * The swap anchor settles EURC off-chain in this fixture, so the
+		 * user's EURC for the second hop is pre-funded.
+		 */
+		await h.giveTokens(h.client.account, 1000n, h.tokens.EURC);
+
+		/*
+		 * Both anchors omit external, so the client builds both envelopes.
+		 */
+		h.swapServer.wrapInitiateTransfer(stripKeetaSendExternal);
+		h.bankServerEU.wrapInitiateTransfer(stripKeetaSendExternal);
+
+		const plans = await h.anchorChaining.getPlans({
+			source: { asset: h.tokens.USDC, location: h.keetaLocation, value: 100n, rail: 'KEETA_SEND' },
+			destination: { asset: 'EUR', location: 'bank-account:iban-swift', recipient: h.client.account.publicKeyString.get(), rail: 'SEPA_PUSH' }
+		});
+		const path = plans?.find(function(plan) {
+			if (plan.path.length !== 2) {
+				return(false);
+			}
+
+			return(plan.path[0]?.providerID === 'SwapKeeta' && plan.path[1]?.providerID === h.euBankProviderID);
+		});
+		if (!path) {
+			throw(new Error('Expected SwapKeeta -> BankEU path'));
+		}
+
+		const capturedExternals: (string | undefined)[] = [];
+		path.on('stepNeedsAction', (payload) => {
+			if (payload.type === 'keetaSendAuthRequired') {
+				capturedExternals.push(payload.action.external);
+				payload.markCompleted({ sent: true });
+			} else {
+				payload.markCompleted();
+			}
+		});
+
+		const result = await path.execute({ requireSendAuth: true });
+		expect(result.steps).toHaveLength(2);
+		expect(capturedExternals).toHaveLength(2);
+
+		const [firstExternal, secondExternal] = capturedExternals;
+		if (firstExternal === undefined || secondExternal === undefined) {
+			throw(new Error('Expected client-built externals on both sends'));
+		}
+
+		// First hop: no prior on-chain operations, so no inputs.
+		const firstDecoded = await AnchorExternal.fromPlainExternal(firstExternal);
+		expect(firstDecoded.envelope.inputs).toBeUndefined();
+		expect(Object.keys(firstDecoded.envelope.anchors)).toEqual([ h.swapSigner.publicKeyString.get() ]);
+
+		// Second hop: filed under BankEU and referencing the first send.
+		const secondDecoded = await AnchorExternal.fromPlainExternal(secondExternal);
+		expect(Object.keys(secondDecoded.envelope.anchors)).toEqual([ h.bankSignerEU.publicKeyString.get() ]);
+		expect(secondDecoded.envelope.inputs).toHaveLength(1);
+
+		const input = secondDecoded.envelope.inputs?.[0];
+		if (input === undefined) {
+			throw(new Error('Expected an input referencing the first send'));
+		}
+
+		expect(input.operationIndex).toBe(0);
+
+		// The referenced block is the first hop's on-chain SEND.
+		const referencedBlock = await h.client.block(input.blockHash);
+		if (referencedBlock === null) {
+			throw(new Error('Referenced input block not found on chain'));
+		}
+
+		const referencedExternals = referencedBlock.operations.flatMap(function(op) {
+			if (op.type === KeetaNet.lib.Block.OperationType.SEND) {
+				return([ op.external ]);
+			}
+
+			return([]);
+		});
+
+		expect(referencedExternals).toEqual([ firstExternal ]);
 	});
 
 	test('direct send: keetaSendAuthRequired fires with correct sendToAddress and value', async function() {

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -18,7 +18,9 @@ import type { ExternalChainAsset } from './asset.js';
 import { isExternalChainAsset } from './asset.js';
 import type { Logger } from './log/index.js';
 import type { BlockHash } from '@keetanetwork/keetanet-client/lib/block/index.js';
+import type { AnchorExternalInput } from './anchor-external.js';
 import type { AnchorMetadataLegalField } from './metadata.types.js';
+import { AnchorExternalBuilder } from './anchor-external.js';
 
 type FXQuoteOrEstimate = NonNullable<Awaited<ReturnType<KeetaFXAnchorClient['getQuotesOrEstimates']>>>[number];
 type AssetMovementProvider = NonNullable<Awaited<ReturnType<KeetaAssetMovementAnchorClient['getProvidersForTransfer']>>>[number];
@@ -45,6 +47,7 @@ interface ChainStepResolutionAssetMovement extends ChainStepResolutionBase<'asse
 	usingInstruction: AssetTransferInstructions;
 	sendingTo: SendingToType;
 	transfer: AssetMovementTransfer;
+	provider: AssetMovementProvider;
 };
 
 interface ChainStepResolutionKeetaSend extends ChainStepResolutionBase<'keetaSend'> {
@@ -1734,7 +1737,8 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 							usingInstruction: usingInstruction,
 							transfer: transfer,
 							sendingTo: sendingToType,
-							valueOut: actualValueOut
+							valueOut: actualValueOut,
+							provider
 						})
 					} else if (step.type === 'keetaSend') {
 						if (this.path.length !== 1) {
@@ -1934,7 +1938,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		return(await promise);
 	}
 
-	async #authorizedSend(options: Pick<AnchorChainingPathExecuteOptions, 'requireSendAuth'> | undefined, sendToAddress: string | GenericAccount, value: bigint, token: TokenAddress | string, external?: string): Promise<void> {
+	async #authorizedSend(options: Pick<AnchorChainingPathExecuteOptions, 'requireSendAuth'> | undefined, sendToAddress: string | GenericAccount, value: bigint, token: TokenAddress | string, external?: string): Promise<string | undefined> {
 		if (options?.requireSendAuth) {
 			await this.#awaitStepCompletion({
 				type: 'keetaSendAuthRequired',
@@ -1948,7 +1952,40 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		}
 
 		const { account } = await this.getAccountsForAction({ type: 'assetMovement', providerMethod: 'initiateTransfer' }, this.#options?.overrides);
-		await this.parent['client'].send(sendToAddress, value, token, external, { account });
+		const published = await this.parent['client'].send(sendToAddress, value, token, external, { account });
+		let publishedBlocks;
+		if ('blocks' in published) {
+			publishedBlocks = published.blocks;
+		} else {
+			publishedBlocks = published.voteStaple.blocks;
+		}
+
+		const sendBlock = publishedBlocks[0];
+		if (sendBlock === undefined) {
+			return(undefined);
+		}
+
+		return(sendBlock.hash.toString());
+	}
+
+	/**
+	 * Construct the unsigned external envelope for a user-funded KEETA_SEND.
+	 */
+	static async #buildKeetaSendExternal(provider: AssetMovementProvider, transactionId: string, inputs: readonly AnchorExternalInput[]): Promise<string | undefined> {
+		const anchorKey = provider.serviceInfo.account;
+		if (anchorKey === undefined) {
+			return(undefined);
+		}
+
+		const anchor = KeetaNet.lib.Account.fromPublicKeyString(anchorKey);
+		const builder = new AnchorExternalBuilder().setAnchor(anchor, { transactionId });
+
+		for (const input of inputs) {
+			builder.addInput(input.blockHash, input.operationIndex);
+		}
+
+		const external = await builder.build();
+		return(external);
 	}
 
 	async #pollTransferStatus(
@@ -2083,6 +2120,12 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		 */
 		let prevWithdrawTx: { location: AssetLocationLike; transaction: { id: string }} | null = null;
 
+		/*
+		 * On-chain operations this execution has published so far. Deferred
+		 * initiations forward these as the external envelope's inputs so the
+		 * anchor's signed envelope references the prior steps' operations.
+		 */
+		const publishedInputs: AnchorExternalInput[] = [];
 		let index = 0;
 		try {
 			for (index = 0; index < this.plan.steps.length; index++) {
@@ -2135,13 +2178,26 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 					onStepCompleted({ type: 'forwarded', plan: step, observedTransaction: observed });
 				} else if (step.type === 'assetMovement' || step.type === 'keetaSend') {
 					if (step.usingInstruction.type === 'KEETA_SEND') {
-						await this.#authorizedSend(
+						/*
+						 * Prefer the anchor-provided external. When absent,
+						 * construct the unsigned correlation envelope locally,
+						 * referencing the prior steps' on-chain operations.
+						 */
+						let external = step.usingInstruction.external;
+						if (external === undefined && step.type === 'assetMovement') {
+							external = await AnchorChainingPlan.#buildKeetaSendExternal(step.provider, step.transfer.transferId, publishedInputs);
+						}
+
+						const sentBlockHash = await this.#authorizedSend(
 							options,
 							step.usingInstruction.sendToAddress,
 							BigInt(step.usingInstruction.value),
 							KeetaNet.lib.Account.fromPublicKeyString(step.usingInstruction.tokenAddress).assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN),
-							step.usingInstruction.external
+							external
 						);
+						if (sentBlockHash !== undefined) {
+							publishedInputs.push({ blockHash: sentBlockHash, operationIndex: 0 });
+						}
 					} else if (index === 0) {
 						if (step.type !== 'assetMovement') {
 							throw(new Error(`Unexpected asset movement step at index ${index} for user-initiated transfer`));

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1732,13 +1732,13 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 
 						return({
 							type: 'assetMovement',
-							step,
+							step: step,
 							valueIn: depositValue,
 							usingInstruction: usingInstruction,
 							transfer: transfer,
 							sendingTo: sendingToType,
 							valueOut: actualValueOut,
-							provider
+							provider: provider
 						})
 					} else if (step.type === 'keetaSend') {
 						if (this.path.length !== 1) {

--- a/src/lib/utils/brand.ts
+++ b/src/lib/utils/brand.ts
@@ -10,3 +10,17 @@ export type Brand<T, BrandName extends string> = T & {
  * it, since it is unique and cannot be easily created by accident.
  */
 export type BrandedString<BrandName extends string> = Brand<symbol, BrandName>;
+
+/**
+ * Brand a string value with a named brand.
+ */
+export function brandString<BrandName extends string>(input: string | BrandedString<BrandName>): BrandedString<BrandName>;
+export function brandString<BrandName extends string>(input: string | BrandedString<BrandName> | undefined): BrandedString<BrandName> | undefined;
+export function brandString<BrandName extends string>(input: string | BrandedString<BrandName> | undefined): BrandedString<BrandName> | undefined {
+	if (input === undefined) {
+		return(undefined);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return(input as BrandedString<BrandName>);
+}

--- a/src/lib/utils/brand.ts
+++ b/src/lib/utils/brand.ts
@@ -17,10 +17,6 @@ export type BrandedString<BrandName extends string> = Brand<symbol, BrandName>;
 export function brandString<BrandName extends string>(input: string | BrandedString<BrandName>): BrandedString<BrandName>;
 export function brandString<BrandName extends string>(input: string | BrandedString<BrandName> | undefined): BrandedString<BrandName> | undefined;
 export function brandString<BrandName extends string>(input: string | BrandedString<BrandName> | undefined): BrandedString<BrandName> | undefined {
-	if (input === undefined) {
-		return(undefined);
-	}
-
 	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-	return(input as BrandedString<BrandName>);
+	return(input as BrandedString<BrandName> | undefined);
 }

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -416,16 +416,23 @@ async function getEndpoints(resolver: Resolver, request: ProviderSearchInput, sh
 			anchorAccount = await serviceInfo.account('string');
 		}
 
+		const legalExtension = await resolveSharedAnchorMetadataLegalExtension(serviceInfo.legal, { logger });
+		const resolvedServiceInfo: KeetaAssetMovementServiceInfo = {
+			...legalExtension,
+			operations: operationsFunctions,
+			supportedAssets: supportedAssets
+		};
+		if (locationMetadata) {
+			resolvedServiceInfo.locationMetadata = locationMetadata;
+		}
+		if (anchorAccount !== undefined) {
+			resolvedServiceInfo.account = anchorAccount;
+		}
+
 		return([
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			id as unknown as ProviderID,
-			{
-				...(await resolveSharedAnchorMetadataLegalExtension(serviceInfo.legal, { logger })),
-				operations: operationsFunctions,
-				supportedAssets: supportedAssets,
-				...(locationMetadata ? { locationMetadata } : {}),
-				...(anchorAccount !== undefined ? { account: anchorAccount } : {})
-			}
+			resolvedServiceInfo
 		]);
 	});
 

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -88,6 +88,7 @@ import Resolver from "../../lib/resolver.js";
 import type { ServiceMetadata, ServiceMetadataAuthenticationType, ServiceMetadataEndpoint, SharedLookupCriteria } from '../../lib/resolver.ts';
 import crypto from '../../lib/utils/crypto.js';
 import type { BrandedString } from '../../lib/utils/brand.js';
+import { brandString } from '../../lib/utils/brand.js';
 import { createAssertEquals } from 'typia';
 import type { ExtractOk, HTTPSignedField } from '../../lib/http-server/common.js';
 import { addSignatureToURL } from '../../lib/http-server/common.js';
@@ -430,8 +431,7 @@ async function getEndpoints(resolver: Resolver, request: ProviderSearchInput, sh
 		}
 
 		return([
-			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-			id as unknown as ProviderID,
+			brandString<'AssetMovementProviderID'>(id),
 			resolvedServiceInfo
 		]);
 	});

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -176,6 +176,13 @@ interface KeetaAssetMovementServiceInfo extends SharedAnchorMetadataLegalExtensi
 
 	supportedAssets: SupportedAssetsMetadata[];
 	locationMetadata?: AnchorCustomLocationMetadata;
+
+	/**
+	 * Public key string of the account the anchor signed its service entry
+	 * with. Present only for signed entries. This is the key external
+	 * envelopes referencing this anchor are filed under.
+	 */
+	account?: string;
 };
 
 /**
@@ -404,6 +411,11 @@ async function getEndpoints(resolver: Resolver, request: ProviderSearchInput, sh
 			});
 		}
 
+		let anchorAccount: string | undefined;
+		if (serviceInfo.account !== undefined) {
+			anchorAccount = await serviceInfo.account('string');
+		}
+
 		return([
 			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			id as unknown as ProviderID,
@@ -411,7 +423,8 @@ async function getEndpoints(resolver: Resolver, request: ProviderSearchInput, sh
 				...(await resolveSharedAnchorMetadataLegalExtension(serviceInfo.legal, { logger })),
 				operations: operationsFunctions,
 				supportedAssets: supportedAssets,
-				...(locationMetadata ? { locationMetadata } : {})
+				...(locationMetadata ? { locationMetadata } : {}),
+				...(anchorAccount !== undefined ? { account: anchorAccount } : {})
 			}
 		]);
 	});


### PR DESCRIPTION
## Summary

Adds inputs to the `AnchorExternal` envelope so an `external` can reference prior on-chain operations by block hash and operation index.