### PR TITLE
Fix Buffer Usage

### DIFF
--- a/.eslint.config.mjs
+++ b/.eslint.config.mjs
@@ -38,5 +38,26 @@ export default [
 				}]
 			}]
 		}
+	},
+	{
+		// Buffer is not available in browser environments. Import it from utils/buffer.js
+		// (the polyfill re-export) instead of using the global or importing from 'buffer'.
+		files: ['src/**/*.ts'],
+		ignores: ['**/*.generated.ts'],
+		rules: {
+			'no-restricted-globals': ['error', {
+				name: 'Buffer',
+				message: "Import Buffer from 'utils/buffer.js' (e.g. './utils/buffer.js' or '../../lib/utils/buffer.js') instead of using the global Buffer."
+			}],
+			'no-restricted-imports': ['error', {
+				paths: [{
+					name: 'buffer',
+					message: "Import Buffer from 'utils/buffer.js' instead of the 'buffer' package."
+				}, {
+					name: 'node:buffer',
+					message: "Import Buffer from 'utils/buffer.js' instead of 'node:buffer'."
+				}]
+			}]
+		}
 	}
 ];

--- a/src/lib/certificates.test.ts
+++ b/src/lib/certificates.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest';
 import * as Certificates from './certificates.js';
 import * as KeetaNetClient from '@keetanetwork/keetanet-client';
-import { bufferToArrayBuffer } from './utils/buffer.js';
+import { bufferToArrayBuffer, Buffer } from './utils/buffer.js';
 import type { Schema as ASN1Schema } from './utils/asn1.js';
 import type { CertificateAttributeValue, CertificateAttributeOIDDB } from '../services/kyc/iso20022.generated.ts';
 import { ExternalReferenceBuilder } from './utils/external.js';

--- a/src/lib/encrypted-container.test.ts
+++ b/src/lib/encrypted-container.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe } from 'vitest';
 import * as EncryptedContainer from './encrypted-container.js';
 import { EncryptedContainerError } from './encrypted-container.js';
 import { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
-import { arrayBufferLikeToBuffer } from './utils/buffer.js';
+import { arrayBufferLikeToBuffer, Buffer } from './utils/buffer.js';
 
 const JStoASN1 = KeetaNetLib.Utils.ASN1.JStoASN1;
 const Account: typeof KeetaNetLib.Account = KeetaNetLib.Account;

--- a/src/lib/http-server/index.test.ts
+++ b/src/lib/http-server/index.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 import * as HTTPServer from './index.js';
 import { KeetaAnchorUserError } from '../error.js';
 import crypto from 'crypto';
+import { Buffer } from '../utils/buffer.js';
 
 function hashData(data: Buffer): Buffer {
 	const hash = crypto.createHash('sha256');

--- a/src/lib/http-server/index.ts
+++ b/src/lib/http-server/index.ts
@@ -14,6 +14,7 @@ import { Log } from '../log/index.js';
 import { createAssert } from 'typia';
 import { assertNever } from '../utils/never.js';
 import { resolveCertificateChainConfig } from '../utils/certificate-network.js';
+import { Buffer } from '../utils/buffer.js';
 
 export const AssertHTTPErrorData: (input: unknown) => { error: string; statusCode?: number; contentType?: string; } = createAssert<{ error: string; statusCode?: number; contentType?: string; }>();
 

--- a/src/services/asset-movement/lib/location.ts
+++ b/src/services/asset-movement/lib/location.ts
@@ -1,6 +1,7 @@
 import { assertNever } from "../../../lib/utils/never.js";
 import type { BankAccountAddressObfuscated, MobileWalletAddressObfuscated } from "../common.js";
 import { assertBankAccountType, assertMobileWalletAccountType, isTronNetworkAlias } from "./location.generated.js";
+import { Buffer } from '../../../lib/utils/buffer.js';
 
 interface BaseLocation<Type extends 'chain' | 'bank-account' | 'mobile-wallet'> {
 	type: Type;

--- a/src/services/fx/server.test.ts
+++ b/src/services/fx/server.test.ts
@@ -6,6 +6,7 @@ import { KeetaNet } from '../../client/index.js';
 import { createNodeAndClient } from '../../lib/utils/tests/node.js';
 import { KeetaAnchorQueueStorageDriverMemory } from '../../lib/queue/index.js';
 import { asleep } from '../../lib/utils/asleep.js';
+import { Buffer } from '../../lib/utils/buffer.js';
 
 const DEBUG = false;
 const TestLogger = DEBUG ? console : undefined;

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -36,6 +36,7 @@ import { assertExchangeBlockParametersAndComputeRefund, convertQuoteToExpectedSw
 import { AsyncDisposableStack } from '../../lib/utils/defer.js';
 import { asleep } from '../../lib/utils/asleep.js';
 import type { SharedAnchorMetadataLegalExtension } from '../../lib/metadata.types.js';
+import { Buffer } from '../../lib/utils/buffer.js';
 
 /**
  * Enable additional runtime "paranoid" checks in the FX server.

--- a/src/services/kyc/common.test.ts
+++ b/src/services/kyc/common.test.ts
@@ -2,6 +2,7 @@ import { test, expect } from 'vitest';
 import { Errors } from './common.js';
 import { KeetaAnchorError, KeetaAnchorUserError } from '../../lib/error.js';
 import * as KeetaNet from '@keetanetwork/keetanet-client';
+import { Buffer } from '../../lib/utils/buffer.js';
 
 for (const errorClass of [
 	Errors.VerificationNotFound,

--- a/src/services/storage/client.test.ts
+++ b/src/services/storage/client.test.ts
@@ -14,6 +14,7 @@ import { testPathPolicy } from './test-utils.js';
 import { EncryptedContainer } from '../../lib/encrypted-container.js';
 import KeetaAnchorResolver from '../../lib/resolver.js';
 import KeetaStorageAnchorClient from './client.js';
+import { Buffer } from '../../lib/utils/buffer.js';
 
 // #region Test Harness
 


### PR DESCRIPTION
This change imports Buffer from utils instead of the node modules to fix issues in browser environments. 

Resolves the following error.  Also adds an eslint rule to prevent using the node buffer.

<img width="492" height="211" alt="image" src="https://github.com/user-attachments/assets/d612c366-b2f0-449b-89ac-b5228e1fa2f5" />
