### PR TITLE
parallel contact loading + metadataOnly list option

### DIFF
--- a/src/services/storage/clients/contacts.test.ts
+++ b/src/services/storage/clients/contacts.test.ts
@@ -273,6 +273,47 @@ describe('Contacts Client - List', function() {
 		}));
 	});
 
+	test('list with metadataOnly returns metadata entries without resolving contacts', function() {
+		return(withContacts(randomSeed(), async function({ contactsClient }) {
+			const created: Contact[] = [];
+			for (const { name, address } of sampleAddresses) {
+				created.push(await contactsClient.create({ label: `Contact ${name}`, address }));
+			}
+
+			const entries = await contactsClient.list({ metadataOnly: true });
+			expect(entries).toHaveLength(sampleAddresses.length);
+
+			const createdIds = created.map(function(contact) { return(contact.id); }).sort();
+			const entryIds = entries.map(function(entry) { return(entry.path.split('/').pop()); }).sort();
+			expect(entryIds).toEqual(createdIds);
+
+			for (const entry of entries) {
+				expect(entry.path).toBeTypeOf('string');
+				expect(entry.createdAt).toBeTypeOf('string');
+				// Metadata only: the contact body (label/address) is not resolved.
+				expect(entry).not.toHaveProperty('label');
+				expect(entry).not.toHaveProperty('address');
+			}
+		}));
+	});
+
+	test('list with metadataOnly respects the location filter', function() {
+		return(withContacts(randomSeed(), async function({ contactsClient }) {
+			const evm = await contactsClient.create({ label: 'EVM', address: evmAddress });
+			await contactsClient.create({ label: 'Bitcoin', address: bitcoinAddress });
+
+			const location = evmAddress.location;
+			expect(location).toBeDefined();
+			if (!location) {
+				return;
+			}
+
+			const entries = await contactsClient.list({ metadataOnly: true, location });
+			expect(entries).toHaveLength(1);
+			expect(entries[0]?.path.split('/').pop()).toBe(evm.id);
+		}));
+	});
+
 	test('list filtered by location returns only matching contacts', function() {
 		const fixtures: { address: ContactAddress }[] = [
 			{ address: evmAddress },

--- a/src/services/storage/clients/contacts.ts
+++ b/src/services/storage/clients/contacts.ts
@@ -297,9 +297,12 @@ export class StorageContactsClient implements ContactsClient {
 		return(result);
 	}
 
+	async list(options?: { location?: AssetLocationLike; metadataOnly?: false; }): Promise<ContactWithMetadata[]>;
+	async list(options: { location?: AssetLocationLike; metadataOnly: true; }): Promise<StorageObjectMetadata[]>;
 	async list(options?: {
 		location?: AssetLocationLike;
-	}): Promise<ContactWithMetadata[]> {
+		metadataOnly?: boolean;
+	}): Promise<ContactWithMetadata[] | StorageObjectMetadata[]> {
 		this.#logger?.debug('StorageContactsClient::list', 'Listing contacts');
 
 		const criteria: { pathPrefix: string; tags?: string[] } = {
@@ -311,15 +314,31 @@ export class StorageContactsClient implements ContactsClient {
 		}
 
 		const searchResult = await this.#session.search(criteria);
-		const contacts: ContactWithMetadata[] = [];
-		for (const metadata of searchResult.results) {
-			const result = await this.#session.get(metadata.path);
-			if (result) {
+
+		if (options?.metadataOnly) {
+			this.#logger?.debug('StorageContactsClient::list', `Listed ${searchResult.results.length} contact metadata entries`);
+			return(searchResult.results);
+		}
+
+		const settled = await Promise.allSettled(
+			searchResult.results.map(async (metadata) => {
+				const result = await this.#session.get(metadata.path);
+				if (!result) {
+					return(undefined);
+				}
 				try {
-					contacts.push(this.#deserialize(result.data, metadata));
+					return(this.#deserialize(result.data, metadata));
 				} catch (error) {
 					this.#logger?.warn('StorageContactsClient::list', `Skipping corrupt contact at ${metadata.path}`, error);
+					return(undefined);
 				}
+			})
+		);
+
+		const contacts: ContactWithMetadata[] = [];
+		for (const outcome of settled) {
+			if (outcome.status === 'fulfilled' && outcome.value) {
+				contacts.push(outcome.value);
 			}
 		}
 


### PR DESCRIPTION
Improves `StorageContactsClient.list()` with parallel loading and a new opt-in `metadataOnly` mode for lighter frontend list views.

## Changes
- **Parallel loading**: contact `get` + deserialize now run concurrently via `Promise.allSettled` instead of a sequential `for` loop. Corrupt/failed entries are skipped and logged rather than failing the whole list.
- **`metadataOnly` option**: `list({ metadataOnly: true })` returns `StorageObjectMetadata[]` straight from the single `search()` call, skipping all per-contact fetches/decryption. Lets frontends render a list cheaply and hydrate each contact on demand.

