### PR TITLE
Feature: Transaction Status Sourcing

### DIFF
--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -51,6 +51,7 @@ type ModeSpec = {
 	name: string;
 	configure: (builder: AnchorExternalBuilder) => void;
 	decode: (external: string) => Promise<AnchorExternal>;
+	decryptionKeys?: Account[];
 	expectedEncrypted: boolean;
 	expectedSigned: boolean;
 };
@@ -76,6 +77,7 @@ const modeSpecs: ModeSpec[] = [
 		name: 'encrypted-unsigned',
 		configure: function(builder) { builder.withPrincipals([anchor2]); },
 		decode: async function(external) { return(await AnchorExternal.fromEncryptedExternal(external, [anchor2])); },
+		decryptionKeys: [anchor2],
 		expectedEncrypted: true,
 		expectedSigned: false
 	},
@@ -85,6 +87,7 @@ const modeSpecs: ModeSpec[] = [
 			builder.withSigner(anchor1).withPrincipals([anchor1]).withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
 		},
 		decode: async function(external) { return(await AnchorExternal.fromEncryptedExternal(external, [anchor1])); },
+		decryptionKeys: [anchor1],
 		expectedEncrypted: true,
 		expectedSigned: true
 	}
@@ -124,6 +127,33 @@ test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
 
 	const peeked = await AnchorExternal.peek(external);
 	expect(peeked).toEqual({ encrypted: mode.expectedEncrypted, signed: mode.expectedSigned });
+});
+
+test.each(modeSpecs)('fromExternal decodes $name without a caller container choice', async function(mode) {
+	const builder = new AnchorExternalBuilder().setAnchor(anchor1, { transactionId: 'tx-1' });
+	mode.configure(builder);
+
+	const external = await builder.build();
+
+	const options: { decryptionKeys?: Account[] } = {};
+	if (mode.decryptionKeys !== undefined) {
+		options.decryptionKeys = mode.decryptionKeys;
+	}
+
+	const decoded = await AnchorExternal.fromExternal(external, options);
+	expect(decoded.envelope).toEqual(builder.toEnvelope());
+	expect(decoded.encrypted).toBe(mode.expectedEncrypted);
+	expect(decoded.signed?.signer.comparePublicKey(anchor1) ?? false).toBe(mode.expectedSigned);
+});
+
+test('fromExternal rejects an encrypted envelope when no decryption keys are supplied', async function() {
+	const external = await new AnchorExternalBuilder()
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.withPrincipals([anchor1])
+		.build();
+
+	const error = await AnchorExternal.fromExternal(external).catch(function(caught: unknown) { return(caught); });
+	expect(KeetaAnchorError.isInstance(error)).toBe(true);
 });
 
 test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {

--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -539,7 +539,7 @@ const signedHelperCases: SignedHelperCase[] = [
 test.each(signedHelperCases)('buildSignedAnchorExternal produces a verified signed envelope: $name', async function({ inputs, encryptTo, decode, expectedEncrypted, expectedInputs }) {
 	const external = await buildSignedAnchorExternal({
 		anchor: anchor1,
-		transactionId: SIGNED_HELPER_TRANSACTION_ID,
+		transactionID: SIGNED_HELPER_TRANSACTION_ID,
 		binding: SIGNED_HELPER_BINDING,
 		...(inputs !== undefined && { inputs }),
 		...(encryptTo !== undefined && { encryptTo })
@@ -548,7 +548,7 @@ test.each(signedHelperCases)('buildSignedAnchorExternal produces a verified sign
 	const decoded = await decode(external);
 	expect(decoded.encrypted).toBe(expectedEncrypted);
 	expect(decoded.signed?.signer.comparePublicKey(anchor1)).toBe(true);
-	expect(decoded.envelope.anchors).toEqual({ [anchor1Key]: { transactionId: SIGNED_HELPER_TRANSACTION_ID }});
+	expect(decoded.envelope.anchors).toEqual({ [anchor1Key]: { transactionID: SIGNED_HELPER_TRANSACTION_ID }});
 	expect(decoded.envelope.binding).toEqual(SIGNED_HELPER_BINDING);
 	expect(decoded.envelope.inputs).toEqual(expectedInputs);
 
@@ -559,7 +559,7 @@ test.each(signedHelperCases)('buildSignedAnchorExternal produces a verified sign
 test('buildSignedAnchorExternal without decryption keys is unreadable by the plain decoder', async function() {
 	const external = await buildSignedAnchorExternal({
 		anchor: anchor1,
-		transactionId: SIGNED_HELPER_TRANSACTION_ID,
+		transactionID: SIGNED_HELPER_TRANSACTION_ID,
 		binding: SIGNED_HELPER_BINDING,
 		encryptTo: [stranger]
 	});

--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -91,8 +91,8 @@ const modeSpecs: ModeSpec[] = [
 ];
 
 const entryCases: { name: string; entry: AnchorExternalEntry }[] = [
-	{ name: 'transactionID', entry: { transactionID: 'tx-12345' }},
-	{ name: 'persistentForwardingID', entry: { persistentForwardingID: 'fwd-67890' }},
+	{ name: 'transactionId', entry: { transactionId: 'tx-12345' }},
+	{ name: 'persistentForwardingId', entry: { persistentForwardingId: 'fwd-67890' }},
 	{ name: 'destination', entry: { destination: '0x0000000000000000000000000000000000000000' }}
 ];
 
@@ -128,7 +128,7 @@ test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
 
 test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
 	const builder = new AnchorExternalBuilder();
-	builder.setAnchor(anchor1, { transactionID: 'tx-1' });
+	builder.setAnchor(anchor1, { transactionId: 'tx-1' });
 	builder.addInput(TEST_INPUT_BLOCK_HASH_1, 0);
 	builder.addInput(TEST_INPUT_BLOCK_HASH_2);
 
@@ -145,7 +145,7 @@ test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
 
 test('an envelope without inputs decodes with the inputs field absent', async function() {
 	const external = await new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionID: 'tx-1' })
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
 		.build();
 
 	const decoded = await AnchorExternal.fromPlainExternal(external);
@@ -154,8 +154,8 @@ test('an envelope without inputs decodes with the inputs field absent', async fu
 
 test('round-trip preserves multiple anchors with mixed entry kinds', async function() {
 	const builder = new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionID: 'tx-1' })
-		.setAnchor(anchor2, { persistentForwardingID: 'fwd-2' })
+		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.setAnchor(anchor2, { persistentForwardingId: 'fwd-2' })
 		.withSigner(anchor2)
 		.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
 
@@ -176,7 +176,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'signer not listed in envelope.anchors',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionID: 'x' })
+				.setAnchor(anchor1, { transactionId: 'x' })
 				.withSigner(stranger)
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.build());
@@ -186,7 +186,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'signer set without binding',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionID: 'x' })
+				.setAnchor(anchor1, { transactionId: 'x' })
 				.withSigner(anchor1)
 				.build());
 		}
@@ -195,7 +195,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'binding set without signer',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionID: 'x' })
+				.setAnchor(anchor1, { transactionId: 'x' })
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.build());
 		}
@@ -240,7 +240,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'maxLength too tight for a signed payload',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionID: 'x' })
+				.setAnchor(anchor1, { transactionId: 'x' })
 				.withSigner(anchor1)
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.withMaxLength(64)
@@ -259,7 +259,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'fromEncryptedExternal with empty principals list',
 		act: async function() {
 			const external = await new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionID: 'x' })
+				.setAnchor(anchor1, { transactionId: 'x' })
 				.withPrincipals([anchor1])
 				.build();
 			return(await AnchorExternal.fromEncryptedExternal(external, []));
@@ -329,7 +329,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'truncated DER',
 		makeExternal: async function() {
-			const valid = await buildPlain({ transactionID: 'x' });
+			const valid = await buildPlain({ transactionId: 'x' });
 			const decoded = Buffer.from(valid, 'base64');
 			const truncated = decoded.subarray(0, Math.max(1, decoded.length - 8));
 			return(Buffer.from(truncated).toString('base64'));
@@ -340,7 +340,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'plaintext blob decoded with the encrypted decoder',
 		makeExternal: async function() {
-			const result = await buildPlain({ transactionID: 'x' });
+			const result = await buildPlain({ transactionId: 'x' });
 			return(result);
 		},
 		decoder: 'encrypted-self',
@@ -349,7 +349,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'encrypted blob decoded with the plain decoder',
 		makeExternal: async function() {
-			const result = await buildEncrypted({ transactionID: 'x' }, [anchor1]);
+			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
 			return(result);
 		},
 		decoder: 'plain',
@@ -471,7 +471,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'encrypted decode with a wrong principal',
 		makeExternal: async function() {
-			const result = await buildEncrypted({ transactionID: 'x' }, [anchor1]);
+			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
 			return(result);
 		},
 		decoder: 'encrypted-stranger',
@@ -548,7 +548,7 @@ test.each(signedHelperCases)('buildSignedAnchorExternal produces a verified sign
 	const decoded = await decode(external);
 	expect(decoded.encrypted).toBe(expectedEncrypted);
 	expect(decoded.signed?.signer.comparePublicKey(anchor1)).toBe(true);
-	expect(decoded.envelope.anchors).toEqual({ [anchor1Key]: { transactionID: SIGNED_HELPER_TRANSACTION_ID }});
+	expect(decoded.envelope.anchors).toEqual({ [anchor1Key]: { transactionId: SIGNED_HELPER_TRANSACTION_ID }});
 	expect(decoded.envelope.binding).toEqual(SIGNED_HELPER_BINDING);
 	expect(decoded.envelope.inputs).toEqual(expectedInputs);
 

--- a/src/lib/anchor-external.test.ts
+++ b/src/lib/anchor-external.test.ts
@@ -89,8 +89,8 @@ const modeSpecs: ModeSpec[] = [
 ];
 
 const entryCases: { name: string; entry: AnchorExternalEntry }[] = [
-	{ name: 'transactionId', entry: { transactionId: 'tx-12345' }},
-	{ name: 'persistentForwardingId', entry: { persistentForwardingId: 'fwd-67890' }},
+	{ name: 'transactionID', entry: { transactionID: 'tx-12345' }},
+	{ name: 'persistentForwardingID', entry: { persistentForwardingID: 'fwd-67890' }},
 	{ name: 'destination', entry: { destination: '0x0000000000000000000000000000000000000000' }}
 ];
 
@@ -126,7 +126,7 @@ test.each(roundTripCases)('round-trips $name', async function({ entry, mode }) {
 
 test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
 	const builder = new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.setAnchor(anchor1, { transactionID: 'tx-1' })
 		.addInput(TEST_INPUT_BLOCK_HASH_1, 0)
 		.addInput(TEST_INPUT_BLOCK_HASH_2);
 	mode.configure(builder);
@@ -142,7 +142,7 @@ test.each(modeSpecs)('round-trips inputs in $name mode', async function(mode) {
 
 test('an envelope without inputs decodes with the inputs field absent', async function() {
 	const external = await new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionId: 'tx-1' })
+		.setAnchor(anchor1, { transactionID: 'tx-1' })
 		.build();
 
 	const decoded = await AnchorExternal.fromPlainExternal(external);
@@ -151,8 +151,8 @@ test('an envelope without inputs decodes with the inputs field absent', async fu
 
 test('round-trip preserves multiple anchors with mixed entry kinds', async function() {
 	const builder = new AnchorExternalBuilder()
-		.setAnchor(anchor1, { transactionId: 'tx-1' })
-		.setAnchor(anchor2, { persistentForwardingId: 'fwd-2' })
+		.setAnchor(anchor1, { transactionID: 'tx-1' })
+		.setAnchor(anchor2, { persistentForwardingID: 'fwd-2' })
 		.withSigner(anchor2)
 		.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX);
 
@@ -173,7 +173,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'signer not listed in envelope.anchors',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionId: 'x' })
+				.setAnchor(anchor1, { transactionID: 'x' })
 				.withSigner(stranger)
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.build());
@@ -183,7 +183,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'signer set without binding',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionId: 'x' })
+				.setAnchor(anchor1, { transactionID: 'x' })
 				.withSigner(anchor1)
 				.build());
 		}
@@ -192,7 +192,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'binding set without signer',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionId: 'x' })
+				.setAnchor(anchor1, { transactionID: 'x' })
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.build());
 		}
@@ -225,7 +225,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'maxLength too tight for a signed payload',
 		act: function() {
 			return(new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionId: 'x' })
+				.setAnchor(anchor1, { transactionID: 'x' })
 				.withSigner(anchor1)
 				.withBinding(TEST_BINDING_PREVIOUS_BLOCK_HASH, TEST_BINDING_OPERATION_INDEX)
 				.withMaxLength(64)
@@ -244,7 +244,7 @@ const misuseCases: MisuseCase[] = [
 		name: 'fromEncryptedExternal with empty principals list',
 		act: async function() {
 			const external = await new AnchorExternalBuilder()
-				.setAnchor(anchor1, { transactionId: 'x' })
+				.setAnchor(anchor1, { transactionID: 'x' })
 				.withPrincipals([anchor1])
 				.build();
 			return(await AnchorExternal.fromEncryptedExternal(external, []));
@@ -314,7 +314,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'truncated DER',
 		makeExternal: async function() {
-			const valid = await buildPlain({ transactionId: 'x' });
+			const valid = await buildPlain({ transactionID: 'x' });
 			const decoded = Buffer.from(valid, 'base64');
 			const truncated = decoded.subarray(0, Math.max(1, decoded.length - 8));
 			return(Buffer.from(truncated).toString('base64'));
@@ -325,7 +325,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'plaintext blob decoded with the encrypted decoder',
 		makeExternal: async function() {
-			const result = await buildPlain({ transactionId: 'x' });
+			const result = await buildPlain({ transactionID: 'x' });
 			return(result);
 		},
 		decoder: 'encrypted-self',
@@ -334,7 +334,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'encrypted blob decoded with the plain decoder',
 		makeExternal: async function() {
-			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
+			const result = await buildEncrypted({ transactionID: 'x' }, [anchor1]);
 			return(result);
 		},
 		decoder: 'plain',
@@ -456,7 +456,7 @@ const decodeRejectionCases: DecodeRejectionCase[] = [
 	{
 		name: 'encrypted decode with a wrong principal',
 		makeExternal: async function() {
-			const result = await buildEncrypted({ transactionId: 'x' }, [anchor1]);
+			const result = await buildEncrypted({ transactionID: 'x' }, [anchor1]);
 			return(result);
 		},
 		decoder: 'encrypted-stranger',

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -31,13 +31,13 @@ export type AnchorExternalEntry =
 		/**
 		 * Transaction id at the anchor.
 		 */
-		transactionId: string;
+		transactionID: string;
 	}
 	| {
 		/**
 		 * Persistent forwarding id at the anchor.
 		 */
-		persistentForwardingId: string;
+		persistentForwardingID: string;
 	}
 	| {
 		/**
@@ -283,11 +283,11 @@ export class AnchorExternalError extends KeetaAnchorUserError {
  * Convert a public entry to an encoded entry.
  */
 function entryToEncoded(entry: AnchorExternalEntry): EncodedAnchorExternalEntryV1 {
-	if ('transactionId' in entry) {
-		return({ t: entry.transactionId });
+	if ('transactionID' in entry) {
+		return({ t: entry.transactionID });
 	}
-	if ('persistentForwardingId' in entry) {
-		return({ p: entry.persistentForwardingId });
+	if ('persistentForwardingID' in entry) {
+		return({ p: entry.persistentForwardingID });
 	}
 
 	return({ d: entry.destination });
@@ -298,10 +298,10 @@ function entryToEncoded(entry: AnchorExternalEntry): EncodedAnchorExternalEntryV
  */
 function entryFromEncoded(entry: EncodedAnchorExternalEntryV1): AnchorExternalEntry {
 	if ('t' in entry) {
-		return({ transactionId: entry.t });
+		return({ transactionID: entry.t });
 	}
 	if ('p' in entry) {
-		return({ persistentForwardingId: entry.p });
+		return({ persistentForwardingID: entry.p });
 	}
 
 	return({ destination: entry.d });

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -37,13 +37,13 @@ export type AnchorExternalEntry =
 		/**
 		 * Transaction id at the anchor.
 		 */
-		transactionID: string;
+		transactionId: string;
 	}
 	| {
 		/**
 		 * Persistent forwarding id at the anchor.
 		 */
-		persistentForwardingID: string;
+		persistentForwardingId: string;
 	}
 	| {
 		/**
@@ -293,11 +293,11 @@ export class AnchorExternalError extends KeetaAnchorUserError {
  * Convert a public entry to an encoded entry.
  */
 function entryToEncoded(entry: AnchorExternalEntry): EncodedAnchorExternalEntryV1 {
-	if ('transactionID' in entry) {
-		return({ t: entry.transactionID });
+	if ('transactionId' in entry) {
+		return({ t: entry.transactionId });
 	}
-	if ('persistentForwardingID' in entry) {
-		return({ p: entry.persistentForwardingID });
+	if ('persistentForwardingId' in entry) {
+		return({ p: entry.persistentForwardingId });
 	}
 
 	return({ d: entry.destination });
@@ -308,10 +308,10 @@ function entryToEncoded(entry: AnchorExternalEntry): EncodedAnchorExternalEntryV
  */
 function entryFromEncoded(entry: EncodedAnchorExternalEntryV1): AnchorExternalEntry {
 	if ('t' in entry) {
-		return({ transactionID: entry.t });
+		return({ transactionId: entry.t });
 	}
 	if ('p' in entry) {
-		return({ persistentForwardingID: entry.p });
+		return({ persistentForwardingId: entry.p });
 	}
 
 	return({ destination: entry.d });
@@ -676,7 +676,7 @@ export type AnchorPayoutExternalOptions = {
  */
 export async function buildSignedAnchorExternal(options: AnchorPayoutExternalOptions): Promise<string> {
 	const builder = new AnchorExternalBuilder();
-	builder.setAnchor(options.anchor, { transactionID: options.transactionID });
+	builder.setAnchor(options.anchor, { transactionId: options.transactionID });
 	builder.withSigner(options.anchor);
 	builder.withBinding(options.binding.previousBlockHash, options.binding.operationIndex);
 

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -800,6 +800,25 @@ export class AnchorExternal {
 	}
 
 	/**
+	 * Decode an external string, dispatching on whether the blob is encrypted.
+	 *
+	 * Encrypted blobs are decrypted with the supplied decryption keys.
+	 * Plaintext blobs ignore them.
+	 *
+	 * @throws {@link AnchorExternalError} on decode failure.
+	 */
+	static async fromExternal(external: string, options?: { decryptionKeys?: Account[] }): Promise<AnchorExternal> {
+		const peeked = await AnchorExternal.peek(external);
+		if (peeked.encrypted) {
+			const encryptedResult = await AnchorExternal.fromEncryptedExternal(external, options?.decryptionKeys ?? []);
+			return(encryptedResult);
+		}
+
+		const plainResult = await AnchorExternal.fromPlainExternal(external);
+		return(plainResult);
+	}
+
+	/**
 	 * Inspect encrypted/signed flags of a candidate external string
 	 * without reading plaintext or requiring a decryption key.
 	 */

--- a/src/lib/anchor-external.ts
+++ b/src/lib/anchor-external.ts
@@ -653,7 +653,7 @@ export type AnchorPayoutExternalOptions = {
 	/**
 	 * Service-scoped transfer/transaction id to correlate.
 	 */
-	transactionId: string;
+	transactionID: string;
 	/**
 	 * On-chain operations feeding this payout in relevance order.
 	 */
@@ -676,7 +676,7 @@ export type AnchorPayoutExternalOptions = {
  */
 export async function buildSignedAnchorExternal(options: AnchorPayoutExternalOptions): Promise<string> {
 	const builder = new AnchorExternalBuilder();
-	builder.setAnchor(options.anchor, { transactionId: options.transactionId });
+	builder.setAnchor(options.anchor, { transactionID: options.transactionID });
 	builder.withSigner(options.anchor);
 	builder.withBinding(options.binding.previousBlockHash, options.binding.operationIndex);
 

--- a/src/lib/anchor-status.ts
+++ b/src/lib/anchor-status.ts
@@ -1,0 +1,231 @@
+import { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
+import type { AccountPublicKeyString } from '@keetanetwork/keetanet-client/lib/account.js';
+
+import { AnchorExternal } from './anchor-external.js';
+import type { AnchorExternalEntry } from './anchor-external.js';
+import type { KeetaNetAccount } from './asset.js';
+import type { VerifiableAccount } from './utils/signing.js';
+
+/**
+ * An anchor reference accepted when resolving a provider.
+ */
+export type AnchorReference = AccountPublicKeyString | VerifiableAccount;
+
+/**
+ * Provider-independent, standardized view of an anchor transfer's status.
+ */
+export type StandardizedTransferStatus<Transaction = unknown> = {
+	/**
+	 * Provider wire lifecycle state. Only `COMPLETE` is standardized.
+	 */
+	status: string;
+	/**
+	 * Anchor-scoped transaction id the status was read for.
+	 */
+	transactionId: string;
+	/**
+	 * Full source transaction record backing the status.
+	 */
+	transaction: Transaction;
+};
+
+/**
+ * Per-call options for {@link AnchorTransactionStatus.getStatus}.
+ */
+export type AnchorGetTransactionStatusOptions = {
+	/**
+	 * Account to authenticate the status request with, for anchors that
+	 * require (or scope) authentication on status reads.
+	 */
+	requesterAccount?: KeetaNetAccount;
+};
+
+/**
+ * Per-call options for {@link AnchorTransactionStatus.getStatusesFromExternal}.
+ */
+export type AnchorExternalTransactionStatusOptions = AnchorGetTransactionStatusOptions & {
+	/**
+	 * Accounts whose keys may decrypt an encrypted envelope.
+	 */
+	decryptionKeys?: VerifiableAccount[];
+};
+
+/**
+ * Per-anchor outcome from {@link AnchorTransactionStatus.getStatusesFromExternal}.
+ */
+export type AnchorTransactionStatusResult<Transaction = unknown> =
+	| {
+		/**
+		 * A status was read for the anchor.
+		 */
+		kind: 'status';
+		status: StandardizedTransferStatus<Transaction>;
+	}
+	| {
+		/**
+		 * Entry carries no transaction id (opaque, persistent-forwarding,
+		 * or destination), so no transfer status applies.
+		 */
+		kind: 'unavailable';
+	}
+	| {
+		/**
+		 * The anchor's provider could not be resolved.
+		 */
+		kind: 'unresolved';
+	}
+	| {
+		/**
+		 * Reading the status failed; the captured error is provided.
+		 */
+		kind: 'error';
+		error: unknown;
+	};
+
+/**
+ * On-chain coordinates of a Keeta operation, used to reverse-lookup the
+ * anchor transfer it belongs to when the operation carries no decodable
+ * transaction id (e.g. a deposit mint observed as a RECEIVE).
+ */
+export type AnchorOnChainReference = {
+	/**
+	 * Network id of the Keeta chain the operation was observed on.
+	 */
+	keetaNetworkId: bigint;
+	/**
+	 * Hash of the block carrying the operation.
+	 */
+	blockHash: string;
+	/**
+	 * Index of the operation within its block.
+	 */
+	operationIndex: number;
+};
+
+/**
+ * Reads the status of a single transaction at one resolved anchor.
+ */
+export interface AnchorTransferReader<Transaction = unknown> {
+	/**
+	 * Read the standardized status of one transaction at this anchor.
+	 */
+	getTransferStatus(transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction>>;
+	/**
+	 * Reverse-lookup the transfer an on-chain operation belongs to, for
+	 * operations that carry no transaction id of their own.
+	 */
+	findByOnChain?(reference: AnchorOnChainReference, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction> | null>;
+}
+
+/**
+ * Resolves an anchor account to a transfer-status reader.
+ */
+export interface AnchorStatusSource<Transaction = unknown> {
+	/**
+	 * Resolve the reader for an anchor account, or `null` if no provider
+	 * serves it.
+	 */
+	getReader(anchor: AnchorReference): Promise<AnchorTransferReader<Transaction> | null>;
+}
+
+/**
+ * Is `true` once a transfer has settled.
+ *
+ * Other states are provider-specific and cannot be classified here.
+ */
+export function isCompletedTransferStatus(status: string): boolean {
+	return(status === 'COMPLETE');
+}
+
+/**
+ * Reads anchor transfer status through a single, provider-independent
+ * surface backed by an injected {@link AnchorStatusSource}.
+ */
+export class AnchorTransactionStatus<Transaction = unknown> {
+	readonly #source: AnchorStatusSource<Transaction>;
+
+	constructor(source: AnchorStatusSource<Transaction>) {
+		this.#source = source;
+	}
+
+	/**
+	 * Resolve the transfer-status reader an anchor account is filed under.
+	 *
+	 * @returns The reader, or `null` if none resolves for the anchor.
+	 */
+	async getReader(anchor: AnchorReference): Promise<AnchorTransferReader<Transaction> | null> {
+		const reader = await this.#source.getReader(anchor);
+		return(reader);
+	}
+
+	/**
+	 * Read the standardized status of a single anchor transaction.
+	 *
+	 * @returns The standardized status, or `null` if the anchor's provider
+	 *          could not be resolved.
+	 */
+	async getStatus(anchor: AnchorReference, transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction> | null> {
+		const reader = await this.getReader(anchor);
+		if (reader === null) {
+			return(null);
+		}
+
+		const status = await reader.getTransferStatus(transactionId, options);
+		return(status);
+	}
+
+	/**
+	 * Read the standardized status of every anchor referenced by an encoded
+	 * external field.
+	 */
+	async getStatusesFromExternal(external: string, options?: AnchorExternalTransactionStatusOptions): Promise<{ [anchorId: string]: AnchorTransactionStatusResult<Transaction> }> {
+		const statusOptions: AnchorGetTransactionStatusOptions = {};
+		if (options?.requesterAccount !== undefined) {
+			statusOptions.requesterAccount = options.requesterAccount;
+		}
+
+		const peeked = await AnchorExternal.peek(external);
+
+		let decoded: AnchorExternal;
+		if (peeked.encrypted) {
+			decoded = await AnchorExternal.fromEncryptedExternal(external, options?.decryptionKeys ?? []);
+		} else {
+			decoded = await AnchorExternal.fromPlainExternal(external);
+		}
+
+		const entries = Object.entries(decoded.envelope.anchors);
+
+		const settled = await Promise.all(entries.map(async ([anchorId, entry]): Promise<[string, AnchorTransactionStatusResult<Transaction>]> => {
+			const result = await this.#readEntryStatus(anchorId, entry, statusOptions);
+			return([anchorId, result]);
+		}));
+
+		const results = Object.fromEntries(settled);
+		return(results);
+	}
+
+	/**
+	 * Resolve a single decoded per-anchor entry to its outcome.
+	 */
+	async #readEntryStatus(anchorId: string, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
+		if (!('transactionId' in entry)) {
+			return({ kind: 'unavailable' });
+		}
+
+		let status: StandardizedTransferStatus<Transaction> | null;
+		try {
+			const anchor = KeetaNetLib.Account.fromPublicKeyString(anchorId);
+			status = await this.getStatus(anchor, entry.transactionId, options);
+		} catch (error) {
+			return({ kind: 'error', error: error });
+		}
+
+		if (status === null) {
+			return({ kind: 'unresolved' });
+		}
+
+		return({ kind: 'status', status: status });
+	}
+}
+
+export default AnchorTransactionStatus;

--- a/src/lib/anchor-status.ts
+++ b/src/lib/anchor-status.ts
@@ -22,7 +22,7 @@ export type StandardizedTransferStatus<Transaction = unknown> = {
 	/**
 	 * Anchor-scoped transaction id the status was read for.
 	 */
-	transactionId: string;
+	transactionID: string;
 	/**
 	 * Full source transaction record backing the status.
 	 */
@@ -91,7 +91,7 @@ export type AnchorOnChainReference = {
 	/**
 	 * Network id of the Keeta chain the operation was observed on.
 	 */
-	keetaNetworkId: bigint;
+	keetaNetworkID: bigint;
 	/**
 	 * Hash of the block carrying the operation.
 	 */
@@ -109,7 +109,7 @@ export interface AnchorTransferReader<Transaction = unknown> {
 	/**
 	 * Read the standardized status of one transaction at this anchor.
 	 */
-	getTransferStatus(transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction>>;
+	getTransferStatus(transactionID: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction>>;
 	/**
 	 * Reverse-lookup the transfer an on-chain operation belongs to, for
 	 * operations that carry no transaction id of their own.
@@ -164,13 +164,13 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 	 * @returns The standardized status, or `null` if the anchor's provider
 	 *          could not be resolved.
 	 */
-	async getStatus(anchor: AnchorReference, transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction> | null> {
+	async getStatus(anchor: AnchorReference, transactionID: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<Transaction> | null> {
 		const reader = await this.getReader(anchor);
 		if (reader === null) {
 			return(null);
 		}
 
-		const status = await reader.getTransferStatus(transactionId, options);
+		const status = await reader.getTransferStatus(transactionID, options);
 		return(status);
 	}
 
@@ -178,7 +178,7 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 	 * Read the standardized status of every anchor referenced by an encoded
 	 * external field.
 	 */
-	async getStatusesFromExternal(external: string, options?: AnchorExternalTransactionStatusOptions): Promise<{ [anchorId: string]: AnchorTransactionStatusResult<Transaction> }> {
+	async getStatusesFromExternal(external: string, options?: AnchorExternalTransactionStatusOptions): Promise<{ [anchorID: string]: AnchorTransactionStatusResult<Transaction> }> {
 		const statusOptions: AnchorGetTransactionStatusOptions = {};
 		if (options?.requesterAccount !== undefined) {
 			statusOptions.requesterAccount = options.requesterAccount;
@@ -195,9 +195,9 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 
 		const entries = Object.entries(decoded.envelope.anchors);
 
-		const settled = await Promise.all(entries.map(async ([anchorId, entry]): Promise<[string, AnchorTransactionStatusResult<Transaction>]> => {
-			const result = await this.#readEntryStatus(anchorId, entry, statusOptions);
-			return([anchorId, result]);
+		const settled = await Promise.all(entries.map(async ([anchorID, entry]): Promise<[string, AnchorTransactionStatusResult<Transaction>]> => {
+			const result = await this.#readEntryStatus(anchorID, entry, statusOptions);
+			return([anchorID, result]);
 		}));
 
 		const results = Object.fromEntries(settled);
@@ -207,15 +207,15 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 	/**
 	 * Resolve a single decoded per-anchor entry to its outcome.
 	 */
-	async #readEntryStatus(anchorId: string, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
-		if (!('transactionId' in entry)) {
+	async #readEntryStatus(anchorID: string, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
+		if (!('transactionID' in entry)) {
 			return({ kind: 'unavailable' });
 		}
 
 		let status: StandardizedTransferStatus<Transaction> | null;
 		try {
-			const anchor = KeetaNetLib.Account.fromPublicKeyString(anchorId);
-			status = await this.getStatus(anchor, entry.transactionId, options);
+			const anchor = KeetaNetLib.Account.fromPublicKeyString(anchorID);
+			status = await this.getStatus(anchor, entry.transactionID, options);
 		} catch (error) {
 			return({ kind: 'error', error: error });
 		}

--- a/src/lib/anchor-status.ts
+++ b/src/lib/anchor-status.ts
@@ -208,14 +208,14 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 	 * Resolve a single decoded per-anchor entry to its outcome.
 	 */
 	async #readEntryStatus(anchorID: string, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
-		if (!('transactionID' in entry)) {
+		if (!('transactionId' in entry)) {
 			return({ kind: 'unavailable' });
 		}
 
 		let status: StandardizedTransferStatus<Transaction> | null;
 		try {
 			const anchor = KeetaNetLib.Account.fromPublicKeyString(anchorID);
-			status = await this.getStatus(anchor, entry.transactionID, options);
+			status = await this.getStatus(anchor, entry.transactionId, options);
 		} catch (error) {
 			return({ kind: 'error', error: error });
 		}

--- a/src/lib/anchor-status.ts
+++ b/src/lib/anchor-status.ts
@@ -184,19 +184,22 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 			statusOptions.requesterAccount = options.requesterAccount;
 		}
 
-		const peeked = await AnchorExternal.peek(external);
-
-		let decoded: AnchorExternal;
-		if (peeked.encrypted) {
-			decoded = await AnchorExternal.fromEncryptedExternal(external, options?.decryptionKeys ?? []);
-		} else {
-			decoded = await AnchorExternal.fromPlainExternal(external);
+		const decodeOptions: { decryptionKeys?: VerifiableAccount[] } = {};
+		if (options?.decryptionKeys !== undefined) {
+			decodeOptions.decryptionKeys = options.decryptionKeys;
 		}
 
+		const decoded = await AnchorExternal.fromExternal(external, decodeOptions);
 		const entries = Object.entries(decoded.envelope.anchors);
-
 		const settled = await Promise.all(entries.map(async ([anchorID, entry]): Promise<[string, AnchorTransactionStatusResult<Transaction>]> => {
-			const result = await this.#readEntryStatus(anchorID, entry, statusOptions);
+			let anchor: KeetaNetAccount;
+			try {
+				anchor = KeetaNetLib.Account.fromPublicKeyString(anchorID);
+			} catch (error) {
+				return([anchorID, { kind: 'error', error: error }]);
+			}
+
+			const result = await this.#readEntryStatus(anchor, entry, statusOptions);
 			return([anchorID, result]);
 		}));
 
@@ -207,14 +210,13 @@ export class AnchorTransactionStatus<Transaction = unknown> {
 	/**
 	 * Resolve a single decoded per-anchor entry to its outcome.
 	 */
-	async #readEntryStatus(anchorID: string, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
+	async #readEntryStatus(anchor: KeetaNetAccount, entry: AnchorExternalEntry, options: AnchorGetTransactionStatusOptions): Promise<AnchorTransactionStatusResult<Transaction>> {
 		if (!('transactionId' in entry)) {
 			return({ kind: 'unavailable' });
 		}
 
 		let status: StandardizedTransferStatus<Transaction> | null;
 		try {
-			const anchor = KeetaNetLib.Account.fromPublicKeyString(anchorID);
 			status = await this.getStatus(anchor, entry.transactionId, options);
 		} catch (error) {
 			return({ kind: 'error', error: error });

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -47,7 +47,7 @@ async function externalReferencesTransfer(external: unknown, txId: string): Prom
 	}
 
 	return(Object.values(decoded.envelope.anchors).some(function(entry) {
-		return('transactionID' in entry && entry.transactionID === txId);
+		return('transactionId' in entry && entry.transactionId === txId);
 	}));
 }
 
@@ -2055,7 +2055,7 @@ describe('AnchorChainingPath keetaSendAuthRequired', function() {
 		expect(decoded.signed).toBeUndefined();
 		expect(decoded.envelope.inputs).toBeUndefined();
 		expect(decoded.envelope.anchors).toEqual({
-			[h.bankSignerEU.publicKeyString.get()]: { transactionID: step1.plan.transfer.transferId }
+			[h.bankSignerEU.publicKeyString.get()]: { transactionId: step1.plan.transfer.transferId }
 		});
 	});
 

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -47,7 +47,7 @@ async function externalReferencesTransfer(external: unknown, txId: string): Prom
 	}
 
 	return(Object.values(decoded.envelope.anchors).some(function(entry) {
-		return('transactionId' in entry && entry.transactionId === txId);
+		return('transactionID' in entry && entry.transactionID === txId);
 	}));
 }
 
@@ -2055,7 +2055,7 @@ describe('AnchorChainingPath keetaSendAuthRequired', function() {
 		expect(decoded.signed).toBeUndefined();
 		expect(decoded.envelope.inputs).toBeUndefined();
 		expect(decoded.envelope.anchors).toEqual({
-			[h.bankSignerEU.publicKeyString.get()]: { transactionId: step1.plan.transfer.transferId }
+			[h.bankSignerEU.publicKeyString.get()]: { transactionID: step1.plan.transfer.transferId }
 		});
 	});
 

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1978,7 +1978,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		}
 
 		const anchor = KeetaNet.lib.Account.fromPublicKeyString(anchorKey);
-		const builder = new AnchorExternalBuilder().setAnchor(anchor, { transactionID });
+		const builder = new AnchorExternalBuilder().setAnchor(anchor, { transactionId: transactionID });
 
 		for (const input of inputs) {
 			builder.addInput(input.blockHash, input.operationIndex);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1971,14 +1971,14 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 	/**
 	 * Construct the unsigned external envelope for a user-funded KEETA_SEND.
 	 */
-	static async #buildKeetaSendExternal(provider: AssetMovementProvider, transactionId: string, inputs: readonly AnchorExternalInput[]): Promise<string | undefined> {
+	static async #buildKeetaSendExternal(provider: AssetMovementProvider, transactionID: string, inputs: readonly AnchorExternalInput[]): Promise<string | undefined> {
 		const anchorKey = provider.serviceInfo.account;
 		if (anchorKey === undefined) {
 			return(undefined);
 		}
 
 		const anchor = KeetaNet.lib.Account.fromPublicKeyString(anchorKey);
-		const builder = new AnchorExternalBuilder().setAnchor(anchor, { transactionId });
+		const builder = new AnchorExternalBuilder().setAnchor(anchor, { transactionID });
 
 		for (const input of inputs) {
 			builder.addInput(input.blockHash, input.operationIndex);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,17 @@ import * as URI from './uri.js';
 
 import Resolver from './resolver.js';
 export { AnchorExternal } from './anchor-external.js';
+export { AnchorTransactionStatus, isCompletedTransferStatus } from './anchor-status.js';
+export type {
+	AnchorOnChainReference,
+	AnchorReference,
+	AnchorStatusSource,
+	AnchorTransferReader,
+	AnchorGetTransactionStatusOptions,
+	AnchorExternalTransactionStatusOptions,
+	AnchorTransactionStatusResult,
+	StandardizedTransferStatus
+} from './anchor-status.js';
 export {
 	Certificates,
 	EncryptedContainer,

--- a/src/services/asset-movement/status-source.test.ts
+++ b/src/services/asset-movement/status-source.test.ts
@@ -27,8 +27,8 @@ function newAccount(): Account {
  * `true` when a SEND's external field references the given transfer, either
  * as the raw transfer id or as an entry in a decodable plaintext envelope.
  */
-async function externalReferencesTransfer(external: unknown, txId: string): Promise<boolean> {
-	if (external === txId) {
+async function externalReferencesTransfer(external: unknown, txID: string): Promise<boolean> {
+	if (external === txID) {
 		return(true);
 	}
 	if (typeof external !== 'string' || external === '') {
@@ -43,7 +43,7 @@ async function externalReferencesTransfer(external: unknown, txId: string): Prom
 	}
 
 	return(Object.values(decoded.envelope.anchors).some(function(entry) {
-		return('transactionId' in entry && entry.transactionId === txId);
+		return('transactionID' in entry && entry.transactionID === txID);
 	}));
 }
 
@@ -82,11 +82,11 @@ async function createStatusFixture() {
 				const fee = 1n;
 				const receive = value - fee;
 				transferCounter += 1;
-				const txId = `transfer-${transferCounter}`;
+				const txID = `transfer-${transferCounter}`;
 				const now = new Date().toISOString();
 
-				statusMap.set(txId, {
-					id: txId,
+				statusMap.set(txID, {
+					id: txID,
 					status: 'PENDING',
 					asset: request.asset,
 					from: { location: request.from.location, value: value.toString(), transactions: { deposit: null, persistentForwarding: null, finalization: null }},
@@ -102,11 +102,11 @@ async function createStatusFixture() {
 						const blockHash = block.hash.toString();
 						for (let operationIndex = 0; operationIndex < block.operations.length; operationIndex++) {
 							const operation = block.operations[operationIndex];
-							if (operation?.type === KeetaNet.lib.Block.OperationType.SEND && await externalReferencesTransfer(operation.external, txId)) {
-								const existing = statusMap.get(txId);
+							if (operation?.type === KeetaNet.lib.Block.OperationType.SEND && await externalReferencesTransfer(operation.external, txID)) {
+								const existing = statusMap.get(txID);
 								if (existing && existing.status !== 'COMPLETE') {
-									statusMap.set(txId, { ...existing, status: 'COMPLETE', updatedAt: new Date().toISOString() });
-									completionIndex.set(`${blockHash}#${operationIndex}`, txId);
+									statusMap.set(txID, { ...existing, status: 'COMPLETE', updatedAt: new Date().toISOString() });
+									completionIndex.set(`${blockHash}#${operationIndex}`, txID);
 								}
 								listenerHandle?.remove();
 							}
@@ -116,7 +116,7 @@ async function createStatusFixture() {
 				});
 
 				return({
-					id: txId,
+					id: txID,
 					instructionChoices: [{
 						type: 'KEETA_SEND' as const,
 						location: request.from.location,
@@ -141,12 +141,12 @@ async function createStatusFixture() {
 				await blockListener.scan();
 				const transactions: KeetaAssetMovementTransaction[] = [];
 				for (const probe of request.transactions ?? []) {
-					const txId = completionIndex.get(`${probe.transaction.id}#${probe.transaction.nonce}`);
-					if (txId === undefined) {
+					const txID = completionIndex.get(`${probe.transaction.id}#${probe.transaction.nonce}`);
+					if (txID === undefined) {
 						continue;
 					}
 
-					const transaction = statusMap.get(txId);
+					const transaction = statusMap.get(txID);
 					if (transaction) {
 						transactions.push(transaction);
 					}
@@ -202,9 +202,9 @@ async function createStatusFixture() {
 	 *
 	 * @returns The hash of the published send block.
 	 */
-	async function fundTransfer(transactionId: string, value: bigint): Promise<string> {
+	async function fundTransfer(transactionID: string, value: bigint): Promise<string> {
 		const external = await new AnchorExternal.Builder()
-			.setAnchor(anchorSigner, { transactionId })
+			.setAnchor(anchorSigner, { transactionID })
 			.build();
 
 		const published = await client.send(anchorDepositAccount, value, token, external);
@@ -244,7 +244,7 @@ test('getStatus: live transfer reads PENDING, then COMPLETE once the on-chain se
 
 	const pending = await fixture.status.getStatus(fixture.anchorSigner, transfer.transferId);
 	expect(pending?.status).toBe('PENDING');
-	expect(pending?.transactionId).toBe(transfer.transferId);
+	expect(pending?.transactionID).toBe(transfer.transferId);
 	expect(isCompletedTransferStatus(pending?.status ?? '')).toBe(false);
 
 	await fixture.fundTransfer(transfer.transferId, 5n);
@@ -264,7 +264,7 @@ test.each([
 	const transfer = await fixture.initiateTransfer(5n);
 
 	const builder = new AnchorExternal.Builder()
-		.setAnchor(fixture.anchorSigner, { transactionId: transfer.transferId });
+		.setAnchor(fixture.anchorSigner, { transactionID: transfer.transferId });
 	if (encrypt) {
 		builder.withPrincipals([ recipient ]);
 	}
@@ -282,7 +282,7 @@ test.each([
 		throw(new Error(`Expected a status result, got ${result?.kind}`));
 	}
 
-	expect(result.status.transactionId).toBe(transfer.transferId);
+	expect(result.status.transactionID).toBe(transfer.transferId);
 	expect(result.status.status).toBe('PENDING');
 });
 
@@ -292,8 +292,8 @@ test('getStatusesFromExternal: entry variants map to unavailable, unresolved, an
 	const opaqueAnchor = newAccount();
 
 	const external = await new AnchorExternal.Builder()
-		.setAnchor(fixture.anchorSigner, { transactionId: 'no-such-transfer' })
-		.setAnchor(unknownAnchor, { transactionId: 'transfer-at-unknown-anchor' })
+		.setAnchor(fixture.anchorSigner, { transactionID: 'no-such-transfer' })
+		.setAnchor(unknownAnchor, { transactionID: 'transfer-at-unknown-anchor' })
 		.setAnchor(opaqueAnchor, { destination: EVM_RECIPIENT })
 		.build();
 
@@ -314,15 +314,15 @@ test('findByOnChain: resolves the transfer by real on-chain coordinates, null ot
 	}
 
 	const found = await reader.findByOnChain({
-		keetaNetworkId: fixture.client.network,
+		keetaNetworkID: fixture.client.network,
 		blockHash: blockHash,
 		operationIndex: 0
 	});
-	expect(found?.transactionId).toBe(transfer.transferId);
+	expect(found?.transactionID).toBe(transfer.transferId);
 	expect(found?.status).toBe('COMPLETE');
 
 	const missing = await reader.findByOnChain({
-		keetaNetworkId: fixture.client.network,
+		keetaNetworkID: fixture.client.network,
 		blockHash: blockHash,
 		operationIndex: 7
 	});

--- a/src/services/asset-movement/status-source.test.ts
+++ b/src/services/asset-movement/status-source.test.ts
@@ -1,0 +1,338 @@
+import { expect, test } from 'vitest';
+
+import type { AssetLocationString, KeetaAssetMovementTransaction } from './common.js';
+import type { ServiceMetadataExternalizable } from '../../lib/resolver.js';
+import { KeetaNet } from '../../client/index.js';
+import { KeetaNetAssetMovementAnchorHTTPServer } from './server.js';
+import { KeetaAnchorUserError } from '../../lib/error.js';
+import { AnchorExternal } from '../../lib/anchor-external.js';
+import { AnchorTransactionStatus, isCompletedTransferStatus } from '../../lib/anchor-status.js';
+import { BlockListener } from '../../lib/block-listener.js';
+import { createNodeAndClient } from '../../lib/utils/tests/node.js';
+import KeetaAssetMovementStatusSource from './status-source.js';
+import KeetaAssetMovementAnchorClient from './client.js';
+import Resolver from '../../lib/resolver.js';
+
+type Account = ReturnType<typeof KeetaNet.lib.Account.fromSeed>;
+
+const EVM_LOCATION: AssetLocationString = 'chain:evm:100';
+const EVM_ASSET_ID = 'evm:0xc0634090F2Fe6c6d75e61Be2b949464aBB498973';
+const EVM_RECIPIENT = 'evm:0x52908400098527886E0F7030069857D2E4169EE7';
+
+function newAccount(): Account {
+	return(KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0));
+}
+
+/**
+ * `true` when a SEND's external field references the given transfer, either
+ * as the raw transfer id or as an entry in a decodable plaintext envelope.
+ */
+async function externalReferencesTransfer(external: unknown, txId: string): Promise<boolean> {
+	if (external === txId) {
+		return(true);
+	}
+	if (typeof external !== 'string' || external === '') {
+		return(false);
+	}
+
+	let decoded;
+	try {
+		decoded = await AnchorExternal.fromPlainExternal(external);
+	} catch {
+		return(false);
+	}
+
+	return(Object.values(decoded.envelope.anchors).some(function(entry) {
+		return('transactionId' in entry && entry.transactionId === txId);
+	}));
+}
+
+/**
+ * The anchor correlates transfers by scanning real on-chain blocks and indexes
+ * completions by block hash and operation index so reverse lookups work.
+ */
+async function createStatusFixture() {
+	const rootAccount = newAccount();
+	const anchorSigner = newAccount();
+	const anchorDepositAccount = newAccount();
+
+	const { userClient: client, fees } = await createNodeAndClient(rootAccount);
+	fees.disable();
+
+	const token = client.baseToken;
+	const keetaLocation: AssetLocationString = `chain:keeta:${client.network}`;
+
+	const statusMap = new Map<string, KeetaAssetMovementTransaction>();
+	const completionIndex = new Map<string, string>();
+	const blockListener = new BlockListener({ client: client.client });
+	let transferCounter = 0;
+
+	const server = new KeetaNetAssetMovementAnchorHTTPServer({
+		metadataSigner: anchorSigner,
+		assetMovement: {
+			supportedAssets: [{
+				asset: token.publicKeyString.get(),
+				paths: [{ pair: [
+					{ location: keetaLocation, id: token.publicKeyString.get(), rails: { common: [ 'KEETA_SEND' ] }},
+					{ location: EVM_LOCATION, id: EVM_ASSET_ID, rails: { common: [ 'EVM_SEND' ] }}
+				] }]
+			}],
+			initiateTransfer: async function(request) {
+				const value = BigInt(request.value);
+				const fee = 1n;
+				const receive = value - fee;
+				transferCounter += 1;
+				const txId = `transfer-${transferCounter}`;
+				const now = new Date().toISOString();
+
+				statusMap.set(txId, {
+					id: txId,
+					status: 'PENDING',
+					asset: request.asset,
+					from: { location: request.from.location, value: value.toString(), transactions: { deposit: null, persistentForwarding: null, finalization: null }},
+					to:   { location: request.to.location,   value: receive.toString(), transactions: { withdraw: null }},
+					fee: null,
+					createdAt: now,
+					updatedAt: now
+				});
+
+				let listenerHandle: { remove: () => void } | null = null;
+				listenerHandle = blockListener.on('block', {
+					callback: async function({ block }) {
+						const blockHash = block.hash.toString();
+						for (let operationIndex = 0; operationIndex < block.operations.length; operationIndex++) {
+							const operation = block.operations[operationIndex];
+							if (operation?.type === KeetaNet.lib.Block.OperationType.SEND && await externalReferencesTransfer(operation.external, txId)) {
+								const existing = statusMap.get(txId);
+								if (existing && existing.status !== 'COMPLETE') {
+									statusMap.set(txId, { ...existing, status: 'COMPLETE', updatedAt: new Date().toISOString() });
+									completionIndex.set(`${blockHash}#${operationIndex}`, txId);
+								}
+								listenerHandle?.remove();
+							}
+						}
+						return({ requiresWork: false });
+					}
+				});
+
+				return({
+					id: txId,
+					instructionChoices: [{
+						type: 'KEETA_SEND' as const,
+						location: request.from.location,
+						sendToAddress: anchorDepositAccount.publicKeyString.get(),
+						value: value.toString(),
+						tokenAddress: token.publicKeyString.get(),
+						assetFee: fee.toString(),
+						totalReceiveAmount: receive.toString()
+					}]
+				});
+			},
+			getTransferStatus: async function(id) {
+				await blockListener.scan();
+				const transaction = statusMap.get(id);
+				if (!transaction) {
+					throw(new KeetaAnchorUserError(`Unknown transfer ID: ${id}`));
+				}
+
+				return({ transaction });
+			},
+			listTransactions: async function(request) {
+				await blockListener.scan();
+				const transactions: KeetaAssetMovementTransaction[] = [];
+				for (const probe of request.transactions ?? []) {
+					const txId = completionIndex.get(`${probe.transaction.id}#${probe.transaction.nonce}`);
+					if (txId === undefined) {
+						continue;
+					}
+
+					const transaction = statusMap.get(txId);
+					if (transaction) {
+						transactions.push(transaction);
+					}
+				}
+
+				return({ transactions, total: String(transactions.length) });
+			}
+		}
+	});
+
+	await server.start();
+
+	await client.setInfo({
+		name: '',
+		description: '',
+		metadata: Resolver.Metadata.formatMetadata({
+			version: 1,
+			currencyMap: {},
+			services: {
+				assetMovement: {
+					Test: await server.serviceMetadata()
+				}
+			}
+		} satisfies ServiceMetadataExternalizable)
+	});
+
+	const resolver = new Resolver({ root: rootAccount, client, trustedCAs: [] });
+	const amClient = new KeetaAssetMovementAnchorClient(client, { resolver });
+	const status = new AnchorTransactionStatus(new KeetaAssetMovementStatusSource({ client, resolver }));
+
+	/**
+	 * Initiate a real transfer at the anchor over HTTP, keeta -> EVM.
+	 */
+	async function initiateTransfer(value: bigint) {
+		const provider = await amClient.getProviderByAccount(anchorSigner);
+		if (provider === null) {
+			throw(new Error('Anchor provider did not resolve by its signing account'));
+		}
+
+		const transfer = await provider.initiateTransfer({
+			asset: { from: token.publicKeyString.get(), to: EVM_ASSET_ID },
+			from: { location: keetaLocation },
+			to: { location: EVM_LOCATION, recipient: EVM_RECIPIENT },
+			value: value
+		});
+
+		return(transfer);
+	}
+
+	/**
+	 * Fund the transfer with a real on-chain SEND carrying a client-built
+	 * plaintext envelope.
+	 *
+	 * @returns The hash of the published send block.
+	 */
+	async function fundTransfer(transactionId: string, value: bigint): Promise<string> {
+		const external = await new AnchorExternal.Builder()
+			.setAnchor(anchorSigner, { transactionId })
+			.build();
+
+		const published = await client.send(anchorDepositAccount, value, token, external);
+		let publishedBlocks;
+		if ('blocks' in published) {
+			publishedBlocks = published.blocks;
+		} else {
+			publishedBlocks = published.voteStaple.blocks;
+		}
+
+		const sendBlock = publishedBlocks[0];
+		if (sendBlock === undefined) {
+			throw(new Error('Expected the send to publish a block'));
+		}
+
+		return(sendBlock.hash.toString());
+	}
+
+	return({
+		client,
+		token,
+		keetaLocation,
+		anchorSigner,
+		anchorDepositAccount,
+		status,
+		initiateTransfer,
+		fundTransfer,
+		[Symbol.asyncDispose]: async function() {
+			await server[Symbol.asyncDispose]?.();
+		}
+	});
+}
+
+test('getStatus: live transfer reads PENDING, then COMPLETE once the on-chain send settles', async function() {
+	await using fixture = await createStatusFixture();
+	const transfer = await fixture.initiateTransfer(5n);
+
+	const pending = await fixture.status.getStatus(fixture.anchorSigner, transfer.transferId);
+	expect(pending?.status).toBe('PENDING');
+	expect(pending?.transactionId).toBe(transfer.transferId);
+	expect(isCompletedTransferStatus(pending?.status ?? '')).toBe(false);
+
+	await fixture.fundTransfer(transfer.transferId, 5n);
+
+	const complete = await fixture.status.getStatus(fixture.anchorSigner, transfer.transferId);
+	expect(complete?.status).toBe('COMPLETE');
+	expect(isCompletedTransferStatus(complete?.status ?? '')).toBe(true);
+	expect(complete?.transaction.id).toBe(transfer.transferId);
+});
+
+test.each([
+	{ kind: 'plaintext', encrypt: false },
+	{ kind: 'encrypted', encrypt: true }
+])('getStatusesFromExternal: $kind envelope resolves the live transfer', async function({ encrypt }) {
+	await using fixture = await createStatusFixture();
+	const recipient = newAccount();
+	const transfer = await fixture.initiateTransfer(5n);
+
+	const builder = new AnchorExternal.Builder()
+		.setAnchor(fixture.anchorSigner, { transactionId: transfer.transferId });
+	if (encrypt) {
+		builder.withPrincipals([ recipient ]);
+	}
+
+	const external = await builder.build();
+
+	const options: Parameters<typeof fixture.status.getStatusesFromExternal>[1] = {};
+	if (encrypt) {
+		options.decryptionKeys = [ recipient ];
+	}
+
+	const results = await fixture.status.getStatusesFromExternal(external, options);
+	const result = results[fixture.anchorSigner.publicKeyString.get()];
+	if (result?.kind !== 'status') {
+		throw(new Error(`Expected a status result, got ${result?.kind}`));
+	}
+
+	expect(result.status.transactionId).toBe(transfer.transferId);
+	expect(result.status.status).toBe('PENDING');
+});
+
+test('getStatusesFromExternal: entry variants map to unavailable, unresolved, and error', async function() {
+	await using fixture = await createStatusFixture();
+	const unknownAnchor = newAccount();
+	const opaqueAnchor = newAccount();
+
+	const external = await new AnchorExternal.Builder()
+		.setAnchor(fixture.anchorSigner, { transactionId: 'no-such-transfer' })
+		.setAnchor(unknownAnchor, { transactionId: 'transfer-at-unknown-anchor' })
+		.setAnchor(opaqueAnchor, { destination: EVM_RECIPIENT })
+		.build();
+
+	const results = await fixture.status.getStatusesFromExternal(external);
+	expect(results[fixture.anchorSigner.publicKeyString.get()]?.kind).toBe('error');
+	expect(results[unknownAnchor.publicKeyString.get()]?.kind).toBe('unresolved');
+	expect(results[opaqueAnchor.publicKeyString.get()]?.kind).toBe('unavailable');
+});
+
+test('findByOnChain: resolves the transfer by real on-chain coordinates, null otherwise', async function() {
+	await using fixture = await createStatusFixture();
+	const transfer = await fixture.initiateTransfer(5n);
+	const blockHash = await fixture.fundTransfer(transfer.transferId, 5n);
+
+	const reader = await fixture.status.getReader(fixture.anchorSigner);
+	if (reader?.findByOnChain === undefined) {
+		throw(new Error('Expected the asset-movement reader to support on-chain lookups'));
+	}
+
+	const found = await reader.findByOnChain({
+		keetaNetworkId: fixture.client.network,
+		blockHash: blockHash,
+		operationIndex: 0
+	});
+	expect(found?.transactionId).toBe(transfer.transferId);
+	expect(found?.status).toBe('COMPLETE');
+
+	const missing = await reader.findByOnChain({
+		keetaNetworkId: fixture.client.network,
+		blockHash: blockHash,
+		operationIndex: 7
+	});
+	expect(missing).toBeNull();
+});
+
+test('getReader: an account with no anchor service entry resolves to null', async function() {
+	await using fixture = await createStatusFixture();
+	const stranger = newAccount();
+
+	const reader = await fixture.status.getReader(stranger);
+	expect(reader).toBeNull();
+});

--- a/src/services/asset-movement/status-source.test.ts
+++ b/src/services/asset-movement/status-source.test.ts
@@ -43,7 +43,7 @@ async function externalReferencesTransfer(external: unknown, txID: string): Prom
 	}
 
 	return(Object.values(decoded.envelope.anchors).some(function(entry) {
-		return('transactionID' in entry && entry.transactionID === txID);
+		return('transactionId' in entry && entry.transactionId === txID);
 	}));
 }
 
@@ -202,9 +202,9 @@ async function createStatusFixture() {
 	 *
 	 * @returns The hash of the published send block.
 	 */
-	async function fundTransfer(transactionID: string, value: bigint): Promise<string> {
+	async function fundTransfer(transactionId: string, value: bigint): Promise<string> {
 		const external = await new AnchorExternal.Builder()
-			.setAnchor(anchorSigner, { transactionID })
+			.setAnchor(anchorSigner, { transactionId })
 			.build();
 
 		const published = await client.send(anchorDepositAccount, value, token, external);
@@ -264,7 +264,7 @@ test.each([
 	const transfer = await fixture.initiateTransfer(5n);
 
 	const builder = new AnchorExternal.Builder()
-		.setAnchor(fixture.anchorSigner, { transactionID: transfer.transferId });
+		.setAnchor(fixture.anchorSigner, { transactionId: transfer.transferId });
 	if (encrypt) {
 		builder.withPrincipals([ recipient ]);
 	}
@@ -292,8 +292,8 @@ test('getStatusesFromExternal: entry variants map to unavailable, unresolved, an
 	const opaqueAnchor = newAccount();
 
 	const external = await new AnchorExternal.Builder()
-		.setAnchor(fixture.anchorSigner, { transactionID: 'no-such-transfer' })
-		.setAnchor(unknownAnchor, { transactionID: 'transfer-at-unknown-anchor' })
+		.setAnchor(fixture.anchorSigner, { transactionId: 'no-such-transfer' })
+		.setAnchor(unknownAnchor, { transactionId: 'transfer-at-unknown-anchor' })
 		.setAnchor(opaqueAnchor, { destination: EVM_RECIPIENT })
 		.build();
 

--- a/src/services/asset-movement/status-source.ts
+++ b/src/services/asset-movement/status-source.ts
@@ -1,0 +1,127 @@
+import type { UserClient as KeetaNetUserClient } from '@keetanetwork/keetanet-client';
+
+import type {
+	AssetLocationString,
+	KeetaAssetMovementAnchorGetTransferStatusClientRequest,
+	KeetaAssetMovementAnchorlistTransactionsClientRequest,
+	KeetaAssetMovementTransaction
+} from './common.js';
+import type {
+	AnchorOnChainReference,
+	AnchorReference,
+	AnchorStatusSource,
+	AnchorTransferReader,
+	AnchorGetTransactionStatusOptions,
+	StandardizedTransferStatus
+} from '../../lib/anchor-status.js';
+import type { Logger } from '../../lib/log/index.js';
+import type { KeetaAssetMovementAnchorProvider } from './client.js';
+import type Resolver from '../../lib/resolver.js';
+import KeetaAssetMovementAnchorClient from './client.js';
+
+/**
+ * Construction inputs for {@link KeetaAssetMovementStatusSource}.
+ */
+export type KeetaAssetMovementStatusSourceConfig = {
+	/**
+	 * Client used to issue the underlying anchor requests.
+	 */
+	client: KeetaNetUserClient;
+	/**
+	 * Resolver used to materialize anchor service metadata.
+	 */
+	resolver: Resolver;
+	/**
+	 * Optional logger forwarded to the underlying client.
+	 */
+	logger?: Logger;
+};
+
+/**
+ * Maps an asset-movement transaction onto the provider-independent
+ * {@link StandardizedTransferStatus}.
+ */
+function transferToStandardized(transaction: KeetaAssetMovementTransaction): StandardizedTransferStatus<KeetaAssetMovementTransaction> {
+	const result: StandardizedTransferStatus<KeetaAssetMovementTransaction> = {
+		status: transaction.status,
+		transactionId: transaction.id,
+		transaction
+	};
+	return(result);
+}
+
+/**
+ * Reads transfer status from a single resolved asset-movement provider and
+ * maps it onto the provider-independent {@link StandardizedTransferStatus}.
+ */
+class KeetaAssetMovementTransferReader implements AnchorTransferReader<KeetaAssetMovementTransaction> {
+	readonly #provider: KeetaAssetMovementAnchorProvider;
+
+	constructor(provider: KeetaAssetMovementAnchorProvider) {
+		this.#provider = provider;
+	}
+
+	async getTransferStatus(transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<KeetaAssetMovementTransaction>> {
+		const request: KeetaAssetMovementAnchorGetTransferStatusClientRequest = { id: transactionId };
+		if (options?.requesterAccount !== undefined) {
+			request.account = options.requesterAccount;
+		}
+
+		const response = await this.#provider.getTransferStatus(request);
+		const result = transferToStandardized(response.transaction);
+		return(result);
+	}
+
+	async findByOnChain(reference: AnchorOnChainReference, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<KeetaAssetMovementTransaction> | null> {
+		const location: AssetLocationString = `chain:keeta:${reference.keetaNetworkId}`;
+		const request: KeetaAssetMovementAnchorlistTransactionsClientRequest = {
+			transactions: [{
+				location,
+				transaction: {
+					id: reference.blockHash,
+					nonce: String(reference.operationIndex)
+				}
+			}]
+		};
+		if (options?.requesterAccount !== undefined) {
+			request.account = options.requesterAccount;
+		}
+
+		const response = await this.#provider.listTransactions(request);
+		const [ match ] = response.transactions;
+		if (match === undefined) {
+			return(null);
+		}
+
+		const result = transferToStandardized(match);
+		return(result);
+	}
+}
+
+/**
+ * Asset-movement implementation of the lib-owned {@link AnchorStatusSource} port.
+ */
+export class KeetaAssetMovementStatusSource implements AnchorStatusSource<KeetaAssetMovementTransaction> {
+	readonly #client: KeetaAssetMovementAnchorClient;
+
+	constructor(config: KeetaAssetMovementStatusSourceConfig) {
+		const clientConfig: { resolver: Resolver; logger?: Logger } = { resolver: config.resolver };
+		if (config.logger !== undefined) {
+			clientConfig.logger = config.logger;
+		}
+
+		this.#client = new KeetaAssetMovementAnchorClient(config.client, clientConfig);
+	}
+
+	async getReader(anchor: AnchorReference): Promise<AnchorTransferReader<KeetaAssetMovementTransaction> | null> {
+		const provider = await this.#client.getProviderByAccount(anchor);
+		if (provider === null) {
+			return(null);
+		}
+
+		const reader = new KeetaAssetMovementTransferReader(provider);
+		return(reader);
+	}
+}
+
+export default KeetaAssetMovementStatusSource;

--- a/src/services/asset-movement/status-source.ts
+++ b/src/services/asset-movement/status-source.ts
@@ -44,7 +44,7 @@ export type KeetaAssetMovementStatusSourceConfig = {
 function transferToStandardized(transaction: KeetaAssetMovementTransaction): StandardizedTransferStatus<KeetaAssetMovementTransaction> {
 	const result: StandardizedTransferStatus<KeetaAssetMovementTransaction> = {
 		status: transaction.status,
-		transactionId: transaction.id,
+		transactionID: transaction.id,
 		transaction
 	};
 	return(result);
@@ -61,8 +61,8 @@ class KeetaAssetMovementTransferReader implements AnchorTransferReader<KeetaAsse
 		this.#provider = provider;
 	}
 
-	async getTransferStatus(transactionId: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<KeetaAssetMovementTransaction>> {
-		const request: KeetaAssetMovementAnchorGetTransferStatusClientRequest = { id: transactionId };
+	async getTransferStatus(transactionID: string, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<KeetaAssetMovementTransaction>> {
+		const request: KeetaAssetMovementAnchorGetTransferStatusClientRequest = { id: transactionID };
 		if (options?.requesterAccount !== undefined) {
 			request.account = options.requesterAccount;
 		}
@@ -73,7 +73,7 @@ class KeetaAssetMovementTransferReader implements AnchorTransferReader<KeetaAsse
 	}
 
 	async findByOnChain(reference: AnchorOnChainReference, options?: AnchorGetTransactionStatusOptions): Promise<StandardizedTransferStatus<KeetaAssetMovementTransaction> | null> {
-		const location: AssetLocationString = `chain:keeta:${reference.keetaNetworkId}`;
+		const location: AssetLocationString = `chain:keeta:${reference.keetaNetworkID}`;
 		const request: KeetaAssetMovementAnchorlistTransactionsClientRequest = {
 			transactions: [{
 				location,


### PR DESCRIPTION
## Summary

Introduces a provider-independent anchor transfer status helper: `AnchorTransactionStatus`. This resolves per-anchor statuses from a transaction id, an encoded external envelope (plaintext or encrypted), or on-chain coordinates, via the injectable `AnchorStatusSource` interface. 