### PR TITLE
Fix: Atomic Swap History

### DIFF
--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -627,7 +627,7 @@ test('an undecodable external degrades to a plain send and keeps the raw string'
 	expect(transaction?.refs.external).toEqual([ external ]);
 });
 
-test('enrichment can be disabled to classify from block shape only', async function() {
+test('enrichment can be disabled; a declared-anchor send is a provisional withdraw', async function() {
 	const user = newAccount();
 	const anchor = newAccount();
 	const token = newToken(user, 0);
@@ -646,8 +646,17 @@ test('enrichment can be disabled to classify from block shape only', async funct
 	const source = new TestStatusSource();
 	source.registerByTxID(anchor, transfer);
 
+	/*
+	 * The block is owned by the perspective and declares an anchor transfer id
+	 * locally, so with enrichment off it is a provisional withdraw attributed to
+	 * the anchor. The authoritative bridge/withdraw split arrives on enrichment.
+	 */
 	const [ transaction ] = await runHistory([ block ], source, { enrich: false });
-	expect(transaction?.type).toBe('send');
+	expect(transaction?.type).toBe('withdraw');
+	expect(transaction?.provisional).toBe(true);
+	expect(transaction?.counterparty).toEqual({ kind: 'anchor', id: anchor.publicKeyString.get() });
+	expect(transaction?.refs.declaredAnchorTxIDs).toEqual([ 'withdraw-tx' ]);
+	expect(transaction?.refs.anchorTxIDs).toEqual([]);
 	expect(transaction?.refs.external).toEqual([ external ]);
 });
 
@@ -1817,6 +1826,199 @@ test('folds a non-atomic anchor conversion from on-chain inputs alone, without e
 	expect(simple[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
 	expect(simple[0]?.refs.blockHashes).toEqual(expect.arrayContaining([ payIn.hash.toString(), delivery.hash.toString() ]));
 	expect(simple[0]?.refs.anchorTxIDs).toHaveLength(0);
+	/* A folded on-chain swap is authoritative, not provisional, but now names the anchor locally. */
+	expect(simple[0]?.provisional).toBeUndefined();
+	expect(simple[0]?.counterparty).toEqual({ kind: 'anchor', id: anchor.publicKeyString.get() });
+});
+
+test('groups two legs of one anchor transfer by their declared id, without enrichment', async function() {
+	const user = newAccount();
+	const anchor = newAccount();
+	const token = newToken(user, 0);
+
+	/*
+	 * transfer-7 is settled by two owned pay-in sends with NO on-chain input
+	 * edge between them; only the shared declared id ties them together.
+	 */
+	const externalA = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const legA = await seal(user, [ sendOp(anchor, token, 50n, externalA) ]);
+	const externalB = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const legB = await seal(user, [ sendOp(anchor, token, 50n, externalB) ]);
+
+	const listed = new UserHistory({ history: pagedFoldCapableSource([ legB, legA ]) });
+	const rows = await listed.list(user);
+	expect(rows).toHaveLength(1);
+	expect(rows[0]?.type).toBe('withdraw');
+	expect(rows[0]?.provisional).toBe(true);
+	expect(rows[0]?.counterparty).toEqual({ kind: 'anchor', id: anchor.publicKeyString.get() });
+	expect(rows[0]?.refs.declaredAnchorTxIDs).toEqual([ 'transfer-7' ]);
+	expect(rows[0]?.refs.anchorTxIDs).toHaveLength(0);
+	/* Drop-not-merge: the surviving row keeps a single leg's block hash. */
+	expect(rows[0]?.refs.blockHashes).toHaveLength(1);
+
+	/* The streaming path collapses the same legs the same way. */
+	const streamed: LogicalTransaction[] = [];
+	for await (const row of listed.iterate(user)) {
+		streamed.push(row);
+	}
+	expect(streamed).toHaveLength(1);
+	expect(streamed[0]?.type).toBe('withdraw');
+});
+
+test('enrichTransaction on a deduped provisional row matches a full enrich', async function() {
+	const user = newAccount();
+	const anchor = newAccount();
+	const token = newToken(user, 0);
+
+	const transfer = makeTransfer({
+		id: 'transfer-7',
+		status: 'COMPLETE',
+		asset: token.publicKeyString.get(),
+		fromLocation: KEETA_LOCATION,
+		toLocation: MOBILE_LOCATION,
+		fromValue: '100',
+		toValue: '100',
+		fee: { asset: token.publicKeyString.get(), value: '1' }
+	});
+	const status = new TestStatusSource();
+	status.registerByTxID(anchor, transfer);
+
+	const externalA = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const legA = await seal(user, [ sendOp(anchor, token, 50n, externalA) ]);
+	const externalB = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const legB = await seal(user, [ sendOp(anchor, token, 50n, externalB) ]);
+
+	const history = new UserHistory({ history: pagedFoldCapableSource([ legB, legA ]), status: new AnchorTransactionStatus(status) });
+
+	const [ provisional ] = await history.list(user);
+	if (provisional === undefined) {
+		throw(new Error('expected a provisional row'));
+	}
+
+	expect(provisional.provisional).toBe(true);
+	expect(provisional.refs.blockHashes).toHaveLength(1);
+
+	const enrichedOnDemand = await history.enrichTransaction(provisional, user);
+	const [ enrichedList ] = await history.list(user, { enrich: true });
+
+	expect(enrichedOnDemand.provisional).toBeUndefined();
+	expect(enrichedOnDemand.type).toBe(enrichedList?.type);
+	expect(enrichedOnDemand.direction).toBe(enrichedList?.direction);
+	expect(enrichedOnDemand.status).toBe(enrichedList?.status);
+	expect(enrichedOnDemand.send).toEqual(enrichedList?.send);
+	expect(enrichedOnDemand.receive).toEqual(enrichedList?.receive);
+	expect(enrichedOnDemand.fee).toEqual(enrichedList?.fee);
+	expect(enrichedOnDemand.counterparty).toEqual(enrichedList?.counterparty);
+});
+
+test('an unsigned foreign declaration is not trusted for grouping or attribution', async function() {
+	const user = newAccount();
+	const other = newAccount();
+	const anchor = newAccount();
+	const token = newToken(other, 0);
+
+	/*
+	 * A foreign block (issued by `other`, not the perspective) declares an
+	 * unsigned anchor id. The perspective must not trust it: no grouping, no
+	 * anchor attribution, no provisional relabel.
+	 */
+	const foreignExternal = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const foreign = await seal(other, [ sendOp(user, token, 30n, foreignExternal) ]);
+
+	const [ row ] = await runHistory([ foreign ], undefined, { enrich: false }, user);
+	expect(row?.type).toBe('receive');
+	expect(row?.provisional).toBeUndefined();
+	expect(row?.counterparty).toEqual({ kind: 'account', id: other.publicKeyString.get() });
+	expect(row?.refs.declaredAnchorTxIDs).toBeUndefined();
+});
+
+test('groups a multi-hop declared-anchor conversion into one row, without enrichment', async function() {
+	const user = newAccount();
+	const anchor = newAccount();
+	const liquidity = newAccount();
+	const tokenP = newToken(user, 0);
+	const tokenM = newToken(user, 1);
+	const tokenFinal = newToken(user, 2);
+
+	/*
+	 * Mirrors a real two-hop anchor swap: transfer-7 (P -> M) settled by a user
+	 * pay-in and a signed anchor delivery, feeding transfer-9 (M -> final) whose
+	 * pay-in declares the transfer-7 pay-in as its on-chain input. All three
+	 * blocks are one user-facing conversion; the enriched list already folds
+	 * them into one row and the unenriched list must match that grouping.
+	 */
+	const transfer7 = makeTransfer({
+		id: 'transfer-7',
+		status: 'COMPLETE',
+		asset: { from: tokenP.publicKeyString.get(), to: tokenM.publicKeyString.get() },
+		fromLocation: KEETA_LOCATION,
+		toLocation: KEETA_LOCATION,
+		fromValue: '1000',
+		toValue: '999'
+	});
+	const transfer9 = makeTransfer({
+		id: 'transfer-9',
+		status: 'COMPLETE',
+		asset: { from: tokenM.publicKeyString.get(), to: tokenFinal.publicKeyString.get() },
+		fromLocation: KEETA_LOCATION,
+		toLocation: KEETA_LOCATION,
+		fromValue: '999',
+		toValue: '990'
+	});
+	const status = new TestStatusSource();
+	status.registerByTxID(anchor, transfer7);
+	status.registerByTxID(anchor, transfer9);
+
+	const payIn7External = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-7' }).build();
+	const payIn7 = await seal(user, [ sendOp(liquidity, tokenP, 1000n, payIn7External) ]);
+
+	const delivery7External = await new AnchorExternal.Builder()
+		.setAnchor(anchor, { transactionId: 'transfer-7' })
+		.withSigner(anchor)
+		.withBinding(KeetaNet.lib.Block.NO_PREVIOUS, 0)
+		.build();
+	const delivery7 = await seal(anchor, [ sendOp(user, tokenM, 999n, delivery7External) ]);
+
+	const payIn9External = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-9' }).addInput(payIn7.hash.toString(), 0).build();
+	const payIn9 = await seal(user, [ sendOp(liquidity, tokenM, 999n, payIn9External) ]);
+
+	const history = new UserHistory({
+		history: pagedFoldCapableSource([ payIn9, delivery7, payIn7 ]),
+		status: new AnchorTransactionStatus(status)
+	});
+
+	/* Unenriched: the two pay-ins chain by their input edge, the delivery is absorbed. */
+	const simple = await history.list(user);
+	expect(simple).toHaveLength(1);
+	const conversion = simple[0];
+	expect(conversion?.type).toBe('withdraw');
+	expect(conversion?.provisional).toBe(true);
+	expect(conversion?.counterparty).toEqual({ kind: 'anchor', id: anchor.publicKeyString.get() });
+	expect(conversion?.refs.blockHashes).toEqual(expect.arrayContaining([ payIn7.hash.toString(), payIn9.hash.toString() ]));
+	expect(conversion?.refs.declaredAnchorTxIDs).toEqual(expect.arrayContaining([ 'transfer-7', 'transfer-9' ]));
+	expect(conversion?.refs.anchorTxIDs).toHaveLength(0);
+	expect(conversion?.refs.blockHashes).not.toContain(delivery7.hash.toString());
+
+	/* Enriched folds the same three blocks into one row too. */
+	const enriched = await history.list(user, { enrich: true });
+	expect(enriched).toHaveLength(1);
+	expect(enriched[0]?.type).toBe('swap');
+	expect(enriched[0]?.provisional).toBeUndefined();
+
+	/*
+	 * Enriching the grouped row on demand must keep the source (and its
+	 * perspective) a detail view needs; a folded conversion is built fresh and
+	 * would otherwise carry no source.
+	 */
+	const [ withSource ] = await history.list(user, { includeSource: true });
+	if (withSource === undefined) {
+		throw(new Error('expected a grouped row'));
+	}
+
+	const enrichedRow = await history.enrichTransaction(withSource, user, { includeSource: true });
+	expect(enrichedRow.type).toBe('swap');
+	expect(enrichedRow.source).toBeDefined();
+	expect(enrichedRow.source?.enriched.perspective).toBe(user.publicKeyString.get());
 });
 
 test('foldChains merges a two-hop linked chain into one conversion', function() {

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -105,10 +105,6 @@ async function runHistory(blocks: Block[], source?: AnchorStatusSource<KeetaAsse
 	const history = new UserHistory(config);
 	const account = queriedAccount ?? blocks[0]?.account ?? null;
 
-	/*
-	 * Listing is lean by default now; these classification/enrichment cases
-	 * opt in unless a case explicitly overrides `enrich`.
-	 */
 	const transactions = await history.list(account, { enrich: true, ...options });
 	return(transactions);
 }
@@ -1452,30 +1448,26 @@ test('a folded multi-hop atomic FX chain retains anchor enrichment', async funct
 	expect(swap?.refs.anchorTxIDs.length).toBeGreaterThan(0);
 });
 
-test('lists leanly by default, then enriches a single transaction on demand', async function() {
+test('lists with no enrichment by default, then enriches a single transaction on demand', async function() {
 	const fixture = await startFXExchangeFixture();
 	await using server = fixture.server;
 	void server;
 
-	/*
-	 * The default list is lean: the swap classifies by on-chain shape with no
-	 * anchor attribution, sparing the per-operation anchor HTTP calls.
-	 */
-	const lean = await fixture.history.list(fixture.userAccount);
-	const leanSwap = lean.find(transaction => transaction.type === 'swap');
-	if (leanSwap === undefined) {
-		throw(new Error('Expected a shape-classified swap in the lean list'));
+	const simple = await fixture.history.list(fixture.userAccount);
+	const simpleSwap = simple.find(transaction => transaction.type === 'swap');
+	if (simpleSwap === undefined) {
+		throw(new Error('Expected a shape-classified swap in the simple list'));
 	}
 
-	expect(leanSwap.counterparty?.kind).not.toBe('anchor');
-	expect(leanSwap.providerStatus).toBeUndefined();
-	expect(leanSwap.refs.anchorTxIDs).toHaveLength(0);
+	expect(simpleSwap.counterparty?.kind).not.toBe('anchor');
+	expect(simpleSwap.providerStatus).toBeUndefined();
+	expect(simpleSwap.refs.anchorTxIDs).toHaveLength(0);
 
 	/*
 	 * Enriching just that transaction resolves its anchor attribution, the way
 	 * a detail view would.
 	 */
-	const enriched = await fixture.history.enrichTransaction(leanSwap, fixture.userAccount);
+	const enriched = await fixture.history.enrichTransaction(simpleSwap, fixture.userAccount);
 	expect(enriched.type).toBe('swap');
 	expect(enriched.counterparty?.kind).toBe('anchor');
 	expect(enriched.providerStatus).toBeDefined();
@@ -1493,8 +1485,7 @@ test('iterate folds a linked FX chain incrementally, matching list', async funct
 	}
 
 	/*
-	 * The stream itself now yields the folded conversion (not the two raw
-	 * hops), so iterate() and list() agree.
+	 * The stream itself now yields the folded conversion.
 	 */
 	const swaps = streamed.filter(transaction => transaction.type === 'swap');
 	expect(swaps).toHaveLength(1);
@@ -1819,18 +1810,13 @@ test('folds a non-atomic anchor conversion from on-chain inputs alone, without e
 	expect(enriched[0]?.send).toEqual({ token: source0.publicKeyString.get(), amount: 1000n });
 	expect(enriched[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
 
-	/*
-	 * Lean (default, no anchor calls): the delivery's external inputs still link
-	 * it to the pay-in, so the conversion must fold into one swap from on-chain
-	 * shape alone - just without the anchor attribution enrichment adds.
-	 */
-	const lean = await history.list(user);
-	expect(lean).toHaveLength(1);
-	expect(lean[0]?.type).toBe('swap');
-	expect(lean[0]?.send).toEqual({ token: source0.publicKeyString.get(), amount: 1000n });
-	expect(lean[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
-	expect(lean[0]?.refs.blockHashes).toEqual(expect.arrayContaining([ payIn.hash.toString(), delivery.hash.toString() ]));
-	expect(lean[0]?.refs.anchorTxIDs).toHaveLength(0);
+	const simple = await history.list(user);
+	expect(simple).toHaveLength(1);
+	expect(simple[0]?.type).toBe('swap');
+	expect(simple[0]?.send).toEqual({ token: source0.publicKeyString.get(), amount: 1000n });
+	expect(simple[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
+	expect(simple[0]?.refs.blockHashes).toEqual(expect.arrayContaining([ payIn.hash.toString(), delivery.hash.toString() ]));
+	expect(simple[0]?.refs.anchorTxIDs).toHaveLength(0);
 });
 
 test('foldChains merges a two-hop linked chain into one conversion', function() {

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -557,7 +557,8 @@ test('an anchor deposit ids the operation and links its sub-transactions', async
 	source.registerByCoord(anchor, block.hash.toString(), 0, transfer);
 
 	const [ transaction ] = await runHistory([ block ], source);
-	expect(transaction?.id).toBe(`${block.hash.toString()}:0`);
+	// A block settling a single transfer keeps the bare block hash as its id.
+	expect(transaction?.id).toBe(block.hash.toString());
 
 	const anchorLeg = transaction?.legs.find(leg => leg.kind === 'anchor');
 	if (anchorLeg?.kind !== 'anchor') {
@@ -583,23 +584,24 @@ test('includeSource resolves a suffixed transaction id to its source block', asy
 	const user = newAccount();
 	const anchor = newAccount();
 	const token = newToken(user, 0);
-	const block = await seal(user, [ receiveOp(anchor, token, 750n) ]);
+	const other = newToken(user, 1);
+	// Two operations settling two different transfers force suffixed ids.
+	const block = await seal(user, [ receiveOp(anchor, token, 750n), receiveOp(anchor, other, 500n) ]);
 
-	const transfer = makeTransfer({
-		id: 'deposit-tx',
-		status: 'PENDING',
-		asset: token.publicKeyString.get(),
-		fromLocation: MOBILE_LOCATION,
-		toLocation: KEETA_LOCATION,
-		fromValue: '750',
-		toValue: '750'
-	});
 	const source = new TestStatusSource();
-	source.registerByCoord(anchor, block.hash.toString(), 0, transfer);
+	source.registerByCoord(anchor, block.hash.toString(), 0, makeTransfer({
+		id: 'deposit-0', status: 'PENDING', asset: token.publicKeyString.get(), fromLocation: MOBILE_LOCATION, toLocation: KEETA_LOCATION, fromValue: '750', toValue: '750'
+	}));
+	source.registerByCoord(anchor, block.hash.toString(), 1, makeTransfer({
+		id: 'deposit-1', status: 'PENDING', asset: other.publicKeyString.get(), fromLocation: MOBILE_LOCATION, toLocation: KEETA_LOCATION, fromValue: '500', toValue: '500'
+	}));
 
-	const [ transaction ] = await runHistory([ block ], source, { includeSource: true });
-	expect(transaction?.id).toBe(`${block.hash.toString()}:0`);
-	expect(transaction?.source?.enriched.blockHash).toBe(block.hash.toString());
+	const transactions = await runHistory([ block ], source, { includeSource: true });
+	expect(transactions).toHaveLength(2);
+	expect(transactions.map(transaction => transaction.id).sort()).toEqual([ `${block.hash.toString()}:0`, `${block.hash.toString()}:1` ]);
+	for (const transaction of transactions) {
+		expect(transaction.source?.enriched.blockHash).toBe(block.hash.toString());
+	}
 });
 
 test('source is absent unless includeSource is requested', async function() {
@@ -2004,6 +2006,7 @@ test('groups a multi-hop declared-anchor conversion into one row, without enrich
 	expect(enriched).toHaveLength(1);
 	expect(enriched[0]?.type).toBe('swap');
 	expect(enriched[0]?.provisional).toBeUndefined();
+	expect(enriched[0]?.id).toBe(conversion?.id);
 
 	/*
 	 * Enriching the grouped row on demand must keep the source (and its
@@ -2017,8 +2020,48 @@ test('groups a multi-hop declared-anchor conversion into one row, without enrich
 
 	const enrichedRow = await history.enrichTransaction(withSource, user, { includeSource: true });
 	expect(enrichedRow.type).toBe('swap');
+	expect(enrichedRow.id).toBe(withSource.id);
 	expect(enrichedRow.source).toBeDefined();
 	expect(enrichedRow.source?.enriched.perspective).toBe(user.publicKeyString.get());
+});
+
+test('a single-transfer anchor row keeps a stable id across enrichment', async function() {
+	const user = newAccount();
+	const anchor = newAccount();
+	const token = newToken(user, 0);
+	const external = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'withdraw-tx' }).build();
+	const block = await seal(user, [ sendOp(anchor, token, 400n, external) ]);
+
+	const transfer = makeTransfer({
+		id: 'withdraw-tx',
+		status: 'COMPLETE',
+		asset: token.publicKeyString.get(),
+		fromLocation: KEETA_LOCATION,
+		toLocation: MOBILE_LOCATION,
+		fromValue: '400',
+		toValue: '400'
+	});
+	const status = new TestStatusSource();
+	status.registerByTxID(anchor, transfer);
+	const history = new UserHistory({ history: pagedFoldCapableSource([ block ]), status: new AnchorTransactionStatus(status) });
+
+	/* The same single-transfer block keeps the bare block hash in both modes. */
+	const [ provisional ] = await history.list(user, { includeSource: true });
+	const [ enriched ] = await history.list(user, { enrich: true, includeSource: true });
+	if (provisional === undefined || enriched === undefined) {
+		throw(new Error('expected a row'));
+	}
+
+	expect(provisional.type).toBe('withdraw');
+	expect(provisional.id).toBe(block.hash.toString());
+	expect(enriched.type).toBe('withdraw');
+	expect(enriched.id).toBe(block.hash.toString());
+
+	/* Enriching the provisional row on demand keeps its id. */
+	const onDemand = await history.enrichTransaction(provisional, user, { includeSource: true });
+	expect(onDemand.id).toBe(provisional.id);
+	expect(onDemand.type).toBe('withdraw');
+	expect(onDemand.refs.anchorTxIDs).toContain('withdraw-tx');
 });
 
 test('foldChains merges a two-hop linked chain into one conversion', function() {

--- a/src/lib/history.test.ts
+++ b/src/lib/history.test.ts
@@ -104,7 +104,12 @@ async function runHistory(blocks: Block[], source?: AnchorStatusSource<KeetaAsse
 
 	const history = new UserHistory(config);
 	const account = queriedAccount ?? blocks[0]?.account ?? null;
-	const transactions = await history.list(account, options);
+
+	/*
+	 * Listing is lean by default now; these classification/enrichment cases
+	 * opt in unless a case explicitly overrides `enrich`.
+	 */
+	const transactions = await history.list(account, { enrich: true, ...options });
 	return(transactions);
 }
 
@@ -357,6 +362,48 @@ test('an atomic swap omits the fee when the non-principal sends use more than on
 	expect(transaction?.send).toEqual({ token: tokenA.publicKeyString.get(), amount: 1000n });
 	expect(transaction?.receive).toEqual({ token: tokenB.publicKeyString.get(), amount: 990n });
 	expect(transaction?.fee).toBeUndefined();
+});
+
+test('folds an accepted swap into one swap from the acceptor perspective', async function() {
+	const creator = newAccount();
+	const acceptor = newAccount();
+	const tokenA = newToken(creator, 0);
+	const tokenB = newToken(creator, 1);
+
+	/*
+	 * Web-wallet P2P accept: the creator's pre-signed SEND+RECEIVE(exact)
+	 * block and the acceptor's SEND-only block publish in one staple. The
+	 * acceptor's receive of tokenA lives in the creator's block.
+	 */
+	const creatorBlock = await seal(creator, [ sendOp(acceptor, tokenA, 1000n), receiveOp(acceptor, tokenB, 990n) ]);
+	const acceptorBlock = await seal(acceptor, [ sendOp(creator, tokenB, 990n) ]);
+
+	const [ transaction, ...rest ] = await runHistory([ acceptorBlock, creatorBlock ], undefined, undefined, acceptor);
+	expect(rest).toHaveLength(0);
+	expect(transaction?.type).toBe('swap');
+	expect(transaction?.direction).toBe('self');
+	expect(transaction?.send).toEqual({ token: tokenB.publicKeyString.get(), amount: 990n });
+	expect(transaction?.receive).toEqual({ token: tokenA.publicKeyString.get(), amount: 1000n });
+	expect(transaction?.counterparty).toEqual({ kind: 'account', id: creator.publicKeyString.get() });
+	expect(transaction?.legs).toHaveLength(2);
+});
+
+test('leaves a send-only block unfolded when the counterparty does not exactly consume it', async function() {
+	const me = newAccount();
+	const other = newAccount();
+	const tokenX = newToken(me, 0);
+	const tokenY = newToken(me, 1);
+
+	/*
+	 * The counterparty sends tokenY back but only partially receives tokenX,
+	 * so the receive does not exactly consume the send: this is not a swap.
+	 */
+	const myBlock = await seal(me, [ sendOp(other, tokenX, 500n) ]);
+	const otherBlock = await seal(other, [ receiveOp(me, tokenX, 400n), sendOp(me, tokenY, 300n) ]);
+
+	const transactions = await runHistory([ myBlock, otherBlock ], undefined, undefined, me);
+	expect(transactions.some(transaction => transaction.type === 'swap')).toBe(false);
+	expect(transactions.some(transaction => transaction.type === 'send' && transaction.send?.token === tokenX.publicKeyString.get())).toBe(true);
 });
 
 // #endregion Block-shape classification
@@ -898,7 +945,7 @@ test('resolves a real withdraw end-to-end through a live node and anchor server'
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const withdraw = transactions.find(transaction => transaction.type === 'withdraw');
 	expect(withdraw).toBeDefined();
 	expect(withdraw?.status).toBe('complete');
@@ -918,7 +965,7 @@ test('resolves a real deposit payout end-to-end from an anchor-issued send', asy
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const deposit = transactions.find(transaction => transaction.type === 'deposit');
 	expect(deposit).toBeDefined();
 	expect(deposit?.status).toBe('complete');
@@ -1282,7 +1329,7 @@ test('folds a real FX exchange into a single swap transaction', async function()
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount, { includeSource: true });
+	const transactions = await fixture.history.list(fixture.userAccount, { includeSource: true, enrich: true });
 	const swaps = transactions.filter(transaction => transaction.type === 'swap');
 	expect(swaps).toHaveLength(1);
 
@@ -1303,7 +1350,7 @@ test('attributes FX swap principal, receive and fee correctly', async function()
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const swap = transactions.find(transaction => transaction.type === 'swap');
 	expect(swap).toBeDefined();
 	expect(swap?.direction).toBe('self');
@@ -1317,7 +1364,7 @@ test('links a real FX exchange to its anchor provider', async function() {
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const swap = transactions.find(transaction => transaction.type === 'swap');
 	expect(swap?.counterparty?.kind).toBe('anchor');
 	expect(swap?.providerStatus).toBeDefined();
@@ -1329,7 +1376,7 @@ test('degrades to a shape-only swap when the FX provider cannot be resolved', as
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const swaps = transactions.filter(transaction => transaction.type === 'swap');
 	expect(swaps).toHaveLength(1);
 
@@ -1354,7 +1401,7 @@ test('reports the net principal for a variable-rate swap that refunds slippage',
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const swap = transactions.find(transaction => transaction.type === 'swap');
 	expect(swap).toBeDefined();
 	expect(swap?.counterparty?.kind).toBe('anchor');
@@ -1373,7 +1420,7 @@ test('surfaces the on-chain input a later FX swap declares and folds the chain i
 	await using server = fixture.server;
 	void server;
 
-	const transactions = await fixture.history.list(fixture.userAccount);
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
 	const swaps = transactions.filter(transaction => transaction.type === 'swap');
 	expect(swaps).toHaveLength(1);
 
@@ -1388,6 +1435,51 @@ test('surfaces the on-chain input a later FX swap declares and folds the chain i
 	 */
 	const refolded = foldChains(transactions).filter(transaction => transaction.type === 'swap');
 	expect(refolded).toHaveLength(1);
+});
+
+test('a folded multi-hop atomic FX chain retains anchor enrichment', async function() {
+	const fixture = await startChainedFXExchangeFixture();
+	await using server = fixture.server;
+	void server;
+
+	const transactions = await fixture.history.list(fixture.userAccount, { enrich: true });
+	const swaps = transactions.filter(transaction => transaction.type === 'swap');
+	expect(swaps).toHaveLength(1);
+
+	const swap = swaps[0];
+	expect(swap?.counterparty?.kind).toBe('anchor');
+	expect(swap?.providerStatus).toBeDefined();
+	expect(swap?.refs.anchorTxIDs.length).toBeGreaterThan(0);
+});
+
+test('lists leanly by default, then enriches a single transaction on demand', async function() {
+	const fixture = await startFXExchangeFixture();
+	await using server = fixture.server;
+	void server;
+
+	/*
+	 * The default list is lean: the swap classifies by on-chain shape with no
+	 * anchor attribution, sparing the per-operation anchor HTTP calls.
+	 */
+	const lean = await fixture.history.list(fixture.userAccount);
+	const leanSwap = lean.find(transaction => transaction.type === 'swap');
+	if (leanSwap === undefined) {
+		throw(new Error('Expected a shape-classified swap in the lean list'));
+	}
+
+	expect(leanSwap.counterparty?.kind).not.toBe('anchor');
+	expect(leanSwap.providerStatus).toBeUndefined();
+	expect(leanSwap.refs.anchorTxIDs).toHaveLength(0);
+
+	/*
+	 * Enriching just that transaction resolves its anchor attribution, the way
+	 * a detail view would.
+	 */
+	const enriched = await fixture.history.enrichTransaction(leanSwap, fixture.userAccount);
+	expect(enriched.type).toBe('swap');
+	expect(enriched.counterparty?.kind).toBe('anchor');
+	expect(enriched.providerStatus).toBeDefined();
+	expect(enriched.refs.anchorTxIDs.length).toBeGreaterThan(0);
 });
 
 test('iterate folds a linked FX chain incrementally, matching list', async function() {
@@ -1620,7 +1712,7 @@ test('iterate suppresses a swap delivery that funds a chained bridge, leaving on
 	 * The swap (pay-in) folds into the bridge as one outbound conversion; the
 	 * anchor's intermediate mid-token delivery is dropped as the other leg.
 	 */
-	const transactions = await history.list(user);
+	const transactions = await history.list(user, { enrich: true });
 	expect(transactions).toHaveLength(1);
 
 	const conversion = transactions[0];
@@ -1679,10 +1771,66 @@ test('iterate absorbs an unresolved delivery leg linked to the funding block', a
 		status: new AnchorTransactionStatus(status)
 	});
 
-	const transactions = await history.list(user);
+	const transactions = await history.list(user, { enrich: true });
 	expect(transactions).toHaveLength(1);
 	expect(transactions[0]?.type).toBe('bridge');
 	expect(transactions.some(transaction => transaction.refs.blockHashes.includes(delivery.hash.toString()))).toBe(false);
+});
+
+test('folds a non-atomic anchor conversion from on-chain inputs alone, without enrichment', async function() {
+	const user = newAccount();
+	const anchor = newAccount();
+	const source0 = newToken(user, 0);
+	const mid = newToken(user, 1);
+
+	const swap = makeTransfer({
+		id: 'transfer-1',
+		status: 'COMPLETE',
+		asset: { from: source0.publicKeyString.get(), to: mid.publicKeyString.get() },
+		fromLocation: KEETA_LOCATION,
+		toLocation: KEETA_LOCATION,
+		fromValue: '1000',
+		toValue: '999'
+	});
+
+	const status = new TestStatusSource();
+	status.registerByTxID(anchor, swap);
+
+	const payInExternal = await new AnchorExternal.Builder().setAnchor(anchor, { transactionId: 'transfer-1' }).build();
+	const payIn = await seal(user, [ sendOp(anchor, source0, 1000n, payInExternal) ]);
+
+	const deliveryExternal = await new AnchorExternal.Builder()
+		.setAnchor(anchor, { transactionId: 'transfer-1' })
+		.withSigner(anchor)
+		.withBinding(KeetaNet.lib.Block.NO_PREVIOUS, 0)
+		.addInput(payIn.hash.toString(), 0)
+		.build();
+	const delivery = await seal(anchor, [ sendOp(user, mid, 999n, deliveryExternal) ]);
+
+	const history = new UserHistory({
+		history: pagedFoldCapableSource([ delivery, payIn ]),
+		status: new AnchorTransactionStatus(status)
+	});
+
+	/* Enriched: the anchor transfer ties both legs into one Converted swap. */
+	const enriched = await history.list(user, { enrich: true });
+	expect(enriched).toHaveLength(1);
+	expect(enriched[0]?.type).toBe('swap');
+	expect(enriched[0]?.send).toEqual({ token: source0.publicKeyString.get(), amount: 1000n });
+	expect(enriched[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
+
+	/*
+	 * Lean (default, no anchor calls): the delivery's external inputs still link
+	 * it to the pay-in, so the conversion must fold into one swap from on-chain
+	 * shape alone - just without the anchor attribution enrichment adds.
+	 */
+	const lean = await history.list(user);
+	expect(lean).toHaveLength(1);
+	expect(lean[0]?.type).toBe('swap');
+	expect(lean[0]?.send).toEqual({ token: source0.publicKeyString.get(), amount: 1000n });
+	expect(lean[0]?.receive).toEqual({ token: mid.publicKeyString.get(), amount: 999n });
+	expect(lean[0]?.refs.blockHashes).toEqual(expect.arrayContaining([ payIn.hash.toString(), delivery.hash.toString() ]));
+	expect(lean[0]?.refs.anchorTxIDs).toHaveLength(0);
 });
 
 test('foldChains merges a two-hop linked chain into one conversion', function() {
@@ -1763,6 +1911,28 @@ test('foldChains drops the headline fee when hops pay fees in different tokens',
 
 	const folded = foldChains([ hop2, hop1 ]);
 	expect(folded[0]?.fee).toBeUndefined();
+});
+
+test('foldChains folds a pay-in send capped by its delivery receive into one swap', function() {
+	const payIn: LogicalTransaction = { id: 'p1:0', type: 'send', status: 'complete', direction: 'out', timestamp: '2026-01-01T00:00:00.000Z', send: { token: 'tokenA', amount: 1000n }, counterparty: { kind: 'account', id: 'anchorX' }, legs: [], refs: { blockHashes: [ 'p1' ], anchorTxIDs: [] }};
+	const delivery: LogicalTransaction = { id: 'd1:0', type: 'receive', status: 'complete', direction: 'in', timestamp: '2026-01-01T00:05:00.000Z', receive: { token: 'tokenB', amount: 999n }, counterparty: { kind: 'account', id: 'anchorX' }, legs: [], refs: { blockHashes: [ 'd1' ], anchorTxIDs: [], inputs: [ { blockHash: 'p1' } ] }};
+
+	const folded = foldChains([ delivery, payIn ]);
+	expect(folded).toHaveLength(1);
+	expect(folded[0]?.type).toBe('swap');
+	expect(folded[0]?.direction).toBe('self');
+	expect(folded[0]?.send).toEqual({ token: 'tokenA', amount: 1000n });
+	expect(folded[0]?.receive).toEqual({ token: 'tokenB', amount: 999n });
+	expect(folded[0]?.refs.blockHashes).toEqual(expect.arrayContaining([ 'p1', 'd1' ]));
+});
+
+test('foldChains leaves a receive linked to a non-send predecessor unfolded', function() {
+	const swap = makeSwap({ id: 's1:0', blockHash: 's1', send: { token: 'tokenA', amount: 1000n }, receive: { token: 'tokenB', amount: 999n }});
+	const deliveryLeg: LogicalTransaction = { id: 'r1:0', type: 'receive', status: 'complete', direction: 'in', timestamp: '2026-01-01T00:05:00.000Z', receive: { token: 'tokenB', amount: 999n }, legs: [], refs: { blockHashes: [ 'r1' ], anchorTxIDs: [], inputs: [ { blockHash: 's1' } ] }};
+
+	const folded = foldChains([ deliveryLeg, swap ]);
+	expect(folded).toHaveLength(2);
+	expect(folded.map(transaction => transaction.type).sort()).toEqual([ 'receive', 'swap' ]);
 });
 
 // #endregion foldChains

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -146,6 +146,12 @@ export type LogicalTransaction = {
 	 */
 	providerStatus?: string;
 	/**
+	 * Set when `type` and `counterparty` were inferred locally from the block's
+	 * anchor `external` without enrichment, so the wallet can render a tentative
+	 * label and enrich on demand. Cleared once the transfer resolves.
+	 */
+	provisional?: boolean;
+	/**
 	 * Flow of value relative to the queried account.
 	 */
 	direction: LogicalDirection;
@@ -194,6 +200,12 @@ export type LogicalTransaction = {
 		 * from the `external` envelope.
 		 */
 		inputs?: AnchorExternalInput[];
+		/**
+		 * Anchor transfer ids declared locally by the block's SEND `external`
+		 * envelopes, available without enrichment. Superseded by `anchorTxIDs`
+		 * once the transfer is resolved.
+		 */
+		declaredAnchorTxIDs?: string[];
 	};
 	/**
 	 * Raw source the transaction was folded from. Present only when
@@ -275,6 +287,33 @@ export type EnrichedBlock = {
 	 * anchor status resolution. Present only when non-empty.
 	 */
 	inputs?: AnchorExternalInput[];
+	/**
+	 * Anchor transfer references decoded locally from the block's SEND
+	 * `external` envelopes and trusted (block-owned by the perspective or
+	 * anchor-signed). Present only when non-empty.
+	 */
+	declaredAnchors?: DeclaredAnchorRef[];
+};
+
+/**
+ * An anchor transfer reference decoded locally from a block's SEND `external`
+ * envelope. `signed` is true when the envelope was signed by `anchorID`, which
+ * makes the reference trustworthy even for a block the perspective does not own.
+ */
+export type DeclaredAnchorRef = {
+	/**
+	 * Anchor public key string the entry is filed under.
+	 */
+	anchorID: string;
+	/**
+	 * Anchor-scoped transaction id declared for this transfer. Matches the
+	 * resolved transfer's id later carried in `refs.anchorTxIDs`.
+	 */
+	transactionID: string;
+	/**
+	 * Whether the declaring `external` was signed by `anchorID`.
+	 */
+	signed: boolean;
 };
 
 /**
@@ -677,10 +716,13 @@ function blockExternals(block: EnrichedBlock): string[] {
 }
 
 /**
- * Decode the on-chain `inputs` declared by a block's SEND `external` envelopes.
+ * Decode a block's SEND `external` envelopes into the on-chain `inputs` they
+ * declare and the anchor transfers they name. Both are captured locally,
+ * independent of anchor status resolution; undecodable envelopes are skipped.
  */
-async function decodeExternalInputs(externals: readonly string[], decryptionKeys: VerifiableAccount[] | undefined): Promise<AnchorExternalInput[]> {
+async function decodeExternalEnvelopes(externals: readonly string[], decryptionKeys: VerifiableAccount[] | undefined): Promise<{ inputs: AnchorExternalInput[]; declaredAnchors: DeclaredAnchorRef[] }> {
 	const inputs: AnchorExternalInput[] = [];
+	const declaredAnchors: DeclaredAnchorRef[] = [];
 	for (const external of externals) {
 		let decoded: AnchorExternal;
 		try {
@@ -700,9 +742,52 @@ async function decodeExternalInputs(externals: readonly string[], decryptionKeys
 				inputs.push(inputReference);
 			}
 		}
+
+		const signerID = decoded.signed?.signer.publicKeyString.get();
+		for (const [ anchorID, entry ] of Object.entries(decoded.envelope.anchors)) {
+			if (!('transactionId' in entry)) {
+				continue;
+			}
+
+			declaredAnchors.push({ anchorID, transactionID: entry.transactionId, signed: signerID === anchorID });
+		}
 	}
 
-	return(inputs);
+	return({ inputs, declaredAnchors });
+}
+
+/**
+ * The single anchor a block's trusted declarations name, or `undefined` when
+ * there are none or they disagree.
+ */
+function declaredAnchorID(block: EnrichedBlock): string | undefined {
+	const refs = block.declaredAnchors ?? [];
+	const first = refs[0];
+	if (first === undefined) {
+		return(undefined);
+	}
+
+	for (const ref of refs) {
+		if (ref.anchorID !== first.anchorID) {
+			return(undefined);
+		}
+	}
+
+	return(first.anchorID);
+}
+
+/**
+ * The distinct anchor transfer ids a block declares locally, in order.
+ */
+function declaredAnchorTxIDsOf(block: EnrichedBlock): string[] {
+	const ids: string[] = [];
+	for (const ref of block.declaredAnchors ?? []) {
+		if (!ids.includes(ref.transactionID)) {
+			ids.push(ref.transactionID);
+		}
+	}
+
+	return(ids);
 }
 
 /**
@@ -717,6 +802,11 @@ function buildRefs(block: EnrichedBlock, anchorTxIDs: string[]): LogicalTransact
 
 	if (block.inputs !== undefined && block.inputs.length > 0) {
 		refs.inputs = block.inputs;
+	}
+
+	const declaredAnchorTxIDs = declaredAnchorTxIDsOf(block);
+	if (declaredAnchorTxIDs.length > 0) {
+		refs.declaredAnchorTxIDs = declaredAnchorTxIDs;
 	}
 
 	return(refs);
@@ -954,9 +1044,14 @@ const sendClassifier: LogicalClassifier = {
 			refs: buildRefs(block, [])
 		};
 
-		const counterparty = uniformCounterparty(sends);
-		if (counterparty !== undefined) {
-			transaction.counterparty = { kind: 'account', id: counterparty };
+		const anchorID = declaredAnchorID(block);
+		if (anchorID !== undefined) {
+			transaction.counterparty = { kind: 'anchor', id: anchorID };
+		} else {
+			const counterparty = uniformCounterparty(sends);
+			if (counterparty !== undefined) {
+				transaction.counterparty = { kind: 'account', id: counterparty };
+			}
 		}
 
 		return([ transaction ]);
@@ -989,9 +1084,14 @@ const receiveClassifier: LogicalClassifier = {
 			refs: buildRefs(block, [])
 		};
 
-		const counterparty = uniformCounterparty(receives);
-		if (counterparty !== undefined) {
-			transaction.counterparty = { kind: 'account', id: counterparty };
+		const anchorID = declaredAnchorID(block);
+		if (anchorID !== undefined) {
+			transaction.counterparty = { kind: 'anchor', id: anchorID };
+		} else {
+			const counterparty = uniformCounterparty(receives);
+			if (counterparty !== undefined) {
+				transaction.counterparty = { kind: 'account', id: counterparty };
+			}
 		}
 
 		return([ transaction ]);
@@ -1224,6 +1324,7 @@ type MergedHopRefs = {
 	anchorTxIDs: string[];
 	externals: string[];
 	inputs: AnchorExternalInput[];
+	declaredAnchorTxIDs: string[];
 };
 
 /**
@@ -1231,7 +1332,7 @@ type MergedHopRefs = {
  * and externals while preserving the ordered on-chain inputs.
  */
 function accumulateHopRefs(hops: readonly LogicalTransaction[]): MergedHopRefs {
-	const merged: MergedHopRefs = { blockHashes: [], anchorTxIDs: [], externals: [], inputs: [] };
+	const merged: MergedHopRefs = { blockHashes: [], anchorTxIDs: [], externals: [], inputs: [], declaredAnchorTxIDs: [] };
 	for (const hop of hops) {
 		for (const blockHash of hop.refs.blockHashes) {
 			pushUnique(merged.blockHashes, blockHash);
@@ -1244,6 +1345,9 @@ function accumulateHopRefs(hops: readonly LogicalTransaction[]): MergedHopRefs {
 		}
 		for (const input of hop.refs.inputs ?? []) {
 			merged.inputs.push(input);
+		}
+		for (const declaredAnchorTxID of hop.refs.declaredAnchorTxIDs ?? []) {
+			pushUnique(merged.declaredAnchorTxIDs, declaredAnchorTxID);
 		}
 	}
 
@@ -1338,7 +1442,7 @@ function conversionShape(head: LogicalTransaction, tail: LogicalTransaction, hop
 }
 
 function mergeChainHops(head: LogicalTransaction, tail: LogicalTransaction, hops: readonly LogicalTransaction[]): LogicalTransaction {
-	const { blockHashes, anchorTxIDs, externals, inputs } = accumulateHopRefs(hops);
+	const { blockHashes, anchorTxIDs, externals, inputs, declaredAnchorTxIDs } = accumulateHopRefs(hops);
 
 	const refs: LogicalTransaction['refs'] = { blockHashes, anchorTxIDs };
 	if (externals.length > 0) {
@@ -1347,6 +1451,10 @@ function mergeChainHops(head: LogicalTransaction, tail: LogicalTransaction, hops
 
 	if (inputs.length > 0) {
 		refs.inputs = inputs;
+	}
+
+	if (declaredAnchorTxIDs.length > 0) {
+		refs.declaredAnchorTxIDs = declaredAnchorTxIDs;
 	}
 
 	const shape = conversionShape(head, tail, hops);
@@ -1396,6 +1504,19 @@ type FoldChain = {
 };
 
 /**
+ * An unenriched leg attributed to an anchor purely from its locally decoded
+ * `external` (a declared transfer id, no authoritative `anchorTxIDs` yet, and
+ * an anchor counterparty). These are the hops of an anchor conversion before
+ * enrichment resolves their true swap/bridge types, so they chain along their
+ * `inputs` edges the way resolved swaps do.
+ */
+function isLocalAnchorHop(transaction: LogicalTransaction): boolean {
+	return(transaction.refs.anchorTxIDs.length === 0
+		&& (transaction.refs.declaredAnchorTxIDs?.length ?? 0) > 0
+		&& transaction.counterparty?.kind === 'anchor');
+}
+
+/**
  * Whether `head` may fold into `successor` along their
  * `refs.inputs` <-> `refs.blockHashes` link: swaps chain into further swaps or
  * a capping bridge, and a pay-in `send` caps into its delivery `receive`. The
@@ -1403,6 +1524,16 @@ type FoldChain = {
  * {@link foldChains} pass and the incremental by-hash resolution.
  */
 function canLink(head: LogicalTransaction, successor: LogicalTransaction): boolean {
+	/*
+	 * Unenriched anchor hops chain to one another along their inputs edges the
+	 * way resolved swaps do, so a multi-hop anchor conversion folds into one row
+	 * without enrichment. The inputs edge itself is always separately required
+	 * by the caller.
+	 */
+	if (isLocalAnchorHop(head) && isLocalAnchorHop(successor)) {
+		return(true);
+	}
+
 	if (head.type === 'swap') {
 		return(successor.type === 'swap' || successor.type === 'bridge');
 	}
@@ -1466,8 +1597,8 @@ function walkChainFrom(head: LogicalTransaction, successorOf: ReadonlyMap<string
 }
 
 function buildChains(transactions: readonly LogicalTransaction[]): Map<string, FoldChain> {
-	const heads = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'send');
-	const successors = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive');
+	const heads = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'send' || isLocalAnchorHop(transaction));
+	const successors = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive' || isLocalAnchorHop(transaction));
 	const { successorOf, predecessorOf } = linkChainSuccessors(heads, successors);
 
 	const chainByMemberId = new Map<string, FoldChain>();
@@ -1522,11 +1653,27 @@ export function foldChains(transactions: readonly LogicalTransaction[]): Logical
 }
 
 /**
+ * The anchor transfer ids a transaction settles: the authoritative
+ * `anchorTxIDs` once enriched, otherwise the ids declared locally by the
+ * block's `external` so an unenriched list de-duplicates a transfer's several
+ * legs the same way. The empty-`anchorTxIDs` gate keeps enriched suppression
+ * identical to before.
+ */
+function settlementIDs(transaction: LogicalTransaction): readonly string[] {
+	const refs = transaction.refs;
+	if (refs.anchorTxIDs.length > 0) {
+		return(refs.anchorTxIDs);
+	}
+
+	return(refs.declaredAnchorTxIDs ?? []);
+}
+
+/**
  * Whether every anchor transfer a logical transaction settles has already been
  * emitted, marking it a duplicate settlement leg.
  */
 function isSettledDuplicate(transaction: LogicalTransaction, emitted: ReadonlySet<string>): boolean {
-	const ids = transaction.refs.anchorTxIDs;
+	const ids = settlementIDs(transaction);
 	if (ids.length === 0) {
 		return(false);
 	}
@@ -1538,7 +1685,7 @@ function isSettledDuplicate(transaction: LogicalTransaction, emitted: ReadonlySe
  * Record the anchor transfers a logical transaction settles.
  */
 function markEmittedTransfers(transaction: LogicalTransaction, emitted: Set<string>): void {
-	for (const id of transaction.refs.anchorTxIDs) {
+	for (const id of settlementIDs(transaction)) {
 		emitted.add(id);
 	}
 }
@@ -1590,6 +1737,49 @@ function suppressSettledDuplicates(transactions: readonly LogicalTransaction[]):
 	}
 
 	return(result);
+}
+
+/**
+ * Relabel a lone unenriched anchor leg to its provisional withdraw/deposit
+ * shape for display. A no-op once enriched (the row then carries authoritative
+ * `anchorTxIDs`), for folded swaps, and for rows with no trusted anchor
+ * declaration. Must run AFTER settlement suppression, since it rewrites `type`
+ * and would otherwise defeat the `type === 'receive'` gate in `isSettledLeg`.
+ */
+function normalizeProvisional(transaction: LogicalTransaction): LogicalTransaction {
+	const refs = transaction.refs;
+	if (refs.anchorTxIDs.length > 0) {
+		return(transaction);
+	}
+
+	if (refs.declaredAnchorTxIDs === undefined || refs.declaredAnchorTxIDs.length === 0) {
+		return(transaction);
+	}
+
+	if (transaction.counterparty?.kind !== 'anchor') {
+		return(transaction);
+	}
+
+	if (transaction.type !== 'send' && transaction.type !== 'receive') {
+		return(transaction);
+	}
+
+	return({ ...transaction, type: transaction.type === 'send' ? 'withdraw' : 'deposit', provisional: true });
+}
+
+/**
+ * Re-attach a caller's `source` to a conversion that lost it. A folded
+ * multi-hop conversion is built fresh by {@link mergeChainHops} and carries no
+ * `source`, so an `includeSource` enrichment would otherwise drop the
+ * perspective a detail view needs. Mirrors how {@link UserHistory.iterate}
+ * carries source into a folded conversion in its `#foldForward` pass.
+ */
+function attachConversionSource(transaction: LogicalTransaction, source: LogicalTransactionSource | undefined, includeSource: boolean): LogicalTransaction {
+	if (!includeSource || transaction.source !== undefined || source === undefined) {
+		return(transaction);
+	}
+
+	return({ ...transaction, source });
 }
 
 /**
@@ -1758,7 +1948,7 @@ export class UserHistory {
 			transactions.push(transaction);
 		}
 
-		const folded = suppressSettledDuplicates(foldChains(transactions));
+		const folded = suppressSettledDuplicates(foldChains(transactions)).map(normalizeProvisional);
 		if (limit !== undefined) {
 			return(folded.slice(0, limit));
 		}
@@ -1801,18 +1991,20 @@ export class UserHistory {
 
 		const blockHashes = new Set(transaction.refs.blockHashes);
 		const folded = foldChains(logical);
+		const includeSource = resolved?.includeSource === true;
+
 		const matchByID = folded.find(function(candidate) {
 			return(candidate.id === transaction.id);
 		});
 		if (matchByID !== undefined) {
-			return(matchByID);
+			return(attachConversionSource(normalizeProvisional(matchByID), transaction.source, includeSource));
 		}
 
 		const matchByBlock = folded.find(function(candidate) {
 			return(candidate.refs.blockHashes.some(hash => blockHashes.has(hash)));
 		});
 
-		return(matchByBlock ?? transaction);
+		return(attachConversionSource(normalizeProvisional(matchByBlock ?? transaction), transaction.source, includeSource));
 	}
 
 	/**
@@ -1897,7 +2089,7 @@ export class UserHistory {
 
 		markEmittedTransfers(out, context.emittedTransfers);
 		markEmittedBlocks(out, context.emittedBlocks);
-		return(out);
+		return(context.foldCapable ? normalizeProvisional(out) : out);
 	}
 
 	/**
@@ -1943,7 +2135,7 @@ export class UserHistory {
 	 * `consumed` so it is skipped when it later pages in.
 	 */
 	async #foldForward(transaction: LogicalTransaction, consumed: Set<string>, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction> {
-		const foldable = transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive';
+		const foldable = transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive' || isLocalAnchorHop(transaction);
 		if (!foldable || transaction.refs.inputs === undefined || transaction.refs.inputs.length === 0) {
 			return(transaction);
 		}
@@ -2089,9 +2281,21 @@ export class UserHistory {
 			result.perspective = perspective;
 		}
 
-		const inputs = await decodeExternalInputs(blockExternals(result), options?.decryptionKeys);
-		if (inputs.length > 0) {
-			result.inputs = inputs;
+		const decoded = await decodeExternalEnvelopes(blockExternals(result), options?.decryptionKeys);
+		if (decoded.inputs.length > 0) {
+			result.inputs = decoded.inputs;
+		}
+
+		/*
+		 * Only trust a declared anchor reference when the block is issued by the
+		 * perspective (its own history) or the entry was signed by the anchor.
+		 * An unsigned foreign block could otherwise assert a transfer id it does
+		 * not own and corrupt grouping.
+		 */
+		const owned = perspective !== undefined && account === perspective;
+		const trustedAnchors = decoded.declaredAnchors.filter(ref => owned || ref.signed);
+		if (trustedAnchors.length > 0) {
+			result.declaredAnchors = trustedAnchors;
 		}
 
 		return(result);

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -819,7 +819,7 @@ function buildRefs(block: EnrichedBlock, anchorTxIDs: string[]): LogicalTransact
 /**
  * Build the logical transaction backing one enriched anchor operation.
  */
-function buildAnchorTransaction(block: EnrichedBlock, enriched: EnrichedOperation, transfer: KeetaAssetMovementTransaction): LogicalTransaction {
+function buildAnchorTransaction(block: EnrichedBlock, enriched: EnrichedOperation, transfer: KeetaAssetMovementTransaction, indexed: boolean): LogicalTransaction {
 	const type = logicalTypeFromTransfer(transfer);
 	const fromKeeta = locationIsChain(transfer.from.location, 'keeta');
 	const direction = directionFromTransfer(type, fromKeeta);
@@ -849,7 +849,7 @@ function buildAnchorTransaction(block: EnrichedBlock, enriched: EnrichedOperatio
 
 	const refs = buildRefs(block, [ transfer.id ]);
 	const transaction: LogicalTransaction = {
-		id: `${block.blockHash}:${enriched.index}`,
+		id: indexed ? `${block.blockHash}:${enriched.index}` : block.blockHash,
 		type,
 		status: settled.status,
 		providerStatus: settled.providerStatus,
@@ -876,21 +876,25 @@ function buildAnchorTransaction(block: EnrichedBlock, enriched: EnrichedOperatio
  */
 const anchorTransferClassifier: LogicalClassifier = {
 	classify(block) {
-		const transactions: LogicalTransaction[] = [];
+		const resolved: { enriched: EnrichedOperation; transfer: KeetaAssetMovementTransaction }[] = [];
 		for (const enriched of block.operations) {
 			const transfer = enriched.transfer;
-			if (transfer === undefined) {
-				continue;
+			if (transfer !== undefined) {
+				resolved.push({ enriched, transfer });
 			}
-
-			transactions.push(buildAnchorTransaction(block, enriched, transfer));
 		}
 
-		if (transactions.length === 0) {
+		if (resolved.length === 0) {
 			return(null);
 		}
 
-		return(transactions);
+		/*
+		 * Suffix the id with the operation index only when the block settles more
+		 * than one transfer; a single-transfer block keeps the bare block hash so
+		 * its id matches the shape-classified (unenriched) row for the same block.
+		 */
+		const indexed = resolved.length > 1;
+		return(resolved.map(entry => buildAnchorTransaction(block, entry.enriched, entry.transfer, indexed)));
 	}
 };
 

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -397,8 +397,9 @@ export type UserHistoryListOptions = {
 	 */
 	cursor?: string;
 	/**
-	 * Enable anchor enrichment.
-	 * Defaults to `true` when a status source is set.
+	 * Enable anchor enrichment, which resolves each operation to its anchor
+	 * transfer over HTTP.
+	 * Defaults to `false`.
 	 */
 	enrich?: boolean;
 	/**
@@ -823,25 +824,67 @@ function principalSend(sends: readonly IndexedView[], receivedToken: string): In
 }
 
 /**
- * Aggregate the non-principal sends into a single fee amount, or `undefined`
- * when there are none or they use more than one token.
+ * Sum amounts into one total, or `undefined` when there are none or they use
+ * more than one token.
  */
-function aggregateFee(feeSends: readonly IndexedView[]): LogicalAmount | undefined {
-	const first = feeSends[0];
+function combineFees(fees: readonly LogicalAmount[]): LogicalAmount | undefined {
+	const first = fees.at(0);
 	if (first === undefined) {
 		return(undefined);
 	}
 
-	let amount = 0n;
-	for (const send of feeSends) {
-		if (send.amount.token !== first.amount.token) {
+	let total = 0n;
+	for (const fee of fees) {
+		if (fee.token !== first.token) {
 			return(undefined);
 		}
 
-		amount += send.amount.amount;
+		total += fee.amount;
 	}
 
-	return({ token: first.amount.token, amount });
+	return({ token: first.token, amount: total });
+}
+
+/**
+ * Aggregate the non-principal sends into a single fee amount, or `undefined`
+ * when there are none or they use more than one token.
+ */
+function aggregateFee(feeSends: readonly IndexedView[]): LogicalAmount | undefined {
+	return(combineFees(feeSends.map(send => send.amount)));
+}
+
+/**
+ * Build a `self`-directed swap from its principal and received legs. Shared by
+ * the single-block classifier and the cross-block accepted-swap fold.
+ */
+function swapTransaction(input: {
+	id: string;
+	timestamp: string;
+	send: LogicalAmount;
+	receive: LogicalAmount;
+	counterparty: NonNullable<LogicalTransaction['counterparty']>;
+	legs: LogicalLeg[];
+	refs: LogicalTransaction['refs'];
+	fee?: LogicalAmount;
+}): LogicalTransaction {
+	const transaction: LogicalTransaction = {
+		id: input.id,
+		type: 'swap',
+		status: 'complete',
+		direction: 'self',
+		timestamp: input.timestamp,
+		send: input.send,
+		receive: input.receive,
+		counterparty: input.counterparty,
+		legs: input.legs,
+		refs: input.refs
+	};
+
+	if (input.fee !== undefined) {
+		transaction.fee = input.fee;
+	}
+
+	return(transaction);
 }
 
 /**
@@ -872,24 +915,16 @@ const atomicSwapClassifier: LogicalClassifier = {
 
 		const fee = aggregateFee(sends.filter(send => send.index !== principal.index));
 
-		const transaction: LogicalTransaction = {
+		return([ swapTransaction({
 			id: block.blockHash,
-			type: 'swap',
-			status: 'complete',
-			direction: 'self',
 			timestamp: block.timestamp,
 			send: principal.amount,
 			receive: received.amount,
 			counterparty: { kind: 'liquidity', id: counterparty },
 			legs: onchainLegs(block),
-			refs: buildRefs(block, [])
-		};
-
-		if (fee !== undefined) {
-			transaction.fee = fee;
-		}
-
-		return([ transaction ]);
+			refs: buildRefs(block, []),
+			...(fee !== undefined ? { fee } : {})
+		}) ]);
 	}
 };
 
@@ -1023,12 +1058,98 @@ function suppressCoveredForeignBlocks(blocks: readonly EnrichedBlock[]): readonl
 }
 
 /**
- * Fold enriched blocks into logical transactions by running the ordered
- * classifiers; the first classifier that applies to a block wins.
+ * Find a block authored by `counterparty` within the staple that exactly
+ * consumes `principal` (a RECEIVE from the perspective for the same token and
+ * amount) and pays a different token back to the perspective, returning the
+ * received amount and that block. This is the counterpart leg of an accepted
+ * P2P swap, whose receive leg the perspective never signs itself.
+ */
+function matchSwapCounterpart(blocks: readonly EnrichedBlock[], perspective: string, counterparty: string, principal: LogicalAmount, consumed: ReadonlySet<string>): { block: EnrichedBlock; receive: LogicalAmount } | undefined {
+	for (const block of blocks) {
+		if (block.account !== counterparty || consumed.has(block.blockHash)) {
+			continue;
+		}
+
+		let consumesPrincipal = false;
+		let payout: LogicalAmount | undefined;
+		for (const enriched of block.operations) {
+			const view = operationView(enriched.operation);
+			if (view === null || view.counterparty !== perspective) {
+				continue;
+			}
+
+			if (view.opType === 'receive' && view.amount.token === principal.token && view.amount.amount === principal.amount) {
+				consumesPrincipal = true;
+			} else if (view.opType === 'send' && view.amount.token !== principal.token) {
+				payout = view.amount;
+			}
+		}
+
+		if (consumesPrincipal && payout !== undefined) {
+			return({ block, receive: payout });
+		}
+	}
+
+	return(undefined);
+}
+
+/**
+ * Fold accepted P2P swaps whose legs span two blocks of one staple: the
+ * perspective signs only a SEND (the token it gives) while its RECEIVE lives
+ * in the counterparty's block.
+ */
+function crossBlockSwaps(blocks: readonly EnrichedBlock[]): { transactions: LogicalTransaction[]; consumed: Set<string> } {
+	const consumed = new Set<string>();
+	const transactions: LogicalTransaction[] = [];
+	const perspective = blocks.find(block => block.perspective !== undefined)?.perspective;
+	if (perspective === undefined) {
+		return({ transactions, consumed });
+	}
+
+	for (const owned of blocks) {
+		if (owned.account !== perspective || consumed.has(owned.blockHash)) {
+			continue;
+		}
+
+		const { sends, receives, otherCount } = viewsOf(owned);
+		const principal = sends[0];
+		if (otherCount !== 0 || receives.length !== 0 || sends.length !== 1 || principal === undefined) {
+			continue;
+		}
+
+		const matched = matchSwapCounterpart(blocks, perspective, principal.counterparty, principal.amount, consumed);
+		if (matched === undefined) {
+			continue;
+		}
+
+		const refs = buildRefs(owned, []);
+		refs.blockHashes = [ ...refs.blockHashes, matched.block.blockHash ];
+		transactions.push(swapTransaction({
+			id: owned.blockHash,
+			timestamp: owned.timestamp,
+			send: principal.amount,
+			receive: matched.receive,
+			counterparty: { kind: 'account', id: principal.counterparty },
+			legs: [ ...onchainLegs(owned), ...onchainLegs(matched.block) ],
+			refs
+		}));
+		consumed.add(owned.blockHash);
+		consumed.add(matched.block.blockHash);
+	}
+
+	return({ transactions, consumed });
+}
+
+/**
+ * Fold enriched blocks into logical transactions. Cross-block accepted swaps
+ * are paired first so neither leg is later dropped or split, then the ordered
+ * classifiers run per block; the first classifier that applies to a block wins.
  */
 function foldHistory(blocks: readonly EnrichedBlock[], classifiers: readonly LogicalClassifier[]): LogicalTransaction[] {
-	const results: LogicalTransaction[] = [];
-	for (const block of suppressCoveredForeignBlocks(blocks)) {
+	const { transactions: swaps, consumed } = crossBlockSwaps(blocks);
+	const results: LogicalTransaction[] = [ ...swaps ];
+	const remaining = blocks.filter(block => !consumed.has(block.blockHash));
+	for (const block of suppressCoveredForeignBlocks(remaining)) {
 		for (const classifier of classifiers) {
 			const classified = classifier.classify(block);
 			if (classified !== null) {
@@ -1068,27 +1189,6 @@ function inputsReference(transaction: LogicalTransaction, candidate: LogicalTran
 	}
 
 	return(false);
-}
-
-/**
- * Sum the hops' fees when they all share one token.
- */
-function combineFees(fees: readonly LogicalAmount[]): LogicalAmount | undefined {
-	const first = fees.at(0);
-	if (first === undefined) {
-		return(undefined);
-	}
-
-	let total = 0n;
-	for (const fee of fees) {
-		if (fee.token !== first.token) {
-			return(undefined);
-		}
-
-		total += fee.amount;
-	}
-
-	return({ token: first.token, amount: total });
 }
 
 /**
@@ -1198,6 +1298,21 @@ function collectHopFees(hops: readonly LogicalTransaction[]): LogicalAmount[] {
 }
 
 /**
+ * The provider status of the latest hop that carries one, so a folded
+ * conversion still reports the anchor's settlement status.
+ */
+function latestHopProviderStatus(hops: readonly LogicalTransaction[]): string | undefined {
+	let providerStatus: string | undefined;
+	for (const hop of hops) {
+		if (hop.providerStatus !== undefined) {
+			providerStatus = hop.providerStatus;
+		}
+	}
+
+	return(providerStatus);
+}
+
+/**
  * The head's legs followed by the tail's, suppressing intermediate hops and
  * avoiding a duplicate when head and tail are the same transaction.
  */
@@ -1208,6 +1323,18 @@ function mergeHopLegs(head: LogicalTransaction, tail: LogicalTransaction): Logic
 	}
 
 	return(legs);
+}
+
+/**
+ * The display shape of a folded conversion.
+ */
+function conversionShape(head: LogicalTransaction, tail: LogicalTransaction, hops: readonly LogicalTransaction[]): { type: LogicalTransaction['type']; direction: LogicalTransaction['direction']; counterparty: LogicalTransaction['counterparty'] } {
+	if (head.type === 'send' && tail.type === 'receive') {
+		return({ type: 'swap', direction: 'self', counterparty: head.counterparty ?? tail.counterparty });
+	}
+
+	const counterparty = tail.type === 'swap' ? sharedCounterparty(hops) : tail.counterparty;
+	return({ type: tail.type, direction: tail.direction, counterparty });
 }
 
 function mergeChainHops(head: LogicalTransaction, tail: LogicalTransaction, hops: readonly LogicalTransaction[]): LogicalTransaction {
@@ -1222,11 +1349,12 @@ function mergeChainHops(head: LogicalTransaction, tail: LogicalTransaction, hops
 		refs.inputs = inputs;
 	}
 
+	const shape = conversionShape(head, tail, hops);
 	const merged: LogicalTransaction = {
 		id: head.id,
-		type: tail.type,
+		type: shape.type,
 		status: aggregateHopStatus(hops),
-		direction: tail.direction,
+		direction: shape.direction,
 		timestamp: earliestHopTimestamp(hops, head.timestamp),
 		legs: mergeHopLegs(head, tail),
 		refs
@@ -1245,22 +1373,22 @@ function mergeChainHops(head: LogicalTransaction, tail: LogicalTransaction, hops
 		merged.fee = fee;
 	}
 
-	/*
-	 * An all-swap chain reports its shared anchor; a chain that ends in a
-	 * bridge takes the bridge's counterparty, since the swap hops only fund it.
-	 */
-	const counterparty = tail.type === 'swap' ? sharedCounterparty(hops) : tail.counterparty;
-	if (counterparty !== undefined) {
-		merged.counterparty = counterparty;
+	if (shape.counterparty !== undefined) {
+		merged.counterparty = shape.counterparty;
+	}
+
+	const providerStatus = latestHopProviderStatus(hops);
+	if (providerStatus !== undefined) {
+		merged.providerStatus = providerStatus;
 	}
 
 	return(merged);
 }
 
 /**
- * An ordered chain of two or more linked swap hops.
+ * An ordered chain of two or more linked hops.
  */
-type SwapChain = {
+type FoldChain = {
 	id: string;
 	head: LogicalTransaction;
 	tail: LogicalTransaction;
@@ -1268,35 +1396,46 @@ type SwapChain = {
 };
 
 /**
- * Group swap transactions into the chains they form through their
- * `refs.inputs` <-> `refs.blockHashes` links. Only chains of two or more hops
- * are returned, keyed by every member's id.
- *
- * Heads and intermediate hops are always swaps; the tail may also be a bridge,
- * which is how a swap that funds an outbound bridge folds into one conversion.
+ * Whether `head` may fold into `successor` along their
+ * `refs.inputs` <-> `refs.blockHashes` link: swaps chain into further swaps or
+ * a capping bridge, and a pay-in `send` caps into its delivery `receive`. The
+ * single source of truth for edge validity, shared by the pure
+ * {@link foldChains} pass and the incremental by-hash resolution.
  */
+function canLink(head: LogicalTransaction, successor: LogicalTransaction): boolean {
+	if (head.type === 'swap') {
+		return(successor.type === 'swap' || successor.type === 'bridge');
+	}
+
+	if (head.type === 'send') {
+		return(successor.type === 'receive');
+	}
+
+	return(false);
+}
+
 /**
- * The forward/backward links between swaps and the swap or bridge each one
- * funds, established through their `refs.inputs` <-> `refs.blockHashes` edges.
- * Each swap keeps at most one successor (its first match).
+ * The forward/backward links between each head and the successor it funds,
+ * established through their `refs.inputs` <-> `refs.blockHashes` edges. Each
+ * head keeps at most one successor (its first match).
  */
-type SwapLinks = {
+type FoldLinks = {
 	successorOf: Map<string, LogicalTransaction>;
 	predecessorOf: Map<string, LogicalTransaction>;
 };
 
-function linkSwapSuccessors(swaps: readonly LogicalTransaction[], successors: readonly LogicalTransaction[]): SwapLinks {
+function linkChainSuccessors(heads: readonly LogicalTransaction[], successors: readonly LogicalTransaction[]): FoldLinks {
 	const successorOf = new Map<string, LogicalTransaction>();
 	const predecessorOf = new Map<string, LogicalTransaction>();
-	for (const swap of swaps) {
+	for (const head of heads) {
 		for (const other of successors) {
-			if (other.id === swap.id || successorOf.has(swap.id)) {
+			if (other.id === head.id || successorOf.has(head.id)) {
 				continue;
 			}
 
-			if (inputsReference(other, swap)) {
-				successorOf.set(swap.id, other);
-				predecessorOf.set(other.id, swap);
+			if (canLink(head, other) && inputsReference(other, head)) {
+				successorOf.set(head.id, other);
+				predecessorOf.set(other.id, head);
 			}
 		}
 	}
@@ -1326,24 +1465,24 @@ function walkChainFrom(head: LogicalTransaction, successorOf: ReadonlyMap<string
 	return(hops);
 }
 
-function buildSwapChains(transactions: readonly LogicalTransaction[]): Map<string, SwapChain> {
-	const swaps = transactions.filter(transaction => transaction.type === 'swap');
-	const successors = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'bridge');
-	const { successorOf, predecessorOf } = linkSwapSuccessors(swaps, successors);
+function buildChains(transactions: readonly LogicalTransaction[]): Map<string, FoldChain> {
+	const heads = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'send');
+	const successors = transactions.filter(transaction => transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive');
+	const { successorOf, predecessorOf } = linkChainSuccessors(heads, successors);
 
-	const chainByMemberId = new Map<string, SwapChain>();
-	for (const swap of swaps) {
-		if (predecessorOf.has(swap.id)) {
+	const chainByMemberId = new Map<string, FoldChain>();
+	for (const head of heads) {
+		if (predecessorOf.has(head.id)) {
 			continue;
 		}
 
-		const hops = walkChainFrom(swap, successorOf);
+		const hops = walkChainFrom(head, successorOf);
 		const tail = hops.at(-1);
 		if (hops.length < 2 || tail === undefined) {
 			continue;
 		}
 
-		const chain: SwapChain = { id: swap.id, head: swap, tail, hops };
+		const chain: FoldChain = { id: head.id, head, tail, hops };
 		for (const hop of hops) {
 			chainByMemberId.set(hop.id, chain);
 		}
@@ -1353,10 +1492,12 @@ function buildSwapChains(transactions: readonly LogicalTransaction[]): Map<strin
 }
 
 /**
- * Fold chained swaps into single conversions for display.
+ * Fold linked chains into single conversions for display: multi-hop swaps, a
+ * swap that funds an outbound bridge, and a pay-in send capped by its delivery
+ * receive (a non-atomic anchor swap seen leanly).
  */
 export function foldChains(transactions: readonly LogicalTransaction[]): LogicalTransaction[] {
-	const chainByMemberId = buildSwapChains(transactions);
+	const chainByMemberId = buildChains(transactions);
 	if (chainByMemberId.size === 0) {
 		return([ ...transactions ]);
 	}
@@ -1626,6 +1767,55 @@ export class UserHistory {
 	}
 
 	/**
+	 * Enrich a single transaction on demand by resolving the anchor transfers
+	 * for only its contributing blocks.
+	 */
+	async enrichTransaction(transaction: LogicalTransaction, account: HistoryAccount, options?: UserHistoryListOptions): Promise<LogicalTransaction> {
+		const source = this.#history;
+		if (typeof source.getVoteStaple !== 'function') {
+			return(transaction);
+		}
+
+		const perspective = perspectiveOf(account);
+		const resolved = this.#withDefaultDecryptionKeys(account, { ...options, enrich: true });
+		const externalCache = new Map<string, ResolvedTransfer | undefined>();
+		const readerCache = new Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>();
+
+		const logical: LogicalTransaction[] = [];
+		const visited = new Set<string>();
+		for (const blockHash of transaction.refs.blockHashes) {
+			if (visited.has(blockHash)) {
+				continue;
+			}
+
+			visited.add(blockHash);
+			const staple = await source.getVoteStaple(blockHash);
+			if (staple === null || staple === undefined) {
+				continue;
+			}
+
+			for (const candidate of await this.#foldStaple(staple, perspective, resolved, externalCache, readerCache)) {
+				logical.push(candidate);
+			}
+		}
+
+		const blockHashes = new Set(transaction.refs.blockHashes);
+		const folded = foldChains(logical);
+		const matchByID = folded.find(function(candidate) {
+			return(candidate.id === transaction.id);
+		});
+		if (matchByID !== undefined) {
+			return(matchByID);
+		}
+
+		const matchByBlock = folded.find(function(candidate) {
+			return(candidate.refs.blockHashes.some(hash => blockHashes.has(hash)));
+		});
+
+		return(matchByBlock ?? transaction);
+	}
+
+	/**
 	 * Stream logical transactions newest-first, paging through history one page
 	 * at a time instead of buffering the full result set. Walks every page until
 	 * history is exhausted, or until {@link UserHistoryListOptions.limit} logical
@@ -1748,18 +1938,17 @@ export class UserHistory {
 	}
 
 	/**
-	 * Fold a swap or bridge that declares on-chain inputs into the full
-	 * conversion it caps, resolving every linked predecessor swap by hash and
-	 * marking each hop `consumed` so it is skipped when it later pages in.
-	 * Returns the input transaction unchanged when it is not the tail of a
-	 * linked chain.
+	 * Fold a tail that declares on-chain inputs into the full conversion it
+	 * caps, resolving every linked predecessor by hash and marking each hop
+	 * `consumed` so it is skipped when it later pages in.
 	 */
 	async #foldForward(transaction: LogicalTransaction, consumed: Set<string>, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction> {
-		if ((transaction.type !== 'swap' && transaction.type !== 'bridge') || transaction.refs.inputs === undefined || transaction.refs.inputs.length === 0) {
+		const foldable = transaction.type === 'swap' || transaction.type === 'bridge' || transaction.type === 'receive';
+		if (!foldable || transaction.refs.inputs === undefined || transaction.refs.inputs.length === 0) {
 			return(transaction);
 		}
 
-		const hops = await this.#resolveSwapChainBackward(transaction, perspective, options, externalCache, readerCache);
+		const hops = await this.#resolveChainBackward(transaction, perspective, options, externalCache, readerCache);
 		const head = hops.at(0);
 		const tail = hops.at(-1);
 		if (hops.length < 2 || head === undefined || tail === undefined) {
@@ -1779,11 +1968,11 @@ export class UserHistory {
 	}
 
 	/**
-	 * Walk a swap chain backward from its tail, following each hop's on-chain
-	 * input to the predecessor swap it references, until the head (a swap with
-	 * no resolvable input) is reached. Returns the hops oldest-first.
+	 * Walk a chain backward from its tail, following each hop's on-chain input
+	 * to the predecessor it references, until the head (a hop with no
+	 * resolvable input) is reached. Returns the hops oldest-first.
 	 */
-	async #resolveSwapChainBackward(tail: LogicalTransaction, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction[]> {
+	async #resolveChainBackward(tail: LogicalTransaction, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction[]> {
 		const hops: LogicalTransaction[] = [ tail ];
 		const seenIds = new Set<string>([ tail.id ]);
 		const triedHashes = new Set<string>();
@@ -1803,8 +1992,8 @@ export class UserHistory {
 	}
 
 	/**
-	 * Resolve the first not-yet-tried input of `current` to the predecessor
-	 * swap it references, or `undefined` when none resolve to a new swap.
+	 * Resolve the first not-yet-tried input of `current` to the predecessor it
+	 * references, or `undefined` when none resolve to a new, linkable hop.
 	 */
 	async #walkToPredecessor(current: LogicalTransaction, triedHashes: Set<string>, seenIds: Set<string>, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction | undefined> {
 		for (const input of current.refs.inputs ?? []) {
@@ -1814,7 +2003,7 @@ export class UserHistory {
 
 			triedHashes.add(input.blockHash);
 
-			const predecessor = await this.#resolvePredecessorSwap(input.blockHash, perspective, options, externalCache, readerCache);
+			const predecessor = await this.#resolveContributing(input.blockHash, current, perspective, options, externalCache, readerCache);
 			if (predecessor !== undefined && !seenIds.has(predecessor.id)) {
 				return(predecessor);
 			}
@@ -1824,10 +2013,11 @@ export class UserHistory {
 	}
 
 	/**
-	 * Fetch the staple settling `blockHash` and return the swap logical
-	 * transaction it contributes to, or `undefined` when it cannot be resolved.
+	 * Fetch the staple settling `blockHash` and return the logical transaction
+	 * it contributes that may fold into `successor` (per {@link canLink}), or
+	 * `undefined` when none can be resolved.
 	 */
-	async #resolvePredecessorSwap(blockHash: string, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction | undefined> {
+	async #resolveContributing(blockHash: string, successor: LogicalTransaction, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<LogicalTransaction | undefined> {
 		const source = this.#history;
 		if (typeof source.getVoteStaple !== 'function') {
 			return(undefined);
@@ -1839,7 +2029,7 @@ export class UserHistory {
 		}
 
 		const logical = foldChains(await this.#foldStaple(staple, perspective, options, externalCache, readerCache));
-		return(logical.find(transaction => transaction.type === 'swap' && transaction.refs.blockHashes.includes(blockHash)));
+		return(logical.find(transaction => transaction.refs.blockHashes.includes(blockHash) && canLink(transaction, successor)));
 	}
 
 	/**
@@ -1867,7 +2057,7 @@ export class UserHistory {
 	async #enrichBlock(block: Block, timestamp: string, perspective: string | undefined, options: UserHistoryListOptions | undefined, externalCache: Map<string, ResolvedTransfer | undefined>, readerCache: Map<string, AnchorTransferReader<KeetaAssetMovementTransaction> | null>): Promise<EnrichedBlock> {
 		const blockHash = block.hash.toString();
 		const account = block.account.publicKeyString.get();
-		const enrichEnabled = options?.enrich !== false && this.#status !== undefined;
+		const enrichEnabled = options?.enrich === true && this.#status !== undefined;
 
 		/*
 		 * A single anchor transfer (an FX swap, say) can be settled by several

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,6 +24,7 @@ export {
 	foldChains
 } from './history.js';
 export type {
+	DeclaredAnchorRef,
 	EnrichedBlock,
 	EnrichedOperation,
 	HistoryEntry,


### PR DESCRIPTION
## Summary

Fixes an issue where atomic swaps do not fold. Additionally, support enriching individual transactions and default enrichment to `false` on `list`.