### PR TITLE
Add `IconsClient.getPublic()` for reading public icons across accounts

### DIFF
--- a/src/services/storage/client.test.ts
+++ b/src/services/storage/client.test.ts
@@ -361,6 +361,64 @@ describe('Storage Client - Public Objects', function() {
 	});
 });
 
+describe('Storage Client - Get Public Content', function() {
+	test('provider.getPublicContent round-trips a public object', function() {
+		return(withClient(randomSeed(), async function({ provider, account, anchorAccount, makePath }) {
+			const data = Buffer.from('public bytes');
+			const path = makePath('pub.bin');
+			await provider.put({ path, data, mimeType: 'image/png', visibility: 'public', account, anchorAccount });
+
+			const result = await provider.getPublicContent({ path, account });
+			expect(result).not.toBeNull();
+			expect(result?.mimeType).toBe('image/png');
+			expect(result?.data).toEqual(data);
+		}));
+	});
+
+	test('provider.getPublicContent returns null for a nonexistent object', function() {
+		return(withClient(randomSeed(), async function({ provider, account, makePath }) {
+			const result = await provider.getPublicContent({ path: makePath('missing.bin'), account });
+			expect(result).toBeNull();
+		}));
+	});
+
+	test('provider.getPublicContent throws for a private object (not null)', function() {
+		return(withClient(randomSeed(), async function({ provider, account, makePath }) {
+			const path = makePath('private.bin');
+			await provider.put({ path, data: Buffer.from('secret'), mimeType: 'image/png', visibility: 'private', account });
+
+			await expect(provider.getPublicContent({ path, account })).rejects.toSatisfy(function(e: unknown) {
+				return(!Errors.DocumentNotFound.isInstance(e));
+			});
+		}));
+	});
+
+	test('session.getPublicContent resolves the working directory', function() {
+		return(withClient(randomSeed(), async function({ provider, account, anchorAccount }) {
+			const ownerKey = account.publicKeyString.get();
+			const data = Buffer.from('session bytes');
+			await provider.put({
+				path: `/user/${ownerKey}/avatar.png`,
+				data,
+				mimeType: 'image/png',
+				visibility: 'public',
+				account,
+				anchorAccount
+			});
+
+			const session = provider.beginSession({
+				account,
+				workingDirectory: `/user/${ownerKey}/`,
+				defaultVisibility: 'public'
+			});
+			const result = await session.getPublicContent('avatar.png');
+			expect(result).not.toBeNull();
+			expect(result?.mimeType).toBe('image/png');
+			expect(result?.data).toEqual(data);
+		}));
+	});
+});
+
 describe('Storage Client - Update Metadata', function() {
 	test('updateMetadata updates tags and visibility', function() {
 		return(withClient(randomSeed(), async function({ provider, account, makePath, putText }) {

--- a/src/services/storage/client.ts
+++ b/src/services/storage/client.ts
@@ -445,6 +445,31 @@ export class KeetaStorageAnchorSession {
 
 		return(await this.provider.getPublicUrl(urlOpts));
 	}
+
+	/**
+	 * Fetch a public object's content under this session's working directory.
+	 *
+	 * Note we don't sign with `this.account` here. The session might be pointed at
+	 * someone else's namespace (a contact, who we only have a public key for), so the
+	 * client account does the signing instead.
+	 *
+	 * @param relativePath - Path relative to the session's working directory
+	 * @param options.ttl - Optional TTL in seconds for the signed URL we generate
+	 *
+	 * @returns The decrypted data and mime-type, or null if not found
+	 */
+	async getPublicContent(
+		relativePath: string,
+		options?: { ttl?: number }
+	): Promise<{ data: Buffer; mimeType: string } | null> {
+		const fullPath = this.#resolvePath(relativePath);
+		const opts: Parameters<typeof this.provider.getPublicContent>[0] = { path: fullPath };
+		if (options?.ttl) {
+			opts.ttl = options.ttl;
+		}
+
+		return(await this.provider.getPublicContent(opts));
+	}
 }
 
 /**
@@ -1289,6 +1314,61 @@ export class KeetaStorageAnchorProvider extends KeetaStorageAnchorBase {
 
 		const finalUrl = addSignatureToURL(publicUrl, { signedField: signed, account: signerAccount.assertAccount() });
 		return(finalUrl.toString());
+	}
+
+	/**
+	 * Download a public object's content. The anchor decrypts it server-side, so
+	 * unlike `get` you can read an object you don't own (e.g. someone else's icon)
+	 * without their private key.
+	 *
+	 * We sign the request as the client account, not the owner. The server decides
+	 * whether that's allowed via its path policy, so a non-owner read may be rejected.
+	 *
+	 * @param options.path - Path to the public object
+	 * @param options.ttl - Optional TTL in seconds for the signed URL we generate
+	 * @param options.account - Optional signer override; defaults to the client account (needs a private key)
+	 *
+	 * @returns The decrypted data and mime-type, or null if not found
+	 *
+	 * @throws AccessDenied if the object exists but is not public
+	 * @throws PrivateKeyRequired if no account with a private key is available to sign
+	 */
+	async getPublicContent(options: {
+		path: string;
+		ttl?: number;
+		account?: KeetaNetAccount;
+	}): Promise<{ data: Buffer; mimeType: string } | null> {
+		this.logger?.debug(`Getting public content at path: ${options.path}`);
+
+		const url = await this.getPublicUrl(options);
+
+		let response: Response;
+		try {
+			response = await fetch(url, { method: 'GET' });
+		} catch (e) {
+			throw(new Errors.ServiceUnavailable(`Network error: ${e instanceof Error ? e.message : String(e)}`));
+		}
+
+		if (!response.ok) {
+			try {
+				await this.#handleBinaryResponseError(response);
+			} catch (e) {
+				if (Errors.DocumentNotFound.isInstance(e)) {
+					return(null);
+				}
+
+				throw(e);
+			}
+		}
+
+		const arrayBuffer = await response.arrayBuffer();
+		const data = arrayBufferLikeToBuffer(arrayBuffer);
+		const contentType = response.headers.get('Content-Type') ?? '';
+		const mimeType = (contentType.split(';')[0] ?? '').trim() || CONTENT_TYPE_OCTET_STREAM;
+
+		this.logger?.debug(`Get public content successful for path: ${options.path}`);
+
+		return({ data, mimeType });
 	}
 
 	/**

--- a/src/services/storage/clients/icon.test.ts
+++ b/src/services/storage/clients/icon.test.ts
@@ -6,7 +6,8 @@ import type KeetaStorageAnchorClient from '../client.js';
 import { StorageIconsClient } from './icon.js';
 import { Errors } from '../common.js';
 import { Buffer } from '../../../lib/utils/buffer.js';
-import { randomSeed, withStorageProvider } from '../test-utils.js';
+import { KeetaNet } from '../../../client/index.js';
+import { randomSeed, withStorageProvider, withAnySignerStorageProvider } from '../test-utils.js';
 
 // #region Test Harness
 
@@ -125,6 +126,95 @@ describe('Icons Client - MIME Type Validation', function() {
 			const invalidIcon: IconData = { data: Buffer.from('not an image'), mimeType };
 			await expect(iconsClient.set(invalidIcon))
 				.rejects.toSatisfy(function(e: unknown) { return(Errors.ValidationFailed.isInstance(e)); });
+		}));
+	});
+});
+
+describe('Icons Client - Get Public (own icon)', function() {
+	test.each(sampleIcons)('set and getPublic icon: $name', function({ icon }) {
+		return(withIcons(randomSeed(), async function({ iconsClient }) {
+			await iconsClient.set(icon);
+
+			const retrieved = await iconsClient.getPublic();
+			expect(retrieved).not.toBeNull();
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(retrieved!.mimeType).toBe(icon.mimeType);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(retrieved!.data).toEqual(icon.data);
+		}));
+	});
+
+	test('getPublic nonexistent icon returns null', function() {
+		return(withIcons(randomSeed(), async function({ iconsClient }) {
+			const result = await iconsClient.getPublic();
+			expect(result).toBeNull();
+		}));
+	});
+
+	test('getPublic matches get() for the same icon', function() {
+		return(withIcons(randomSeed(), async function({ iconsClient }) {
+			await iconsClient.set(jpegIcon);
+
+			const viaGet = await iconsClient.get();
+			const viaPublic = await iconsClient.getPublic();
+			expect(viaGet).not.toBeNull();
+			expect(viaPublic).not.toBeNull();
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(viaPublic!.mimeType).toBe(viaGet!.mimeType);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(viaPublic!.data).toEqual(viaGet!.data);
+		}));
+	});
+
+	test('getPublic after delete returns null', function() {
+		return(withIcons(randomSeed(), async function({ iconsClient }) {
+			await iconsClient.set(pngIcon);
+			await iconsClient.delete();
+
+			const result = await iconsClient.getPublic();
+			expect(result).toBeNull();
+		}));
+	});
+});
+
+describe('Icons Client - Get Public (cross-account)', function() {
+	test("reads another account's public icon when the signer is authorized", function() {
+		return(withAnySignerStorageProvider(randomSeed(), async function({ provider, account }) {
+			// Some other account uploads an icon to its own namespace.
+			const owner = KeetaNet.lib.Account.fromSeed(randomSeed(), 0);
+			const ownerKey = owner.publicKeyString.get();
+			expect(ownerKey).not.toBe(account.publicKeyString.get());
+			const basePath = `/user/${ownerKey}/`;
+
+			await provider.getIconsClient({ account: owner, basePath }).set(pngIcon);
+
+			// Now we (the client account, not the owner) pull it down. getPublic
+			// signs as the client, so we never touch the owner's private key.
+			const readerIcons = provider.getIconsClient({ account: owner, basePath });
+			const result = await readerIcons.getPublic();
+			expect(result).not.toBeNull();
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(result!.mimeType).toBe(pngIcon.mimeType);
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			expect(result!.data).toEqual(pngIcon.data);
+		}));
+	});
+
+	test('rejects a foreign signer when the policy pins the signer to the owner', function() {
+		return(withStorageProvider(randomSeed(), async function({ provider, account }) {
+			const owner = KeetaNet.lib.Account.fromSeed(randomSeed(), 0);
+			const ownerKey = owner.publicKeyString.get();
+			expect(ownerKey).not.toBe(account.publicKeyString.get());
+			const basePath = `/user/${ownerKey}/`;
+
+			await provider.getIconsClient({ account: owner, basePath }).set(pngIcon);
+
+			// This policy only trusts the owner's signature, so our client-signed read
+			// should be turned away. The point is it errors rather than quietly returning null.
+			const readerIcons = provider.getIconsClient({ account: owner, basePath });
+			await expect(readerIcons.getPublic()).rejects.toSatisfy(function(e: unknown) {
+				return(!Errors.DocumentNotFound.isInstance(e));
+			});
 		}));
 	});
 });

--- a/src/services/storage/clients/icon.ts
+++ b/src/services/storage/clients/icon.ts
@@ -24,6 +24,13 @@ export interface IconsClient {
 	set(icon: IconData): Promise<void>;
 	get(): Promise<IconData | null>;
 	delete(): Promise<boolean>;
+	/**
+	 * Fetch a public icon, including one that belongs to another account.
+	 * `get` only works for your own icon; this goes through the public endpoint,
+	 * where the anchor decrypts server-side so you don't need the owner's key.
+	 * Optional so existing implementers don't break.
+	 */
+	getPublic?(): Promise<IconData | null>;
 }
 
 // #endregion
@@ -69,6 +76,19 @@ export class StorageIconsClient implements IconsClient {
 		}
 
 		this.#logger?.debug('StorageIconsClient::get', 'Icon retrieved');
+		return({ data: result.data, mimeType: result.mimeType });
+	}
+
+	async getPublic(): Promise<IconData | null> {
+		this.#logger?.debug('StorageIconsClient::getPublic', 'Getting public icon');
+
+		const result = await this.#session.getPublicContent(ICON_FILENAME);
+		if (!result) {
+			this.#logger?.debug('StorageIconsClient::getPublic', 'Public icon not found');
+			return(null);
+		}
+
+		this.#logger?.debug('StorageIconsClient::getPublic', 'Public icon retrieved');
 		return({ data: result.data, mimeType: result.mimeType });
 	}
 

--- a/src/services/storage/test-utils.ts
+++ b/src/services/storage/test-utils.ts
@@ -121,6 +121,19 @@ export class TestPathPolicy implements PathPolicy<TestParsedPath> {
 export const testPathPolicy: TestPathPolicy = new TestPathPolicy();
 
 /**
+ * Like {@link TestPathPolicy}, but lets any account sign a public read instead of
+ * only the owner. Returning `null` from `getAuthorizedSigner` makes the server trust
+ * the signer named in the URL, which matches how the deployed anchors behave.
+ */
+export class AnySignerTestPathPolicy extends TestPathPolicy {
+	getAuthorizedSigner(): InstanceType<typeof KeetaNet.lib.Account> | null {
+		return(null);
+	}
+}
+
+export const anySignerTestPathPolicy: AnySignerTestPathPolicy = new AnySignerTestPathPolicy();
+
+/**
  * Create test metadata with sensible defaults.
  */
 export function testMetadata(
@@ -547,8 +560,9 @@ export interface StorageProviderTestContext {
  * Shared test harness that stands up a storage server, resolves a provider,
  * and passes the provider context to the test function.
  */
-export async function withStorageProvider(
+async function runWithStorageProvider(
 	seed: string | ArrayBuffer,
+	pathPolicies: PathPolicy<TestParsedPath>[],
 	testFunction: (ctx: StorageProviderTestContext) => Promise<void>
 ): Promise<void> {
 	const account = KeetaNet.lib.Account.fromSeed(seed, 0);
@@ -564,7 +578,7 @@ export async function withStorageProvider(
 	await using server = new KeetaNetStorageAnchorHTTPServer({
 		backend,
 		anchorAccount,
-		pathPolicies: [testPathPolicy]
+		pathPolicies
 	});
 
 	await server.start();
@@ -595,6 +609,28 @@ export async function withStorageProvider(
 	}
 
 	await testFunction({ provider: maybeProvider, account, storageClient });
+}
+
+/**
+ * Test harness with the default owner-only policy.
+ */
+export async function withStorageProvider(
+	seed: string | ArrayBuffer,
+	testFunction: (ctx: StorageProviderTestContext) => Promise<void>
+): Promise<void> {
+	return(await runWithStorageProvider(seed, [testPathPolicy], testFunction));
+}
+
+/**
+ * Test harness for cross-account public reads, where any account can read a public
+ * object. `ctx.account` is the reader doing the signing; spin up a separate owner
+ * account inside the test to play the other side.
+ */
+export async function withAnySignerStorageProvider(
+	seed: string | ArrayBuffer,
+	testFunction: (ctx: StorageProviderTestContext) => Promise<void>
+): Promise<void> {
+	return(await runWithStorageProvider(seed, [anySignerTestPathPolicy], testFunction));
 }
 
 // #endregion


### PR DESCRIPTION
Adds a way to download a public icon's bytes, including one that belongs to another account, instead of only being able to mint a public URL.


## Changes

* New `getPublic()` on `IconsClient` to download a public icon's bytes, including one that belongs to another account. Returns `{ data, mimeType }`, or `null` when there's nothing there.
* Backed by `getPublicContent()` on the session and provider. It mints the public URL, fetches it, and lets the anchor decrypt server-side via `/api/public`, so the caller never needs the owner's key.
* Added tests for the own-icon round-trip, parity with `get()`, not-found and post-delete cases, and cross-account reads (plus a negative test for the owner-pinned policy). Added an `AnySignerTestPathPolicy` and harness to model the deployed behavior.
