### PR TITLE
release 0.0.85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.84",
+	"version": "0.0.85",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.84",
+			"version": "0.0.85",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.84",
+	"version": "0.0.85",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
Includes changes from:
 - #394

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only manifest version fields change with no runtime or dependency updates in the diff.
> 
> **Overview**
> Bumps **`@keetanetwork/anchor`** from **0.0.84** to **0.0.85** in `package.json` and the root entry in `package-lock.json`. No dependency or source changes appear in this diff; it is a version-only release cut (PR description notes inclusion of **#394** elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78305e39f3d19a09c8290036a0e28fb85aaaa127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->