### PR TITLE
Release 0.0.86

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.85",
+	"version": "0.0.86",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.85",
+			"version": "0.0.86",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.85",
+	"version": "0.0.86",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
Includes changes from:
 - #396 
 - #387 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime or dependency updates in the diff.
> 
> **Overview**
> **Release 0.0.86** — bumps `@keetanetwork/anchor` from **0.0.85** to **0.0.86** in `package.json` and the root entry in `package-lock.json`.
> 
> No dependency, script, or source changes appear in this diff. The PR description notes this release bundles work from **#396** and **#387**; those changes are not shown here—only the version identifiers are updated for publish/tagging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8162aab6010c1e64edfa183c4b96dad91ac2e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->