### PR TITLE
Feature: Add Queue Multiplexing Scheduler

### DIFF
--- a/.cspell.config.mjs
+++ b/.cspell.config.mjs
@@ -152,7 +152,8 @@ export default {
 			filename: 'src/lib/queue/**/*.ts',
 			words: [
 				'dequeue',
-				'enqueue'
+				'enqueue',
+				'zset'
 			]
 		},
 		{

--- a/.cspell.config.mjs
+++ b/.cspell.config.mjs
@@ -89,6 +89,7 @@ export default {
 		'Retryable',
 		'retval',
 		'satoshis',
+		'schedulable',
 		'secp',
 		'SEPA',
 		'singleworker',

--- a/src/lib/queue/drivers/queue_firestore.ts
+++ b/src/lib/queue/drivers/queue_firestore.ts
@@ -13,7 +13,9 @@ import type {
 import {
 	MethodLogger,
 	ManageStatusUpdates,
-	ConvertStringToRequestID
+	ConvertStringToRequestID,
+	EncodeQueuePath,
+	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
 
@@ -52,7 +54,7 @@ export default class KeetaAnchorQueueStorageDriverFirestore<QueueRequest extends
 		this.logger = options?.logger;
 		this.firestoreInternal = options.firestore;
 		this.path = options.path ?? [];
-		this.pathStr = ['root', ...this.path].join('.');
+		this.pathStr = EncodeQueuePath(this.path);
 		this.namespace = options.namespace;
 		Object.freeze(this.path);
 
@@ -326,6 +328,8 @@ export default class KeetaAnchorQueueStorageDriverFirestore<QueueRequest extends
 	}
 
 	async partition(path: string): Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {
+		ValidateQueuePartitionSegment(path);
+
 		this.methodLogger('partition')?.debug(`Creating partitioned queue storage driver for path: ${path}`);
 
 		if (this.firestoreInternal === null) {

--- a/src/lib/queue/drivers/queue_postgres.ts
+++ b/src/lib/queue/drivers/queue_postgres.ts
@@ -10,12 +10,17 @@ import type {
 	KeetaAnchorQueueEntryAncillaryData,
 	KeetaAnchorQueueStatus,
 	KeetaAnchorQueueFilter,
+	KeetaAnchorQueueScanFilter,
 	KeetaAnchorQueueWorkerID
 } from '../index.ts';
 import {
 	MethodLogger,
 	ManageStatusUpdates,
-	ConvertStringToRequestID
+	ConvertStringToRequestID,
+	DecodeQueuePathRelative,
+	EncodeQueuePath,
+	QUEUE_PATH_SEPARATOR,
+	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
 
@@ -25,6 +30,13 @@ import type { Logger } from '../../log/index.ts';
 import type { JSONSerializable } from '../../utils/json.js';
 
 import type * as pg from 'pg';
+
+/**
+ * Characters with special meaning inside a SQL LIKE pattern (PostgreSQL 17
+ * docs section 9.7.1): `%` and `_` are wildcards and `\` is the default
+ * escape character.
+ */
+const LIKE_META_CHARACTER_PATTERN = /[\\%_]/g;
 
 type QueueEntryRow = {
 	id: string;
@@ -79,7 +91,8 @@ export default class KeetaAnchorQueueStorageDriverPostgres<QueueRequest extends 
 		this.tablePrefix = options?.tablePrefix;
 		this.poolInternal = options.pool;
 		this.path = options.path ?? [];
-		this.pathStr = ['root', ...this.path].join('.');
+		this.pathStr = EncodeQueuePath(this.path);
+
 		Object.freeze(this.path);
 
 		this.tableNameEntries = `${this.tablePrefix ?? 'queue'}_entries`;
@@ -201,6 +214,29 @@ export default class KeetaAnchorQueueStorageDriverPostgres<QueueRequest extends 
 							await client.query(`INSERT INTO ${this.tableNameSchemaVersion} (version, applied_at) VALUES (2, $1)`, [Date.now()]);
 							await client.query('COMMIT');
 							logger?.debug('Applied schema version 2');
+						} catch (error) {
+							await client.query('ROLLBACK');
+							throw(error);
+						}
+					}
+
+					/*
+					 * Version 3: status-leading composite index.
+					 *
+					 * scanActivePaths filters on status across all paths, so
+					 * the path-leading version-2 indexes cannot serve it as a
+					 * range scan.
+					 */
+					if (currentVersion < 3) {
+						logger?.debug('Applying schema version 3: Status-leading composite index');
+
+						await client.query('BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED');
+						try {
+							await client.query(`CREATE INDEX IF NOT EXISTS idx_${this.tableNameEntries}_status_path ON ${this.tableNameEntries}(status, path)`);
+
+							await client.query(`INSERT INTO ${this.tableNameSchemaVersion} (version, applied_at) VALUES (3, $1)`, [Date.now()]);
+							await client.query('COMMIT');
+							logger?.debug('Applied schema version 3');
 						} catch (error) {
 							await client.query('ROLLBACK');
 							throw(error);
@@ -589,7 +625,41 @@ export default class KeetaAnchorQueueStorageDriverPostgres<QueueRequest extends 
 		}));
 	}
 
+	async scanActivePaths(statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<string[][]> {
+		if (statuses.length === 0) {
+			return([]);
+		}
+
+		return(await this.dbTransaction('scanActivePaths', async (client, logger) => {
+			logger?.debug('Scanning for active partition paths under', this.pathStr, 'with statuses', statuses, 'and filter', filter);
+
+			const escapedPrefix = this.pathStr.replace(LIKE_META_CHARACTER_PATTERN, '\\$&');
+			const prefixLike = `${escapedPrefix}${QUEUE_PATH_SEPARATOR}%`;
+
+			const conditions = ['status = ANY($1::text[])', '(path = $2 OR path LIKE $3)'];
+			const params: (KeetaAnchorQueueStatus[] | string | number)[] = [statuses, this.pathStr, prefixLike];
+			let paramIndex = params.length + 1;
+			if (filter?.updatedBefore) {
+				conditions.push(`updated < $${paramIndex++}`);
+				params.push(filter.updatedBefore.getTime());
+			}
+			if (filter?.updatedAfter) {
+				conditions.push(`updated >= $${paramIndex++}`);
+				params.push(filter.updatedAfter.getTime());
+			}
+
+			const rows = await client.query<{ path: string }>(`
+				SELECT DISTINCT path FROM ${this.tableNameEntries}
+				WHERE ${conditions.join(' AND ')}`, params);
+
+			return(rows.rows.map((row) => {
+				return(DecodeQueuePathRelative(row.path, this.path));
+			}));
+		}));
+	}
+
 	async partition(path: string) : Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {
+		ValidateQueuePartitionSegment(path);
 		this.methodLogger('partition')?.debug(`Creating partitioned queue storage driver for path: ${path}`);
 
 		if (this.poolInternal === null) {

--- a/src/lib/queue/drivers/queue_redis.ts
+++ b/src/lib/queue/drivers/queue_redis.ts
@@ -13,7 +13,9 @@ import type {
 import {
 	MethodLogger,
 	ManageStatusUpdates,
-	ConvertStringToRequestID
+	ConvertStringToRequestID,
+	EncodeQueuePath,
+	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
 
@@ -51,7 +53,7 @@ export default class KeetaAnchorQueueStorageDriverRedis<QueueRequest extends JSO
 		this.logger = options?.logger
 		this.redisInternal = options.redis;
 		this.path = options.path ?? [];
-		this.pathStr = ['root', ...this.path].join('.');
+		this.pathStr = EncodeQueuePath(this.path);
 		Object.freeze(this.path);
 
 		this.methodLogger('new')?.debug('Initialized Redis queue storage driver');
@@ -413,6 +415,8 @@ export default class KeetaAnchorQueueStorageDriverRedis<QueueRequest extends JSO
 	}
 
 	async partition(path: string): Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {
+		ValidateQueuePartitionSegment(path);
+
 		this.methodLogger('partition')?.debug(`Creating partitioned queue storage driver for path: ${path}`);
 
 		if (this.redisInternal === null) {

--- a/src/lib/queue/drivers/queue_redis.ts
+++ b/src/lib/queue/drivers/queue_redis.ts
@@ -8,13 +8,16 @@ import type {
 	KeetaAnchorQueueEntryAncillaryData,
 	KeetaAnchorQueueStatus,
 	KeetaAnchorQueueFilter,
+	KeetaAnchorQueueScanFilter,
 	KeetaAnchorQueueWorkerID
 } from '../index.ts';
 import {
 	MethodLogger,
 	ManageStatusUpdates,
 	ConvertStringToRequestID,
+	DecodeQueuePathRelative,
 	EncodeQueuePath,
+	QUEUE_PATH_SEPARATOR,
 	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
@@ -24,6 +27,12 @@ import type { JSONSerializable } from '../../utils/json.js';
 import { asleep } from '../../utils/asleep.js';
 
 import type { RedisClientType } from 'redis';
+
+/**
+ * The characters with special meaning in a Redis SCAN MATCH glob pattern,
+ * escaped so partition path characters are always matched literally
+ */
+const GLOB_META_CHARACTER_PATTERN = /[\\*?[\]]/g;
 
 type QueueEntryData = {
 	id: string;
@@ -412,6 +421,77 @@ export default class KeetaAnchorQueueStorageDriverRedis<QueueRequest extends JSO
 		logger?.debug(`Queried queue with id ${this.id} with filter:`, filter, '-- found', entries.length, 'entries');
 
 		return(entries);
+	}
+
+	async scanActivePaths(statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<string[][]> {
+		if (statuses.length === 0) {
+			return([]);
+		}
+
+		const redis = await this.getRedis();
+		const logger = this.methodLogger('scanActivePaths');
+
+		logger?.debug('Scanning for active partition paths under', this.pathStr, 'with statuses', statuses, 'and filter', filter);
+
+		/*
+		 * The per-(path, status) sorted-set indexes carry the entry's
+		 * `updated` time as the score, so the time filter maps directly to
+		 * a ZCOUNT score range ('(' marks the exclusive upper bound)
+		 */
+		let minScore = '-inf';
+		if (filter?.updatedAfter) {
+			minScore = String(filter.updatedAfter.getTime());
+		}
+
+		let maxScore = '+inf';
+		if (filter?.updatedBefore) {
+			maxScore = `(${filter.updatedBefore.getTime()}`;
+		}
+
+		const activeEncodedPaths = new Set<string>();
+
+		/* This driver's own partition: probe its index keys directly */
+		for (const status of statuses) {
+			const selfCount = await redis.zCount(this.indexKey(status), minScore, maxScore);
+			if (selfCount > 0) {
+				activeEncodedPaths.add(this.pathStr);
+				break;
+			}
+		}
+
+		/*
+		 * Descendant partitions: their index keys are the only sorted sets
+		 * under the key prefix ending in `:index:<status>`, and Redis
+		 * removes empty sorted sets, so every surviving key is a candidate
+		 */
+		const escapedPrefix = `queue:${this.pathStr}${QUEUE_PATH_SEPARATOR}`.replace(GLOB_META_CHARACTER_PATTERN, '\\$&');
+		for await (const key of redis.scanIterator({ MATCH: `${escapedPrefix}*`, COUNT: 100, TYPE: 'zset' })) {
+			for (const status of statuses) {
+				const indexSuffix = `:index:${status}`;
+				if (!key.endsWith(indexSuffix)) {
+					continue;
+				}
+
+				const encodedPath = key.slice('queue:'.length, key.length - indexSuffix.length);
+				if (activeEncodedPaths.has(encodedPath)) {
+					break;
+				}
+
+				const count = await redis.zCount(key, minScore, maxScore);
+				if (count > 0) {
+					activeEncodedPaths.add(encodedPath);
+				}
+
+				break;
+			}
+		}
+
+		const active: string[][] = [];
+		for (const encodedPath of activeEncodedPaths) {
+			active.push(DecodeQueuePathRelative(encodedPath, this.path));
+		}
+
+		return(active);
 	}
 
 	async partition(path: string): Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {

--- a/src/lib/queue/drivers/queue_sqlite3.ts
+++ b/src/lib/queue/drivers/queue_sqlite3.ts
@@ -13,7 +13,9 @@ import type {
 import {
 	MethodLogger,
 	ManageStatusUpdates,
-	ConvertStringToRequestID
+	ConvertStringToRequestID,
+	EncodeQueuePath,
+	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
 
@@ -56,7 +58,7 @@ export default class KeetaAnchorQueueStorageDriverSQLite3<QueueRequest extends J
 		this.logger = options?.logger;
 		this.dbInternal = options.db;
 		this.path = options.path ?? [];
-		this.pathStr = ['root', ...this.path].join('.');
+		this.pathStr = EncodeQueuePath(this.path);
 		Object.freeze(this.path);
 
 		this.methodLogger('new')?.debug('Initialized SQLite3 queue storage driver with DB:', options.db);
@@ -467,6 +469,8 @@ export default class KeetaAnchorQueueStorageDriverSQLite3<QueueRequest extends J
 	}
 
 	async partition(path: string) : Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {
+		ValidateQueuePartitionSegment(path);
+
 		this.methodLogger('partition')?.debug(`Creating partitioned queue storage driver for path: ${path}`);
 
 		if (this.dbInternal === null) {

--- a/src/lib/queue/drivers/queue_sqlite3.ts
+++ b/src/lib/queue/drivers/queue_sqlite3.ts
@@ -8,13 +8,16 @@ import type {
 	KeetaAnchorQueueEntryAncillaryData,
 	KeetaAnchorQueueStatus,
 	KeetaAnchorQueueFilter,
+	KeetaAnchorQueueScanFilter,
 	KeetaAnchorQueueWorkerID
 } from '../index.ts';
 import {
 	MethodLogger,
 	ManageStatusUpdates,
 	ConvertStringToRequestID,
+	DecodeQueuePathRelative,
 	EncodeQueuePath,
+	QUEUE_PATH_SEPARATOR,
 	ValidateQueuePartitionSegment
 } from '../internal.js';
 import { Errors } from '../common.js';
@@ -106,6 +109,7 @@ export default class KeetaAnchorQueueStorageDriverSQLite3<QueueRequest extends J
 
 				CREATE INDEX IF NOT EXISTS idx_queue_entries_status ON queue_entries(status);
 				CREATE INDEX IF NOT EXISTS idx_queue_entries_updated ON queue_entries(updated);
+				CREATE INDEX IF NOT EXISTS idx_queue_entries_status_path ON queue_entries(status, path);
 				CREATE INDEX IF NOT EXISTS idx_queue_idempotent_keys_idempotent_id ON queue_idempotent_keys(idempotent_id);
 			`);
 
@@ -465,6 +469,49 @@ export default class KeetaAnchorQueueStorageDriverSQLite3<QueueRequest extends J
 			logger?.debug(`Queried queue with id ${this.id} with filter:`, filter, '-- found', entries.length, 'entries');
 
 			return(entries);
+		}));
+	}
+
+	async scanActivePaths(statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<string[][]> {
+		if (statuses.length === 0) {
+			return([]);
+		}
+
+		return(await this.dbTransaction('scanActivePaths', async (db, logger) => {
+			logger?.debug('Scanning for active partition paths under', this.pathStr, 'with statuses', statuses, 'and filter', filter);
+
+			/*
+			 * substr() prefix matching instead of LIKE: SQLite's LIKE is
+			 * ASCII case-insensitive and would need wildcard escaping
+			 */
+			const prefix = `${this.pathStr}${QUEUE_PATH_SEPARATOR}`;
+			const statusPlaceholders = statuses.map(function() {
+				return('?');
+			}).join(', ');
+
+			const conditions = [
+				`status IN (${statusPlaceholders})`,
+				'(path = ? OR substr(path, 1, ?) = ?)'
+			];
+
+			const params: (string | number)[] = [...statuses, this.pathStr, prefix.length, prefix];
+			if (filter?.updatedBefore) {
+				conditions.push('updated < ?');
+				params.push(filter.updatedBefore.getTime());
+			}
+			if (filter?.updatedAfter) {
+				conditions.push('updated >= ?');
+				params.push(filter.updatedAfter.getTime());
+			}
+
+			const rows = await db.all<{ path: string }[]>(
+				`SELECT DISTINCT path FROM queue_entries WHERE ${conditions.join(' AND ')}`,
+				...params
+			);
+
+			return(rows.map((row) => {
+				return(DecodeQueuePathRelative(row.path, this.path));
+			}));
 		}));
 	}
 

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -2465,6 +2465,65 @@ test('Failed pipe moves refresh the entry timestamp for sweep retry', async func
 	}
 
 	/*
+	 * A batch rejected by an idempotent conflict: the conflicting member is
+	 * marked moved, while the members the rejection left behind keep their
+	 * status but get a fresh `updated` timestamp.
+	 */
+	{
+		await using sourceQueue = await root.partition('conflict-source');
+		await using targetQueue = await root.partition('conflict-target');
+
+		await using targetRunner = new KeetaAnchorQueueRunnerJSONConfigProc<string[], null>({
+			id: 'move-refresh-conflict-target',
+			queue: targetQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: null });
+			}
+		});
+		await using sourceRunner = new KeetaAnchorQueueRunnerJSONConfigProc<JSONSerializable, string>({
+			id: 'move-refresh-conflict-source',
+			queue: sourceQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: 'out' });
+			}
+		});
+
+		/*
+		 * Minimum batch size 2: after the conflict removes one member, the
+		 * remainder can no longer form a batch and stays behind
+		 */
+		sourceRunner.pipeBatch(targetRunner, 10, 2);
+
+		const conflictID = await sourceRunner.add({ key: 'conflict' });
+		const strandedID = await sourceRunner.add({ key: 'stranded' });
+		await sourceRunner.run();
+
+		const stranded = await sourceRunner.get(strandedID);
+		expect(stranded?.status, 'both source entries complete before any move attempt').toBe('completed');
+
+		const updatedAtCompletion = stranded?.updated.getTime();
+
+		/*
+		 * Pre-seed the target with one member's idempotent key so the batch
+		 * add is rejected with an idempotent conflict
+		 */
+		await targetQueue.add(['seed'], { idempotentKeys: new Set([conflictID]) });
+
+		vi.advanceTimersByTime(5000);
+		await sourceRunner.maintain();
+
+		const conflicted = await sourceRunner.get(conflictID);
+		expect(conflicted?.status, 'the conflicting member is marked moved').toBe('moved');
+
+		const strandedAfter = await sourceRunner.get(strandedID);
+		expect(strandedAfter?.status, 'the left-behind member keeps its status').toBe('completed');
+		expect(strandedAfter?.failures, 'the left-behind member keeps its failure count').toBe(stranded?.failures);
+		expect(strandedAfter?.updated.getTime() ?? 0, 'the left-behind member timestamp is refreshed for sweep retry').toBeGreaterThan(updatedAtCompletion ?? Number.POSITIVE_INFINITY);
+	}
+
+	/*
 	 * A working pipe: the successful move still marks the entry as moved
 	 */
 	{

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -163,7 +163,7 @@ const drivers: {
 	},
 	'SQLite3': {
 		persistent: true,
-		scanActivePaths: false,
+		scanActivePaths: true,
 		skip: false,
 		create: async function(key: string, options = { leave: false }) {
 			const filePath = path.join(os.tmpdir(), `anchor-queue-tests-${RunKey}-${key}.sqlite3.db`);
@@ -198,7 +198,7 @@ const drivers: {
 	},
 	'Redis': {
 		persistent: true,
-		scanActivePaths: false,
+		scanActivePaths: true,
 		skip: async function() {
 			return(getTestingRedisConfig() === null);
 		},

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -112,6 +112,7 @@ function getTestingFirestoreConfig(): { host: string; port: number; } | null {
 const drivers: {
 	[driverName: string]: {
 		persistent: boolean;
+		scanActivePaths: boolean;
 		skip: boolean | (() => Promise<boolean>);
 		create: (key: string, options?: { leave?: boolean; randomBackingName?: boolean; }) => Promise<{
 			queue: KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>;
@@ -121,6 +122,7 @@ const drivers: {
 } = {
 	'Memory': {
 		persistent: false,
+		scanActivePaths: true,
 		skip: false,
 		create: async function(key: string) {
 			const queue = new KeetaAnchorQueueStorageDriverMemory({ id: key, logger: logger });
@@ -134,6 +136,7 @@ const drivers: {
 	},
 	'File': {
 		persistent: true,
+		scanActivePaths: true,
 		skip: false,
 		create: async function(key: string, options = { leave: false }) {
 			const filePath = path.join(os.tmpdir(), `anchor-queue-tests-${RunKey}-${key}.file.json`);
@@ -160,6 +163,7 @@ const drivers: {
 	},
 	'SQLite3': {
 		persistent: true,
+		scanActivePaths: false,
 		skip: false,
 		create: async function(key: string, options = { leave: false }) {
 			const filePath = path.join(os.tmpdir(), `anchor-queue-tests-${RunKey}-${key}.sqlite3.db`);
@@ -194,6 +198,7 @@ const drivers: {
 	},
 	'Redis': {
 		persistent: true,
+		scanActivePaths: false,
 		skip: async function() {
 			return(getTestingRedisConfig() === null);
 		},
@@ -248,6 +253,7 @@ const drivers: {
 	},
 	'PostgreSQL': {
 		persistent: true,
+		scanActivePaths: true,
 		skip: async function() {
 			return(getTestingPostgresConfig() === null);
 		},
@@ -351,6 +357,7 @@ const drivers: {
 	},
 	'Firestore': {
 		persistent: true,
+		scanActivePaths: false,
 		skip: async function() {
 			return(getTestingFirestoreConfig() === null);
 		},
@@ -1876,7 +1883,132 @@ suite.sequential('Driver Tests', async function() {
 						expect(entry1_partition?.request).toEqual({ key: 'partition_test_1_again' });
 					}
 				});
+
+				/* Test that partition segments containing the path separator are rejected */
+				testRunner('Partition Segment Validation', async function() {
+					await expect(queue.partition('invalid.segment')).rejects.toThrow('may not contain');
+
+					await using validPartition = await queue.partition('valid-segment');
+					await expect(validPartition.partition('nested.invalid')).rejects.toThrow('may not contain');
+				});
 			});
+
+			if (driverConfig.scanActivePaths) {
+				suite('Scan Active Paths', function(): void {
+					/**
+					 * Get the driver's scanActivePaths method, which the
+					 * driver config asserts is implemented
+					 */
+					function getScan(scanQueue: KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>): NonNullable<KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>['scanActivePaths']> {
+						const scan = scanQueue.scanActivePaths?.bind(scanQueue);
+						if (scan === undefined) {
+							throw(new Error(`internal error: driver '${driver}' is expected to implement scanActivePaths`));
+						}
+						return(scan);
+					}
+
+					/**
+					 * Sort relative paths into a deterministic order for comparison
+					 */
+					function sortPaths(paths: string[][]): string[][] {
+						return([...paths].sort(function(a, b) {
+							return(a.join('\u0000').localeCompare(b.join('\u0000')));
+						}));
+					}
+
+					testRunner('Active Partitions Only', async function() {
+						await using driverInstance = await driverConfig.create('scan_active');
+						const localQueue = driverInstance.queue;
+						const scan = getScan(localQueue);
+
+						await using stageA = await localQueue.partition('saga-one:deposit');
+						await using stageB = await localQueue.partition('saga-one:withdraw');
+						await using stageC = await localQueue.partition('saga-two:deposit');
+						await using nested = await stageA.partition('inner');
+
+						await localQueue.add({ v: 0 });
+						await stageA.add({ v: 1 });
+						await stageB.add({ v: 2 }, { status: 'failed_temporarily' });
+						await stageC.add({ v: 3 }, { status: 'completed' });
+						await nested.add({ v: 4 });
+
+						const active = await scan(['pending', 'failed_temporarily', 'stuck', 'aborted']);
+						expect(sortPaths(active), 'active paths are relative and exclude quiescent partitions').toEqual(sortPaths([
+							[],
+							['saga-one:deposit'],
+							['saga-one:deposit', 'inner'],
+							['saga-one:withdraw']
+						]));
+
+						/* A partitioned driver reports only its own subtree, relative to itself */
+						const scanFromStageA = getScan(stageA);
+						const scopedToStageA = await scanFromStageA(['pending']);
+						expect(sortPaths(scopedToStageA), 'a partitioned driver reports its own subtree relative to itself').toEqual(sortPaths([
+							[],
+							['inner']
+						]));
+
+						/* An empty status list matches nothing */
+						const noStatuses = await scan([]);
+						expect(noStatuses, 'an empty status list matches nothing').toEqual([]);
+					});
+
+					testRunner('Prefix Wildcard Escaping', async function() {
+						await using driverInstance = await driverConfig.create('scan_meta');
+						const localQueue = driverInstance.queue;
+
+						await using underscoreName = await localQueue.partition('p_a');
+						await using underscoreDecoy = await localQueue.partition('pxa');
+						await using percentName = await localQueue.partition('q%');
+						await using percentDecoy = await localQueue.partition('qqq');
+
+						await using underscoreChild = await underscoreName.partition('child');
+						await using underscoreDecoyChild = await underscoreDecoy.partition('child');
+						await using percentChild = await percentName.partition('child');
+						await using percentDecoyChild = await percentDecoy.partition('child');
+
+						await underscoreChild.add({ v: 1 });
+						await underscoreDecoyChild.add({ v: 2 });
+						await percentChild.add({ v: 3 });
+						await percentDecoyChild.add({ v: 4 });
+
+						const underscoreScan = getScan(underscoreName);
+						const underscoreActive = await underscoreScan(['pending']);
+						expect(underscoreActive, 'a "_" in the prefix does not match other partitions').toEqual([['child']]);
+
+						const percentScan = getScan(percentName);
+						const percentActive = await percentScan(['pending']);
+						expect(percentActive, 'a "%" in the prefix does not match other partitions').toEqual([['child']]);
+					});
+
+					testRunner('Time Filters', async function() {
+						await using driverInstance = await driverConfig.create('scan_time');
+						const localQueue = driverInstance.queue;
+						const scan = getScan(localQueue);
+
+						await using partition = await localQueue.partition('part');
+						await partition.add({ v: 1 });
+
+						const future = new Date(Date.now() + 100_000);
+						const past = new Date(Date.now() - 100_000);
+
+						const beforeFuture = await scan(['pending'], { updatedBefore: future });
+						expect(beforeFuture, 'updatedBefore in the future includes a fresh entry').toEqual([['part']]);
+
+						const beforePast = await scan(['pending'], { updatedBefore: past });
+						expect(beforePast, 'updatedBefore in the past excludes a fresh entry').toEqual([]);
+
+						const afterPast = await scan(['pending'], { updatedAfter: past });
+						expect(afterPast, 'updatedAfter in the past includes a fresh entry').toEqual([['part']]);
+
+						const afterFuture = await scan(['pending'], { updatedAfter: future });
+						expect(afterFuture, 'updatedAfter in the future excludes a fresh entry').toEqual([]);
+
+						const bothBounds = await scan(['pending'], { updatedAfter: past, updatedBefore: future });
+						expect(bothBounds, 'an entry inside both bounds is included').toEqual([['part']]);
+					});
+				});
+			}
 
 			if (driverConfig.persistent) {
 				testRunner('Persistence Tests', async function() {
@@ -2230,5 +2362,142 @@ suite.sequential('Driver Tests', async function() {
 				}
 			}
 		});
+	}
+});
+
+test('Failed pipe moves refresh the entry timestamp for sweep retry', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	vi.useFakeTimers();
+	cleanup.defer(function() {
+		vi.useRealTimers();
+	});
+
+	await using root = new KeetaAnchorQueueStorageDriverMemory({ id: 'move-refresh', logger: logger });
+
+	/*
+	 * A single pipe whose target is destroyed: the move fails, so the entry
+	 * must keep its status and failure count but get a fresh `updated`
+	 * timestamp so a time-bounded sweep keeps retrying it
+	 */
+	{
+		await using sourceQueue = await root.partition('single-source');
+		const targetQueue = await root.partition('single-target');
+
+		await using targetRunner = new KeetaAnchorQueueRunnerJSONConfigProc<string, null>({
+			id: 'move-refresh-single-target',
+			queue: targetQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: null });
+			}
+		});
+		await using sourceRunner = new KeetaAnchorQueueRunnerJSONConfigProc<JSONSerializable, string>({
+			id: 'move-refresh-single-source',
+			queue: sourceQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: 'out' });
+			}
+		});
+
+		sourceRunner.pipe(targetRunner);
+
+		const id = await sourceRunner.add({ key: 'single' });
+		await sourceRunner.run();
+
+		const completed = await sourceRunner.get(id);
+		expect(completed?.status, 'the source entry completes before any move attempt').toBe('completed');
+
+		const updatedAtCompletion = completed?.updated.getTime();
+
+		await targetQueue.destroy();
+		vi.advanceTimersByTime(5000);
+		await sourceRunner.maintain();
+
+		const afterFailedMove = await sourceRunner.get(id);
+		expect(afterFailedMove?.status, 'a failed move leaves the status unchanged').toBe('completed');
+		expect(afterFailedMove?.failures, 'a failed move leaves the failure count unchanged').toBe(completed?.failures);
+		expect(afterFailedMove?.updated.getTime() ?? 0, 'a failed move refreshes the updated timestamp').toBeGreaterThan(updatedAtCompletion ?? Number.POSITIVE_INFINITY);
+	}
+
+	/*
+	 * A batch pipe whose target is destroyed: same refresh contract
+	 */
+	{
+		await using sourceQueue = await root.partition('batch-source');
+		const targetQueue = await root.partition('batch-target');
+
+		await using targetRunner = new KeetaAnchorQueueRunnerJSONConfigProc<string[], null>({
+			id: 'move-refresh-batch-target',
+			queue: targetQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: null });
+			}
+		});
+		await using sourceRunner = new KeetaAnchorQueueRunnerJSONConfigProc<JSONSerializable, string>({
+			id: 'move-refresh-batch-source',
+			queue: sourceQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: 'out' });
+			}
+		});
+		sourceRunner.pipeBatch(targetRunner, 10, 1);
+
+		const id = await sourceRunner.add({ key: 'batch' });
+		await sourceRunner.run();
+
+		const completed = await sourceRunner.get(id);
+		expect(completed?.status, 'the source entry completes before any move attempt').toBe('completed');
+
+		const updatedAtCompletion = completed?.updated.getTime();
+
+		await targetQueue.destroy();
+		vi.advanceTimersByTime(5000);
+		await sourceRunner.maintain();
+
+		const afterFailedMove = await sourceRunner.get(id);
+		expect(afterFailedMove?.status, 'a failed batch move leaves the status unchanged').toBe('completed');
+		expect(afterFailedMove?.failures, 'a failed batch move leaves the failure count unchanged').toBe(completed?.failures);
+		expect(afterFailedMove?.updated.getTime() ?? 0, 'a failed batch move refreshes the updated timestamp').toBeGreaterThan(updatedAtCompletion ?? Number.POSITIVE_INFINITY);
+	}
+
+	/*
+	 * A working pipe: the successful move still marks the entry as moved
+	 */
+	{
+		await using sourceQueue = await root.partition('working-source');
+		await using targetQueue = await root.partition('working-target');
+
+		await using targetRunner = new KeetaAnchorQueueRunnerJSONConfigProc<string, null>({
+			id: 'move-refresh-working-target',
+			queue: targetQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: null });
+			}
+		});
+		await using sourceRunner = new KeetaAnchorQueueRunnerJSONConfigProc<JSONSerializable, string>({
+			id: 'move-refresh-working-source',
+			queue: sourceQueue,
+			logger: logger,
+			processor: async function() {
+				return({ status: 'completed', output: 'out' });
+			}
+		});
+
+		sourceRunner.pipe(targetRunner);
+
+		const id = await sourceRunner.add({ key: 'working' });
+		await sourceRunner.run();
+		await sourceRunner.maintain();
+
+		const afterMove = await sourceRunner.get(id);
+		expect(afterMove?.status, 'a successful move marks the entry as moved').toBe('moved');
+
+		const movedEntry = await targetRunner.get(id);
+		expect(movedEntry, 'the moved entry arrives at the target stage').toBeDefined();
 	}
 });

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1383,6 +1383,18 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 								iterationTargetSeenRequestIDs.add(requestID);
 								allTargetSeenRequestIDs.add(requestID);
 							}
+
+							/*
+							 * The conflict rejected the whole batch, so the
+							 * non-conflicting members were not added either.
+							 */
+							for (const requestID of batchLocalIDs) {
+								if (error.idempotentIDsFound.has(requestID)) {
+									continue;
+								}
+
+								await this.refreshFailedMoveTimestamp(requestID, statusTarget);
+							}
 						} else {
 							/*
 							 * If we got some kind of other error adding these

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -9,7 +9,11 @@ import { Errors } from './common.js';
 import {
 	MethodLogger,
 	ManageStatusUpdates,
-	ConvertStringToRequestID
+	ConvertStringToRequestID,
+	DecodeQueuePathRelative,
+	EncodeQueuePath,
+	IsEncodedQueuePathWithin,
+	ValidateQueuePartitionSegment
 } from './internal.js';
 import { AsyncDisposableStack } from '../utils/defer.js';
 
@@ -51,6 +55,17 @@ export type KeetaAnchorQueueEntry<QueueRequest, QueueResult> = {
  */
 export type KeetaAnchorQueueEntryExtra = {
 	[key in 'idempotentKeys' | 'id' | 'status']?: (key extends 'id' ? KeetaAnchorQueueRequestID | string : KeetaAnchorQueueEntry<never, never>[key]) | undefined;
+};
+
+export type KeetaAnchorQueueScanFilter = {
+	/**
+	 * Only consider entries last updated before this date
+	 */
+	updatedBefore?: Date;
+	/**
+	 * Only consider entries last updated at or after this date
+	 */
+	updatedAfter?: Date;
 };
 
 export type KeetaAnchorQueueFilter = {
@@ -176,6 +191,24 @@ export interface KeetaAnchorQueueStorageDriver<QueueRequest extends JSONSerializ
 	get(id: KeetaAnchorQueueRequestID): Promise<KeetaAnchorQueueEntry<QueueRequest, QueueResult> | null>;
 
 	/**
+	 * Return the distinct partition paths at or below this driver's path that
+	 * hold at least one entry whose status is in `statuses` and, when a filter
+	 * is given, whose `updated` timestamp falls inside the filter bounds.
+	 *
+	 * This lets a multiplexing scheduler poll only the partitions with
+	 * actionable work in a single backend round-trip, instead of polling
+	 * every partition individually.
+	 *
+	 * Optional: drivers that do not implement it cannot back a multiplexing
+	 * scheduler.
+	 *
+	 * @param statuses The statuses that mark a partition as active
+	 * @param filter Optional bounds on the entries' `updated` timestamp
+	 * @returns The distinct active partition paths, relative to this driver
+	 */
+	scanActivePaths?: (statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter) => Promise<string[][]>;
+
+	/**
 	 * Perform maintenance tasks on the storage driver
 	 * (e.g. cleaning up old entries, etc)
 	 *
@@ -238,11 +271,12 @@ export class KeetaAnchorQueueStorageDriverMemory<QueueRequest extends JSONSerial
 	}
 
 	protected get queue(): KeetaAnchorQueueEntry<QueueRequest, QueueResult>[] {
-		const pathKey = ['root', ...this.path].join('.');
+		const pathKey = EncodeQueuePath(this.path);
 		let retval = this.queueStorage[pathKey];
 		if (retval === undefined) {
 			retval = this.queueStorage[pathKey] = [];
 		}
+
 		return(retval);
 	}
 
@@ -397,8 +431,49 @@ export class KeetaAnchorQueueStorageDriverMemory<QueueRequest extends JSONSerial
 		return(retval);
 	}
 
+	async scanActivePaths(statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<string[][]> {
+		this.checkDestroyed();
+
+		if (statuses.length === 0) {
+			return([]);
+		}
+
+		const wanted = new Set(statuses);
+		const updatedBefore = filter?.updatedBefore;
+		const updatedAfter = filter?.updatedAfter;
+		const active: string[][] = [];
+		for (const [ pathKey, entries ] of Object.entries(this.queueStorage)) {
+			if (!IsEncodedQueuePathWithin(pathKey, this.path)) {
+				continue;
+			}
+
+			const hasActive = entries.some(function(entry) {
+				if (!wanted.has(entry.status)) {
+					return(false);
+				}
+				if (updatedBefore && entry.updated >= updatedBefore) {
+					return(false);
+				}
+				if (updatedAfter && entry.updated < updatedAfter) {
+					return(false);
+				}
+
+				return(true);
+			});
+			if (!hasActive) {
+				continue;
+			}
+
+			active.push(DecodeQueuePathRelative(pathKey, this.path));
+		}
+
+		return(active);
+	}
+
 	async partition(path: string): Promise<KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>> {
 		this.checkDestroyed();
+
+		ValidateQueuePartitionSegment(path);
 
 		const logger = this.methodLogger('partition');
 
@@ -1148,6 +1223,20 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 		}
 	}
 
+	/**
+	 * Re-arm a pipeable entry whose move to the next stage failed by bumping
+	 * its `updated` timestamp without changing its status or failure count.
+	 */
+	private async refreshFailedMoveTimestamp(id: KeetaAnchorQueueRequestID, statusTarget: KeetaAnchorPipeableQueueStatus): Promise<void> {
+		const logger = this.methodLogger('refreshFailedMoveTimestamp');
+
+		try {
+			await this.queue.setStatus(id, statusTarget, { oldStatus: statusTarget, by: this.workerID });
+		} catch (error: unknown) {
+			logger?.debug(`Failed to refresh timestamp for ${statusTarget} request with id ${String(id)} after a failed move:`, error);
+		}
+	}
+
 	private async moveCompletedToNextStage(statusTarget: KeetaAnchorPipeableQueueStatus): Promise<void> {
 		const logger = this.methodLogger('moveCompletedToNextStage');
 
@@ -1304,6 +1393,7 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 
 							for (const requestID of batchLocalIDs) {
 								skipRequestIDs.add(requestID);
+								await this.refreshFailedMoveTimestamp(requestID, statusTarget);
 							}
 
 						}
@@ -1341,6 +1431,7 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 					} catch (error: unknown) {
 						logger?.error(`Failed to move completed request with id ${String(request.id)} to next stage:`, error);
 						shouldMarkAsMoved = false;
+						await this.refreshFailedMoveTimestamp(request.id, statusTarget);
 					}
 					if (shouldMarkAsMoved) {
 						IncrRequestSentToPipes(request.id);

--- a/src/lib/queue/internal.ts
+++ b/src/lib/queue/internal.ts
@@ -77,6 +77,63 @@ export function ManageStatusUpdates<QueueResult>(id: KeetaAnchorQueueRequestID, 
 }
 
 /**
+ * The reserved marker segment prepended to every encoded queue path so that
+ * the root partition (an empty path) still has a non-empty storage key.
+ */
+const QUEUE_PATH_ROOT_MARKER = 'root';
+
+/**
+ * The separator used to join partition path segments into a storage key.
+ * Segments must never contain it -- see {@link ValidateQueuePartitionSegment}.
+ */
+export const QUEUE_PATH_SEPARATOR = '.';
+
+/**
+ * Encode a partition path into the canonical storage key shared by every
+ * queue storage driver.
+ */
+export function EncodeQueuePath(path: readonly string[]): string {
+	const encodedPath = [QUEUE_PATH_ROOT_MARKER, ...path].join(QUEUE_PATH_SEPARATOR);
+	return(encodedPath);
+}
+
+/**
+ * Decode a canonical storage key into partition path segments relative to
+ * `basePath`. The input must be a key produced by {@link EncodeQueuePath}
+ * for a path at or below `basePath`.
+ */
+export function DecodeQueuePathRelative(encodedPath: string, basePath: readonly string[]): string[] {
+	const absoluteSegments = encodedPath.split(QUEUE_PATH_SEPARATOR).slice(1);
+	const relativeSegments = absoluteSegments.slice(basePath.length);
+	return(relativeSegments);
+}
+
+/**
+ * Check whether a canonical storage key addresses `basePath` itself or a
+ * partition below it.
+ */
+export function IsEncodedQueuePathWithin(encodedPath: string, basePath: readonly string[]): boolean {
+	const encodedBasePath = EncodeQueuePath(basePath);
+	if (encodedPath === encodedBasePath) {
+		return(true);
+	}
+
+	const within = encodedPath.startsWith(`${encodedBasePath}${QUEUE_PATH_SEPARATOR}`);
+	return(within);
+}
+
+/**
+ * Ensure a partition path segment cannot corrupt the encoded storage key.
+ *
+ * @throws {@link Error} when the segment contains the path separator
+ */
+export function ValidateQueuePartitionSegment(segment: string): void {
+	if (segment.includes(QUEUE_PATH_SEPARATOR)) {
+		throw(new Error(`Partition path segment may not contain "${QUEUE_PATH_SEPARATOR}": ${segment}`));
+	}
+}
+
+/**
  * Convert a string to a KeetaAnchorQueueRequestID (branded string type)
  *
  * Use only when appropriate, such as when receiving a request ID from an

--- a/src/lib/queue/scheduler.test.ts
+++ b/src/lib/queue/scheduler.test.ts
@@ -1,9 +1,5 @@
 import { test, expect, vi } from 'vitest';
-import * as os from 'os';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as sqlite from 'sqlite';
-import * as sqlite3 from 'sqlite3';
+import type { Firestore } from '@google-cloud/firestore';
 
 import type { JSONSerializable } from '../utils/json.ts';
 import { AsyncDisposableStack } from '../utils/defer.js';
@@ -16,7 +12,7 @@ import type {
 import type { KeetaAnchorSchedulable } from './scheduler.ts';
 import { KeetaAnchorQueueScheduler } from './scheduler.js';
 import { KeetaAnchorQueueStorageDriverMemory } from './index.js';
-import KeetaAnchorQueueStorageDriverSQLite3 from './drivers/queue_sqlite3.js';
+import KeetaAnchorQueueStorageDriverFirestore from './drivers/queue_firestore.js';
 
 /**
  * A schedulable unit driving a real storage driver: each pass drains the
@@ -649,35 +645,26 @@ test('Scheduler constructor and start validate their inputs', async function() {
 	await root.destroy();
 
 	/*
-	 * A driver without scanActivePaths cannot back the scheduler.
+	 * A driver without scanActivePaths cannot back the scheduler. The
+	 * Firestore driver's connection factory is lazy, so start() rejects
+	 * before any connection is attempted.
 	 */
-	const filePath = path.join(os.tmpdir(), `anchor-scheduler-tests-${crypto.randomUUID()}.sqlite3.db`);
-	const sqliteDriver = new KeetaAnchorQueueStorageDriverSQLite3({
-		db: async function() {
-			return(await sqlite.open({
-				filename: filePath,
-				driver: sqlite3.Database,
-				mode: sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
-			}));
+	const firestoreDriver = new KeetaAnchorQueueStorageDriverFirestore({
+		firestore: async function(): Promise<Firestore> {
+			throw(new Error('internal error: the connection factory must never be invoked'));
 		},
+		namespace: 'scheduler-unsupported',
 		id: 'scheduler-unsupported'
 	});
 	try {
 		const scheduler = new KeetaAnchorQueueScheduler({
-			driver: sqliteDriver,
+			driver: firestoreDriver,
 			units: []
 		});
 		expect(function() {
 			scheduler.start();
 		}, 'a driver without scanActivePaths is rejected at start').toThrow('does not implement scanActivePaths');
 	} finally {
-		await sqliteDriver.destroy();
-		for (const addFileSuffix of ['', '-shm', '-wal']) {
-			try {
-				fs.unlinkSync(`${filePath}${addFileSuffix}`);
-			} catch {
-				/* Ignore */
-			}
-		}
+		await firestoreDriver.destroy();
 	}
 });

--- a/src/lib/queue/scheduler.test.ts
+++ b/src/lib/queue/scheduler.test.ts
@@ -8,8 +8,12 @@ import * as sqlite3 from 'sqlite3';
 import type { JSONSerializable } from '../utils/json.ts';
 import { AsyncDisposableStack } from '../utils/defer.js';
 
+import type {
+	KeetaAnchorQueueScanFilter,
+	KeetaAnchorQueueStatus,
+	KeetaAnchorQueueStorageDriver
+} from './index.ts';
 import type { KeetaAnchorSchedulable } from './scheduler.ts';
-import type { KeetaAnchorQueueStorageDriver } from './index.ts';
 import { KeetaAnchorQueueScheduler } from './scheduler.js';
 import { KeetaAnchorQueueStorageDriverMemory } from './index.js';
 import KeetaAnchorQueueStorageDriverSQLite3 from './drivers/queue_sqlite3.js';
@@ -62,6 +66,25 @@ class TestSchedulableUnit implements KeetaAnchorSchedulable {
 }
 
 /**
+ * A memory driver that fails selected `scanActivePaths` calls (by 1-based
+ * call index) to model transient backend outages
+ */
+class ScanFailureMemoryDriver extends KeetaAnchorQueueStorageDriverMemory {
+	readonly failScanCalls = new Set<number>();
+	private scanCallIndex = 0;
+
+	override async scanActivePaths(statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<string[][]> {
+		this.scanCallIndex++;
+		if (this.failScanCalls.has(this.scanCallIndex)) {
+			throw(new Error(`induced scan failure on call ${this.scanCallIndex}`));
+		}
+
+		const paths = await super.scanActivePaths(statuses, filter);
+		return(paths);
+	}
+}
+
+/**
  * Give the scheduler loop's promise chains enough microtask turns to settle
  * without advancing the fake clock
  */
@@ -91,6 +114,7 @@ type SchedulerHarness = {
  */
 function createSchedulerHarness(cleanup: InstanceType<typeof AsyncDisposableStack>, options: {
 	prefixes: string[];
+	root?: KeetaAnchorQueueStorageDriverMemory;
 	unitOptions?: { [prefix: string]: { yieldPasses?: number; onPass?: () => Promise<void>; }};
 	pollIntervalMs?: number;
 	sweepIntervalMs?: number;
@@ -108,7 +132,7 @@ function createSchedulerHarness(cleanup: InstanceType<typeof AsyncDisposableStac
 		vi.useRealTimers();
 	});
 
-	const root = new KeetaAnchorQueueStorageDriverMemory({ id: 'scheduler-test' });
+	const root = options.root ?? new KeetaAnchorQueueStorageDriverMemory({ id: 'scheduler-test' });
 
 	cleanup.defer(async function() {
 		await root[Symbol.asyncDispose]();
@@ -526,6 +550,87 @@ test('Scheduler startup sweep skips terminal rows older than the startup window'
 	expect(alpha.passBudgets.length, 'the startup sweep never selected the historical terminal row').toBe(0);
 });
 
+test('Scheduler retries a sweep whose scan failed instead of skipping the interval', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	const root = new ScanFailureMemoryDriver({ id: 'scheduler-scan-failure' });
+	const { scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		root: root,
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 600_000,
+		sweepStalenessMs: 5000
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	const id = await alphaStage.add({ v: 1 });
+	await alphaStage.setStatus(id, 'processing', { oldStatus: 'pending' });
+
+	/*
+	 * Age the in-flight entry past the staleness bound before starting.
+	 */
+	vi.advanceTimersByTime(10_000);
+
+	/*
+	 * The first iteration scans: fast pass (call 1), then the sweep's
+	 * stale-processing scan (call 2), which fails mid-sweep
+	 */
+	root.failScanCalls.add(2);
+
+	scheduler.start();
+
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the failed sweep selected nothing').toBe(0);
+
+	await advanceAndSettle(1000);
+	expect(alpha.passBudgets.length, 'the sweep was retried on the next poll instead of waiting out the sweep interval').toBe(1);
+});
+
+test('Scheduler restores notified heads dropped by a failed scan', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	const root = new ScanFailureMemoryDriver({ id: 'scheduler-head-restore' });
+	const { scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		root: root,
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 600_000,
+		busyIntervalMs: 100
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	scheduler.start();
+	await settleAsyncWork();
+
+	/*
+	 * The startup iteration consumed scan calls 1-3. The notify-triggered
+	 * iteration's fast pass is call 4.
+	 */
+	root.failScanCalls.add(4);
+
+	scheduler.notify('alpha:stage');
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the failed iteration ran nothing').toBe(0);
+
+	/*
+	 * A failed iteration waits out the poll interval, not the busy cadence.
+	 */
+	await advanceAndSettle(100);
+	expect(alpha.passBudgets.length, 'a failed iteration is not retried at the busy cadence').toBe(0);
+
+	await advanceAndSettle(900);
+	expect(alpha.passBudgets.length, 'the restored head ran once the backend recovered').toBe(1);
+});
+
 test('Scheduler constructor and start validate their inputs', async function() {
 	const root = new KeetaAnchorQueueStorageDriverMemory({ id: 'scheduler-validation' });
 	expect(function() {
@@ -543,7 +648,9 @@ test('Scheduler constructor and start validate their inputs', async function() {
 
 	await root.destroy();
 
-	/* A driver without scanActivePaths cannot back the scheduler */
+	/*
+	 * A driver without scanActivePaths cannot back the scheduler.
+	 */
 	const filePath = path.join(os.tmpdir(), `anchor-scheduler-tests-${crypto.randomUUID()}.sqlite3.db`);
 	const sqliteDriver = new KeetaAnchorQueueStorageDriverSQLite3({
 		db: async function() {

--- a/src/lib/queue/scheduler.test.ts
+++ b/src/lib/queue/scheduler.test.ts
@@ -1,0 +1,576 @@
+import { test, expect, vi } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as sqlite from 'sqlite';
+import * as sqlite3 from 'sqlite3';
+
+import type { JSONSerializable } from '../utils/json.ts';
+import { AsyncDisposableStack } from '../utils/defer.js';
+
+import type { KeetaAnchorSchedulable } from './scheduler.ts';
+import type { KeetaAnchorQueueStorageDriver } from './index.ts';
+import { KeetaAnchorQueueScheduler } from './scheduler.js';
+import { KeetaAnchorQueueStorageDriverMemory } from './index.js';
+import KeetaAnchorQueueStorageDriverSQLite3 from './drivers/queue_sqlite3.js';
+
+/**
+ * A schedulable unit driving a real storage driver: each pass drains the
+ * pending entries of the unit's stage partition.
+ */
+class TestSchedulableUnit implements KeetaAnchorSchedulable {
+	readonly partitionPrefix: string;
+	readonly passBudgets: (number | undefined)[] = [];
+	deactivateCount = 0;
+	active = false;
+
+	private readonly root: KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>;
+	private yieldPassesRemaining: number;
+	private readonly onPass?: (() => Promise<void>) | undefined;
+
+	constructor(root: KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>, prefix: string, options?: { yieldPasses?: number; onPass?: () => Promise<void>; }) {
+		this.root = root;
+		this.partitionPrefix = prefix;
+		this.yieldPassesRemaining = options?.yieldPasses ?? 0;
+		this.onPass = options?.onPass;
+	}
+
+	async runPass(budgetMs?: number): Promise<boolean> {
+		this.active = true;
+		this.passBudgets.push(budgetMs);
+
+		await this.onPass?.();
+
+		if (this.yieldPassesRemaining > 0) {
+			this.yieldPassesRemaining--;
+			return(true);
+		}
+
+		const stage = await this.root.partition(`${this.partitionPrefix}:stage`);
+		const pending = await stage.query({ status: 'pending' });
+		for (const entry of pending) {
+			await stage.setStatus(entry.id, 'completed', { oldStatus: 'pending' });
+		}
+
+		return(false);
+	}
+
+	async deactivate(): Promise<void> {
+		this.active = false;
+		this.deactivateCount++;
+	}
+}
+
+/**
+ * Give the scheduler loop's promise chains enough microtask turns to settle
+ * without advancing the fake clock
+ */
+async function settleAsyncWork(): Promise<void> {
+	for (let turn = 0; turn < 256; turn++) {
+		await Promise.resolve();
+	}
+}
+
+/**
+ * Advance the fake clock, then let the scheduler loop settle
+ */
+async function advanceAndSettle(ms: number): Promise<void> {
+	await vi.advanceTimersByTimeAsync(ms);
+	await settleAsyncWork();
+}
+
+type SchedulerHarness = {
+	root: KeetaAnchorQueueStorageDriverMemory;
+	scheduler: KeetaAnchorQueueScheduler;
+	units: TestSchedulableUnit[];
+};
+
+/**
+ * Build a memory-backed scheduler over freshly constructed test units and
+ * register cleanup (fake timers, scheduler stop, driver dispose)
+ */
+function createSchedulerHarness(cleanup: InstanceType<typeof AsyncDisposableStack>, options: {
+	prefixes: string[];
+	unitOptions?: { [prefix: string]: { yieldPasses?: number; onPass?: () => Promise<void>; }};
+	pollIntervalMs?: number;
+	sweepIntervalMs?: number;
+	sweepStalenessMs?: number;
+	moveRetryWindowMs?: number;
+	startupMoveRetryWindowMs?: number;
+	idleDeactivateMs?: number;
+	passBudgetMs?: number;
+	busyIntervalMs?: number;
+	maxHeadsPerIteration?: number;
+}): SchedulerHarness {
+	vi.useFakeTimers();
+
+	cleanup.defer(function() {
+		vi.useRealTimers();
+	});
+
+	const root = new KeetaAnchorQueueStorageDriverMemory({ id: 'scheduler-test' });
+
+	cleanup.defer(async function() {
+		await root[Symbol.asyncDispose]();
+	});
+
+	const units = options.prefixes.map(function(prefix) {
+		return(new TestSchedulableUnit(root, prefix, options.unitOptions?.[prefix]));
+	});
+
+	const scheduler = new KeetaAnchorQueueScheduler({
+		driver: root,
+		units: units,
+		pollIntervalMs: options.pollIntervalMs,
+		sweepIntervalMs: options.sweepIntervalMs,
+		sweepStalenessMs: options.sweepStalenessMs,
+		moveRetryWindowMs: options.moveRetryWindowMs,
+		startupMoveRetryWindowMs: options.startupMoveRetryWindowMs,
+		idleDeactivateMs: options.idleDeactivateMs,
+		passBudgetMs: options.passBudgetMs,
+		busyIntervalMs: options.busyIntervalMs,
+		maxHeadsPerIteration: options.maxHeadsPerIteration
+	});
+
+	cleanup.defer(async function() {
+		await scheduler.stop();
+	});
+
+	const harness: SchedulerHarness = { root: root, scheduler: scheduler, units: units };
+	return(harness);
+}
+
+test('Scheduler runs only the units owning active partitions', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha', 'beta'],
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 60_000,
+		passBudgetMs: 250
+	});
+	const [alpha, beta] = units;
+	if (!alpha || !beta) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	const id = await alphaStage.add({ v: 1 });
+
+	scheduler.start();
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the unit owning the pending partition ran once').toBe(1);
+	expect(alpha.passBudgets[0], 'the pass budget is forwarded to the unit').toBe(250);
+	expect(beta.passBudgets.length, 'the idle unit never ran').toBe(0);
+
+	const entry = await alphaStage.get(id);
+	expect(entry?.status, 'the pending entry was processed').toBe('completed');
+
+	/* A head owned by no unit is ignored without disturbing the loop */
+	scheduler.notify('nobody:stage');
+	await settleAsyncWork();
+	expect(beta.passBudgets.length, 'an unowned head does not run other units').toBe(0);
+});
+
+test('Scheduler notify wakes the loop before the poll interval', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	scheduler.start();
+
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'no unit runs while nothing is active').toBe(0);
+
+	const alphaStage = await root.partition('alpha:stage');
+	const id = await alphaStage.add({ v: 1 });
+
+	scheduler.notify('alpha:stage');
+
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the notified unit ran without a timer tick').toBe(1);
+
+	const entry = await alphaStage.get(id);
+	expect(entry?.status, 'the notified entry was processed').toBe('completed');
+});
+
+test('Scheduler latches a notify that arrives during an in-flight pass', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	/*
+	 * alpha's pass enqueues work for beta and notifies mid-iteration; the
+	 * level-triggered set must schedule the next iteration immediately
+	 */
+	let notifyDuringPass: (() => Promise<void>) | undefined;
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha', 'beta'],
+		unitOptions: {
+			'alpha': {
+				onPass: async function() {
+					await notifyDuringPass?.();
+					notifyDuringPass = undefined;
+				}
+			}
+		},
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000
+	});
+	const [alpha, beta] = units;
+	if (!alpha || !beta) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const betaStage = await root.partition('beta:stage');
+	notifyDuringPass = async function() {
+		await betaStage.add({ v: 2 });
+		scheduler.notify('beta:stage');
+	};
+
+	const alphaStage = await root.partition('alpha:stage');
+	await alphaStage.add({ v: 1 });
+
+	scheduler.start();
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the initially active unit ran').toBeGreaterThanOrEqual(1);
+	expect(beta.passBudgets.length, 'the mid-pass notify ran the other unit without a timer tick').toBeGreaterThanOrEqual(1);
+});
+
+test('Scheduler sweep recovers stale processing entries the fast pass skips', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 5000,
+		sweepStalenessMs: 5000
+	});
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	const id = await alphaStage.add({ v: 1 });
+	await alphaStage.setStatus(id, 'processing', { oldStatus: 'pending' });
+
+	/* Age the in-flight entry past the staleness bound before starting */
+	vi.advanceTimersByTime(10_000);
+
+	scheduler.start();
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the sweep selected the unit holding the stale entry').toBeGreaterThanOrEqual(1);
+});
+
+test('Scheduler ages terminal rows out of the sweep and deactivates the idle unit', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 5000,
+		sweepStalenessMs: 300_000,
+		moveRetryWindowMs: 20_000,
+		idleDeactivateMs: 30_000
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	await alphaStage.add({ v: 1 });
+
+	scheduler.start();
+
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'the unit processed the pending entry').toBeGreaterThanOrEqual(1);
+
+	/* Within the retry window, the terminal row keeps selecting the unit */
+	await advanceAndSettle(10_000);
+	const passesWithinWindow = alpha.passBudgets.length;
+	expect(passesWithinWindow, 'the sweep keeps selecting a fresh terminal row').toBeGreaterThan(1);
+
+	/* Once the row ages out, the sweeps stop selecting the unit */
+	await advanceAndSettle(30_000);
+	const passesAfterAgeOut = alpha.passBudgets.length;
+
+	await advanceAndSettle(30_000);
+	expect(alpha.passBudgets.length, 'an aged-out terminal row no longer selects the unit').toBe(passesAfterAgeOut);
+
+	/* The idle unit is eventually deactivated and stays deactivated */
+	await advanceAndSettle(60_000);
+	expect(alpha.deactivateCount, 'the idle unit was deactivated').toBeGreaterThanOrEqual(1);
+	expect(alpha.active, 'the deactivated unit stays inactive').toBe(false);
+
+	const deactivationsAfterCollection = alpha.deactivateCount;
+	await advanceAndSettle(60_000);
+	expect(alpha.deactivateCount, 'a deactivated unit is not repeatedly deactivated').toBe(deactivationsAfterCollection);
+});
+
+test('Scheduler startup sweep recovers terminal rows older than the retry window', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 5000,
+		sweepStalenessMs: 300_000,
+		moveRetryWindowMs: 20_000
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	await alphaStage.add({ v: 1 }, { status: 'completed' });
+
+	/* Age the terminal row past the retry window before starting */
+	vi.advanceTimersByTime(60_000);
+
+	scheduler.start();
+	await settleAsyncWork();
+
+	expect(alpha.passBudgets.length, 'the widened startup sweep selected the aged terminal row').toBe(1);
+
+	/* Subsequent windowed sweeps no longer select the aged-out row */
+	await advanceAndSettle(15_000);
+	expect(alpha.passBudgets.length, 'windowed sweeps skip the aged-out row').toBe(1);
+});
+
+test('Scheduler reschedules a unit that exhausts its budget at the busy cadence', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		unitOptions: {
+			'alpha': { yieldPasses: 2 }
+		},
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000,
+		passBudgetMs: 50,
+		busyIntervalMs: 100
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	scheduler.start();
+	await settleAsyncWork();
+
+	scheduler.notify('alpha:stage');
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'a budget-exhausted yield does not rerun the unit within the same tick').toBe(1);
+
+	await advanceAndSettle(100);
+	expect(alpha.passBudgets.length, 'the yielded unit reran after one busy interval').toBe(2);
+
+	await advanceAndSettle(100);
+	expect(alpha.passBudgets.length, 'the yielded unit reran until it drained').toBe(3);
+	expect(alpha.passBudgets, 'the budget is forwarded on every pass').toEqual([50, 50, 50]);
+
+	await advanceAndSettle(1_000);
+	expect(alpha.passBudgets.length, 'a drained unit stops rerunning').toBe(3);
+});
+
+test('Scheduler paces reruns while a unit reports progress it cannot make', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	/*
+	 * A unit that always reports remaining progress models a runner whose
+	 * lock is held by another worker; the scheduler must not spin hot
+	 */
+	const { scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		unitOptions: {
+			'alpha': { yieldPasses: 1_000 }
+		},
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000,
+		busyIntervalMs: 100
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	scheduler.start();
+	await settleAsyncWork();
+
+	scheduler.notify('alpha:stage');
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length, 'a spurious progress report yields exactly one pass per busy interval').toBe(1);
+
+	await advanceAndSettle(100);
+	expect(alpha.passBudgets.length, 'the rerun waited out the busy interval').toBe(2);
+
+	await advanceAndSettle(500);
+	expect(alpha.passBudgets.length, 'reruns stay bounded by the busy cadence').toBeLessThanOrEqual(8);
+});
+
+test('Scheduler defers heads over the per-iteration cap without dropping them', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha', 'beta', 'gamma'],
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000,
+		busyIntervalMs: 100,
+		maxHeadsPerIteration: 1
+	});
+
+	for (const prefix of ['alpha', 'beta', 'gamma']) {
+		const stage = await root.partition(`${prefix}:stage`);
+		await stage.add({ v: 1 });
+	}
+
+	function totalPasses(): number {
+		return(units.reduce(function(sum, unit) {
+			return(sum + unit.passBudgets.length);
+		}, 0));
+	}
+
+	scheduler.start();
+	await settleAsyncWork();
+	expect(totalPasses(), 'the first iteration ran only the capped head count').toBe(1);
+
+	await advanceAndSettle(100);
+	expect(totalPasses(), 'a deferred head ran on the next busy interval').toBe(2);
+
+	await advanceAndSettle(100);
+	expect(totalPasses(), 'every deferred head eventually ran').toBe(3);
+
+	for (const prefix of ['alpha', 'beta', 'gamma']) {
+		const stage = await root.partition(`${prefix}:stage`);
+		const pending = await stage.query({ status: 'pending' });
+		expect(pending.length, `no pending work remains for ${prefix}`).toBe(0);
+	}
+});
+
+test('Scheduler cap does not starve deferred heads behind busy units', async function() {
+	await using cleanup = new AsyncDisposableStack();
+
+	/*
+	 * Every unit always reports remaining progress
+	 */
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha', 'beta', 'gamma'],
+		unitOptions: {
+			'alpha': { yieldPasses: 1_000 },
+			'beta': { yieldPasses: 1_000 },
+			'gamma': { yieldPasses: 1_000 }
+		},
+		pollIntervalMs: 600_000,
+		sweepIntervalMs: 600_000,
+		busyIntervalMs: 100,
+		maxHeadsPerIteration: 2
+	});
+
+	const [alpha, beta, gamma] = units;
+	if (!alpha || !beta || !gamma) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	for (const prefix of ['alpha', 'beta', 'gamma']) {
+		const stage = await root.partition(`${prefix}:stage`);
+		await stage.add({ v: 1 });
+	}
+
+	scheduler.start();
+
+	await settleAsyncWork();
+	expect(alpha.passBudgets.length + beta.passBudgets.length + gamma.passBudgets.length, 'the first iteration ran only the capped head count').toBe(2);
+	expect(gamma.passBudgets.length, 'the head over the cap was deferred').toBe(0);
+
+	await advanceAndSettle(100);
+	expect(gamma.passBudgets.length, 'the deferred head ran ahead of the busy reruns').toBe(1);
+
+	await advanceAndSettle(300);
+	for (const unit of [alpha, beta, gamma]) {
+		expect(unit.passBudgets.length, `the busy units share the cap fairly (${unit.partitionPrefix})`).toBeGreaterThanOrEqual(2);
+	}
+});
+
+test('Scheduler startup sweep skips terminal rows older than the startup window', async function() {
+	await using cleanup = new AsyncDisposableStack();
+	const { root, scheduler, units } = createSchedulerHarness(cleanup, {
+		prefixes: ['alpha'],
+		pollIntervalMs: 1000,
+		sweepIntervalMs: 5000,
+		sweepStalenessMs: 300_000,
+		moveRetryWindowMs: 20_000,
+		startupMoveRetryWindowMs: 30_000
+	});
+
+	const [alpha] = units;
+	if (!alpha) {
+		throw(new Error('internal error: units missing'));
+	}
+
+	const alphaStage = await root.partition('alpha:stage');
+	await alphaStage.add({ v: 1 }, { status: 'completed' });
+
+	/* Age the terminal row past the startup window before starting */
+	vi.advanceTimersByTime(60_000);
+
+	scheduler.start();
+	await settleAsyncWork();
+
+	expect(alpha.passBudgets.length, 'the startup sweep never selected the historical terminal row').toBe(0);
+});
+
+test('Scheduler constructor and start validate their inputs', async function() {
+	const root = new KeetaAnchorQueueStorageDriverMemory({ id: 'scheduler-validation' });
+	expect(function() {
+		return(new KeetaAnchorQueueScheduler({
+			driver: root,
+			units: [new TestSchedulableUnit(root, 'has:colon')]
+		}));
+	}, 'a prefix containing ":" is rejected').toThrow('may not contain ":"');
+	expect(function() {
+		return(new KeetaAnchorQueueScheduler({
+			driver: root,
+			units: [new TestSchedulableUnit(root, 'dup'), new TestSchedulableUnit(root, 'dup')]
+		}));
+	}, 'duplicate prefixes are rejected').toThrow('Duplicate schedulable partition prefix');
+
+	await root.destroy();
+
+	/* A driver without scanActivePaths cannot back the scheduler */
+	const filePath = path.join(os.tmpdir(), `anchor-scheduler-tests-${crypto.randomUUID()}.sqlite3.db`);
+	const sqliteDriver = new KeetaAnchorQueueStorageDriverSQLite3({
+		db: async function() {
+			return(await sqlite.open({
+				filename: filePath,
+				driver: sqlite3.Database,
+				mode: sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
+			}));
+		},
+		id: 'scheduler-unsupported'
+	});
+	try {
+		const scheduler = new KeetaAnchorQueueScheduler({
+			driver: sqliteDriver,
+			units: []
+		});
+		expect(function() {
+			scheduler.start();
+		}, 'a driver without scanActivePaths is rejected at start').toThrow('does not implement scanActivePaths');
+	} finally {
+		await sqliteDriver.destroy();
+		for (const addFileSuffix of ['', '-shm', '-wal']) {
+			try {
+				fs.unlinkSync(`${filePath}${addFileSuffix}`);
+			} catch {
+				/* Ignore */
+			}
+		}
+	}
+});

--- a/src/lib/queue/scheduler.ts
+++ b/src/lib/queue/scheduler.ts
@@ -1,0 +1,472 @@
+import type {
+	KeetaAnchorQueueScanFilter,
+	KeetaAnchorQueueStatus,
+	KeetaAnchorQueueStorageDriver
+} from './index.ts';
+import type { Logger } from '../log/index.ts';
+import type { JSONSerializable } from '../utils/json.ts';
+import { MethodLogger } from './internal.js';
+
+/**
+ * The statuses the fast pass treats as actionable work: the owning unit's
+ * next pass will process or requeue them without waiting for any timeout.
+ */
+const fastPassStatuses: KeetaAnchorQueueStatus[] = ['pending', 'failed_temporarily', 'stuck', 'aborted'];
+
+/**
+ * The status the recovery sweep inspects for stale in-flight work. Live
+ * locks and in-flight entries also carry it, so the sweep only selects
+ * entries older than the staleness bound.
+ */
+const staleProcessingStatuses: KeetaAnchorQueueStatus[] = ['processing'];
+
+/**
+ * The pipeable statuses the recovery sweep inspects for failed stage moves.
+ * Terminal-stage entries also carry them, so the sweep only selects entries
+ * recently touched by the failed-move timestamp refresh.
+ */
+const moveRetryStatuses: KeetaAnchorQueueStatus[] = ['completed', 'failed_permanently'];
+
+/**
+ * A unit of work (e.g. a saga's runners) that a
+ * {@link KeetaAnchorQueueScheduler} can multiplex.
+ */
+export interface KeetaAnchorSchedulable {
+	/**
+	 * Static routing key: the unit owns every partition whose head segment
+	 * equals this prefix or starts with `${prefix}:`. The prefix must not
+	 * contain `:`.
+	 */
+	readonly partitionPrefix: string;
+
+	/**
+	 * Run exactly one processing pass, building any lazily-initialized
+	 * resources first.
+	 *
+	 * @param budgetMs - Optional time budget; a unit exhausting it must
+	 *                   yield and report that progress may remain.
+	 * @returns Whether progress may remain
+	 */
+	runPass(budgetMs?: number): Promise<boolean>;
+
+	/**
+	 * Release built resources after an idle period. A later
+	 * {@link runPass} must rebuild them lazily.
+	 */
+	deactivate(): Promise<void>;
+}
+
+export type KeetaAnchorQueueSchedulerOptions<QueueRequest extends JSONSerializable, QueueResult extends JSONSerializable> = {
+	/**
+	 * The root storage driver to scan for active partitions -- it must
+	 * implement `scanActivePaths`
+	 */
+	driver: KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>;
+	/**
+	 * The schedulable units to multiplex, keyed by their partition prefix
+	 */
+	units: Iterable<KeetaAnchorSchedulable>;
+	/**
+	 * The logger to use for logging
+	 */
+	logger?: Logger | undefined;
+	/**
+	 * Safety-net cadence between fast passes while idle (default 5s)
+	 */
+	pollIntervalMs?: number | undefined;
+	/**
+	 * Cadence of the recovery sweep (default 60s)
+	 */
+	sweepIntervalMs?: number | undefined;
+	/**
+	 * Age bound for the sweep's stale-`processing` scan. Over-selection is
+	 * harmless because the selected unit applies its own stuck threshold
+	 * (default 300s, the anchor default process timeout)
+	 */
+	sweepStalenessMs?: number | undefined;
+	/**
+	 * Recency window for the sweep's failed-move scan. Must exceed
+	 * `sweepIntervalMs` plus worst-case pass latency or the failed-move
+	 * refresh chain breaks between sweeps (default `4 * sweepIntervalMs`)
+	 */
+	moveRetryWindowMs?: number | undefined;
+	/**
+	 * Recency window for the startup sweep's failed-move scan, covering
+	 * process downtime during which the failed-move refresh chain could
+	 * not run (default 24 hours)
+	 */
+	startupMoveRetryWindowMs?: number | undefined;
+	/**
+	 * Age after which a unit that has not run is deactivated (default 15
+	 * minutes)
+	 */
+	idleDeactivateMs?: number | undefined;
+	/**
+	 * Per-unit time budget passed to each `runPass` (default none)
+	 */
+	passBudgetMs?: number | undefined;
+	/**
+	 * Pause before rerunning units that reported remaining progress.
+	 */
+	busyIntervalMs?: number | undefined;
+	/**
+	 * Maximum partition heads processed per loop iteration.
+	 */
+	maxHeadsPerIteration?: number | undefined;
+};
+
+/**
+ * A single-loop scheduler that multiplexes many {@link KeetaAnchorSchedulable}
+ * units over one storage backend.
+ *
+ * Instead of one poll loop per unit, one loop scans the backend for
+ * partitions holding actionable entries and runs only the owning units.
+ *
+ * {@link notify} is level-triggered: a notification arriving during an
+ * in-flight iteration schedules the next iteration instead of being lost.
+ */
+export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = JSONSerializable, QueueResult extends JSONSerializable = JSONSerializable> {
+	private readonly driver: KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>;
+	private readonly unitsByPrefix: Map<string, KeetaAnchorSchedulable>;
+	private readonly logger?: Logger | undefined;
+
+	private readonly pollIntervalMs: number;
+	private readonly sweepIntervalMs: number;
+	private readonly sweepStalenessMs: number;
+	private readonly moveRetryWindowMs: number;
+	private readonly startupMoveRetryWindowMs: number;
+	private readonly idleDeactivateMs: number;
+	private readonly passBudgetMs: number | undefined;
+	private readonly busyIntervalMs: number;
+	private readonly maxHeadsPerIteration: number;
+
+	/**
+	 * Heads notified since the loop last consumed the set (level-triggered)
+	 */
+	private readonly notifiedHeads = new Set<string>();
+	/**
+	 * Heads whose units reported remaining progress. Rerun at the busy
+	 * cadence rather than immediately: progress reports can be spurious (a
+	 * runner lock held by another worker) and an un-paced rerun would spin
+	 * the loop hot against the backend
+	 */
+	private readonly rerunHeads = new Set<string>();
+	/**
+	 * Heads deferred over the per-iteration cap. Consumed ahead of the
+	 * progress reruns so a busy set of early heads cannot starve the
+	 * deferred ones
+	 */
+	private readonly deferredHeads = new Set<string>();
+	/**
+	 * Prefixes of units that have run and not yet been deactivated, with the
+	 * timestamp of their most recent pass
+	 */
+	private readonly lastRunAtByPrefix = new Map<string, number>();
+	private wakeLoop: (() => void) | null = null;
+	private running = false;
+	private loopPromise: Promise<void> | null = null;
+	private lastSweepAt: number | null = null;
+
+	readonly id: string;
+
+	constructor(options: KeetaAnchorQueueSchedulerOptions<QueueRequest, QueueResult>) {
+		this.driver = options.driver;
+		this.logger = options.logger;
+		this.id = crypto.randomUUID();
+
+		this.pollIntervalMs = options.pollIntervalMs ?? 5_000;
+		this.sweepIntervalMs = options.sweepIntervalMs ?? 60_000;
+		this.sweepStalenessMs = options.sweepStalenessMs ?? 300_000;
+		this.moveRetryWindowMs = options.moveRetryWindowMs ?? this.sweepIntervalMs * 4;
+		this.startupMoveRetryWindowMs = options.startupMoveRetryWindowMs ?? 86_400_000;
+		this.idleDeactivateMs = options.idleDeactivateMs ?? 900_000;
+		this.passBudgetMs = options.passBudgetMs;
+		this.busyIntervalMs = options.busyIntervalMs ?? 100;
+		this.maxHeadsPerIteration = options.maxHeadsPerIteration ?? 100;
+
+		this.unitsByPrefix = new Map();
+		for (const unit of options.units) {
+			const prefix = unit.partitionPrefix;
+			if (prefix.includes(':')) {
+				throw(new Error(`Schedulable partition prefix may not contain ":": ${prefix}`));
+			}
+			if (this.unitsByPrefix.has(prefix)) {
+				throw(new Error(`Duplicate schedulable partition prefix: ${prefix}`));
+			}
+
+			this.unitsByPrefix.set(prefix, unit);
+		}
+
+		this.methodLogger('new')?.debug('Created queue scheduler with', this.unitsByPrefix.size, 'schedulable units');
+	}
+
+	private methodLogger(method: string): Logger | undefined {
+		return(MethodLogger(this.logger, {
+			class: 'KeetaAnchorQueueScheduler',
+			file: 'src/lib/queue/scheduler.ts',
+			method: method,
+			instanceID: this.id
+		}));
+	}
+
+	/**
+	 * Start the scheduler loop
+	 *
+	 * @throws {@link Error} when the driver does not implement `scanActivePaths`
+	 */
+	start(): void {
+		if (this.running) {
+			return;
+		}
+
+		if (this.driver.scanActivePaths === undefined) {
+			throw(new Error(`Storage driver ${this.driver.name} does not implement scanActivePaths and cannot back a multiplexing scheduler`));
+		}
+
+		this.methodLogger('start')?.debug('Starting scheduler loop');
+
+		this.running = true;
+		this.lastSweepAt = null;
+		this.loopPromise = this.loop();
+	}
+
+	/**
+	 * Wake the scheduler for a partition head (the first path segment below
+	 * the scheduler's driver), typically after an enqueue. Level-triggered:
+	 * never lost, even during an in-flight iteration.
+	 */
+	notify(head: string): void {
+		this.notifiedHeads.add(head);
+		this.wake();
+	}
+
+	/**
+	 * Stop the scheduler loop and wait for any in-flight iteration to finish
+	 */
+	async stop(): Promise<void> {
+		this.methodLogger('stop')?.debug('Stopping scheduler loop');
+
+		this.running = false;
+		this.wake();
+
+		await this.loopPromise;
+
+		this.loopPromise = null;
+	}
+
+	private wake(): void {
+		const wakeLoop = this.wakeLoop;
+		this.wakeLoop = null;
+
+		wakeLoop?.();
+	}
+
+	private async sleepUntilWake(ms: number): Promise<void> {
+		await new Promise<void>((resolve) => {
+			const timer = setTimeout(() => {
+				this.wakeLoop = null;
+				resolve();
+			}, ms);
+
+			this.wakeLoop = () => {
+				clearTimeout(timer);
+				resolve();
+			};
+		});
+	}
+
+	private async loop(): Promise<void> {
+		const logger = this.methodLogger('loop');
+
+		while (this.running) {
+			try {
+				await this.iteration();
+			} catch (error: unknown) {
+				logger?.error('Scheduler iteration failed:', error);
+			}
+
+			if (!this.running) {
+				break;
+			}
+
+			/*
+			 * A notify that arrived during the iteration schedules the next
+			 * iteration immediately instead of waiting out the poll interval
+			 */
+			if (this.notifiedHeads.size !== 0) {
+				continue;
+			}
+
+			/*
+			 * Progress reruns and deferred heads run at the busy cadence,
+			 * never immediately: a unit can report progress without making
+			 * any (its runner lock held by another worker), and an un-paced
+			 * rerun would spin the loop hot against the backend
+			 */
+			if (this.rerunHeads.size !== 0 || this.deferredHeads.size !== 0) {
+				await this.sleepUntilWake(this.busyIntervalMs);
+				continue;
+			}
+
+			await this.sleepUntilWake(this.pollIntervalMs);
+		}
+	}
+
+	private async iteration(): Promise<void> {
+		const heads = this.consumeQueuedHeads();
+
+		await this.collectFastPassHeads(heads);
+		await this.collectSweepHeads(heads);
+
+		await this.runOwningUnits(heads);
+		await this.deactivateIdleUnits();
+	}
+
+	/*
+	 * Consumption order sets the run order under the per-iteration cap:
+	 * deferred heads first (they already waited a full iteration), then
+	 * fresh notifications, then progress reruns last.
+	 */
+	private consumeQueuedHeads(): Set<string> {
+		const heads = new Set(this.deferredHeads);
+		this.deferredHeads.clear();
+
+		for (const head of this.notifiedHeads) {
+			heads.add(head);
+		}
+
+		this.notifiedHeads.clear();
+
+		for (const head of this.rerunHeads) {
+			heads.add(head);
+		}
+
+		this.rerunHeads.clear();
+
+		return(heads);
+	}
+
+	private async scanHeadsInto(heads: Set<string>, statuses: KeetaAnchorQueueStatus[], filter?: KeetaAnchorQueueScanFilter): Promise<void> {
+		if (this.driver.scanActivePaths === undefined) {
+			throw(new Error(`Storage driver ${this.driver.name} does not implement scanActivePaths`));
+		}
+
+		const paths = await this.driver.scanActivePaths(statuses, filter);
+		for (const path of paths) {
+			const head = path[0];
+			if (head === undefined) {
+				/*
+				 * Entries at the driver's own partition have no head to route
+				 */
+				continue;
+			}
+
+			heads.add(head);
+		}
+	}
+
+	private async collectFastPassHeads(heads: Set<string>): Promise<void> {
+		await this.scanHeadsInto(heads, fastPassStatuses);
+	}
+
+	private async collectSweepHeads(heads: Set<string>): Promise<void> {
+		const now = Date.now();
+
+		const lastSweepAt = this.lastSweepAt;
+		const isStartupSweep = lastSweepAt === null;
+		if (lastSweepAt !== null && now - lastSweepAt < this.sweepIntervalMs) {
+			return;
+		}
+
+		this.lastSweepAt = now;
+
+		this.methodLogger('collectSweepHeads')?.debug('Running recovery sweep (startup:', isStartupSweep, ')');
+
+		await this.scanHeadsInto(heads, staleProcessingStatuses, {
+			updatedBefore: new Date(now - this.sweepStalenessMs)
+		});
+
+		/*
+		 * The startup sweep widens the failed-move window to cover process
+		 * downtime during which the refresh chain could not run.
+		 */
+		let window = this.moveRetryWindowMs;
+		if (isStartupSweep) {
+			window = Math.max(window, this.startupMoveRetryWindowMs);
+		}
+
+		await this.scanHeadsInto(heads, moveRetryStatuses, {
+			updatedAfter: new Date(now - window)
+		});
+	}
+
+	private async runOwningUnits(heads: Set<string>): Promise<void> {
+		const logger = this.methodLogger('runOwningUnits');
+
+		let processed = 0;
+		for (const head of heads) {
+			if (!this.running) {
+				return;
+			}
+
+			const [prefix] = head.split(':', 1);
+			if (prefix === undefined) {
+				continue;
+			}
+
+			const unit = this.unitsByPrefix.get(prefix);
+			if (unit === undefined) {
+				logger?.debug('No schedulable unit owns partition head', head);
+				continue;
+			}
+
+			/*
+			 * Defer owned heads over the cap so external notifications
+			 * interleave with a large backlog instead of waiting a full
+			 * iteration out
+			 */
+			if (processed >= this.maxHeadsPerIteration) {
+				this.deferredHeads.add(head);
+				continue;
+			}
+
+			processed++;
+			this.lastRunAtByPrefix.set(prefix, Date.now());
+
+			try {
+				const progressRemains = await unit.runPass(this.passBudgetMs);
+				if (progressRemains) {
+					this.rerunHeads.add(head);
+				}
+			} catch (error: unknown) {
+				logger?.error('Pass for unit with prefix', prefix, 'failed:', error);
+			}
+		}
+	}
+
+	private async deactivateIdleUnits(): Promise<void> {
+		const logger = this.methodLogger('deactivateIdleUnits');
+		const now = Date.now();
+
+		for (const [prefix, lastRunAt] of this.lastRunAtByPrefix) {
+			if (now - lastRunAt < this.idleDeactivateMs) {
+				continue;
+			}
+
+			const unit = this.unitsByPrefix.get(prefix);
+			if (unit === undefined) {
+				this.lastRunAtByPrefix.delete(prefix);
+				continue;
+			}
+
+			logger?.debug('Deactivating idle unit with prefix', prefix);
+
+			try {
+				await unit.deactivate();
+				this.lastRunAtByPrefix.delete(prefix);
+			} catch (error: unknown) {
+				logger?.error('Failed to deactivate unit with prefix', prefix, ':', error);
+			}
+		}
+	}
+}

--- a/src/lib/queue/scheduler.ts
+++ b/src/lib/queue/scheduler.ts
@@ -59,11 +59,11 @@ export interface KeetaAnchorSchedulable {
 export type KeetaAnchorQueueSchedulerOptions<QueueRequest extends JSONSerializable, QueueResult extends JSONSerializable> = {
 	/**
 	 * The root storage driver to scan for active partitions -- it must
-	 * implement `scanActivePaths`
+	 * implement `scanActivePaths`.
 	 */
 	driver: KeetaAnchorQueueStorageDriver<QueueRequest, QueueResult>;
 	/**
-	 * The schedulable units to multiplex, keyed by their partition prefix
+	 * The schedulable units to multiplex, keyed by their partition prefix.
 	 */
 	units: Iterable<KeetaAnchorSchedulable>;
 	/**
@@ -71,38 +71,38 @@ export type KeetaAnchorQueueSchedulerOptions<QueueRequest extends JSONSerializab
 	 */
 	logger?: Logger | undefined;
 	/**
-	 * Safety-net cadence between fast passes while idle (default 5s)
+	 * Safety-net cadence between fast passes while idle (default 5s).
 	 */
 	pollIntervalMs?: number | undefined;
 	/**
-	 * Cadence of the recovery sweep (default 60s)
+	 * Cadence of the recovery sweep (default 60s).
 	 */
 	sweepIntervalMs?: number | undefined;
 	/**
 	 * Age bound for the sweep's stale-`processing` scan. Over-selection is
 	 * harmless because the selected unit applies its own stuck threshold
-	 * (default 300s, the anchor default process timeout)
+	 * (default 300s, the anchor default process timeout).
 	 */
 	sweepStalenessMs?: number | undefined;
 	/**
 	 * Recency window for the sweep's failed-move scan. Must exceed
 	 * `sweepIntervalMs` plus worst-case pass latency or the failed-move
-	 * refresh chain breaks between sweeps (default `4 * sweepIntervalMs`)
+	 * refresh chain breaks between sweeps (default `4 * sweepIntervalMs`).
 	 */
 	moveRetryWindowMs?: number | undefined;
 	/**
 	 * Recency window for the startup sweep's failed-move scan, covering
 	 * process downtime during which the failed-move refresh chain could
-	 * not run (default 24 hours)
+	 * not run (default 24 hours).
 	 */
 	startupMoveRetryWindowMs?: number | undefined;
 	/**
 	 * Age after which a unit that has not run is deactivated (default 15
-	 * minutes)
+	 * minutes).
 	 */
 	idleDeactivateMs?: number | undefined;
 	/**
-	 * Per-unit time budget passed to each `runPass` (default none)
+	 * Per-unit time budget passed to each `runPass` (default none).
 	 */
 	passBudgetMs?: number | undefined;
 	/**
@@ -141,25 +141,25 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 	private readonly maxHeadsPerIteration: number;
 
 	/**
-	 * Heads notified since the loop last consumed the set (level-triggered)
+	 * Heads notified since the loop last consumed the set (level-triggered).
 	 */
 	private readonly notifiedHeads = new Set<string>();
 	/**
 	 * Heads whose units reported remaining progress. Rerun at the busy
 	 * cadence rather than immediately: progress reports can be spurious (a
 	 * runner lock held by another worker) and an un-paced rerun would spin
-	 * the loop hot against the backend
+	 * the loop hot against the backend.
 	 */
 	private readonly rerunHeads = new Set<string>();
 	/**
 	 * Heads deferred over the per-iteration cap. Consumed ahead of the
 	 * progress reruns so a busy set of early heads cannot starve the
-	 * deferred ones
+	 * deferred ones.
 	 */
 	private readonly deferredHeads = new Set<string>();
 	/**
 	 * Prefixes of units that have run and not yet been deactivated, with the
-	 * timestamp of their most recent pass
+	 * timestamp of their most recent pass.
 	 */
 	private readonly lastRunAtByPrefix = new Map<string, number>();
 	private wakeLoop: (() => void) | null = null;
@@ -241,7 +241,7 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 	}
 
 	/**
-	 * Stop the scheduler loop and wait for any in-flight iteration to finish
+	 * Stop the scheduler loop and wait for any in-flight iteration to finish.
 	 */
 	async stop(): Promise<void> {
 		this.methodLogger('stop')?.debug('Stopping scheduler loop');
@@ -279,9 +279,11 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 		const logger = this.methodLogger('loop');
 
 		while (this.running) {
+			let iterationFailed = false;
 			try {
 				await this.iteration();
 			} catch (error: unknown) {
+				iterationFailed = true;
 				logger?.error('Scheduler iteration failed:', error);
 			}
 
@@ -290,22 +292,31 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 			}
 
 			/*
-			 * A notify that arrived during the iteration schedules the next
-			 * iteration immediately instead of waiting out the poll interval
+			 * A failed iteration restores its heads for retry, but always
+			 * waits out the poll interval: retrying restored heads at the
+			 * busy cadence would hammer a backend that is already failing.
 			 */
-			if (this.notifiedHeads.size !== 0) {
-				continue;
-			}
+			if (!iterationFailed) {
+				/*
+				 * A notify that arrived during the iteration schedules the
+				 * next iteration immediately instead of waiting out the
+				 * poll interval.
+				 */
+				if (this.notifiedHeads.size !== 0) {
+					continue;
+				}
 
-			/*
-			 * Progress reruns and deferred heads run at the busy cadence,
-			 * never immediately: a unit can report progress without making
-			 * any (its runner lock held by another worker), and an un-paced
-			 * rerun would spin the loop hot against the backend
-			 */
-			if (this.rerunHeads.size !== 0 || this.deferredHeads.size !== 0) {
-				await this.sleepUntilWake(this.busyIntervalMs);
-				continue;
+				/*
+				 * Progress reruns and deferred heads run at the busy
+				 * cadence, never immediately: a unit can report progress
+				 * without making any (its runner lock held by another
+				 * worker), and an un-paced rerun would spin the loop hot
+				 * against the backend.
+				 */
+				if (this.rerunHeads.size !== 0 || this.deferredHeads.size !== 0) {
+					await this.sleepUntilWake(this.busyIntervalMs);
+					continue;
+				}
 			}
 
 			await this.sleepUntilWake(this.pollIntervalMs);
@@ -315,10 +326,24 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 	private async iteration(): Promise<void> {
 		const heads = this.consumeQueuedHeads();
 
-		await this.collectFastPassHeads(heads);
-		await this.collectSweepHeads(heads);
+		try {
+			await this.collectFastPassHeads(heads);
+			await this.collectSweepHeads(heads);
 
-		await this.runOwningUnits(heads);
+			await this.runOwningUnits(heads);
+		} catch (error: unknown) {
+			/*
+			 * A throw before the heads reach their units (a scan failure)
+			 * would silently drop them; restore them so the next iteration
+			 * retries instead of waiting for another scan or notify.
+			 */
+			for (const head of heads) {
+				this.deferredHeads.add(head);
+			}
+
+			throw(error);
+		}
+
 		await this.deactivateIdleUnits();
 	}
 
@@ -356,7 +381,7 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 			const head = path[0];
 			if (head === undefined) {
 				/*
-				 * Entries at the driver's own partition have no head to route
+				 * Entries at the driver's own partition have no head to route.
 				 */
 				continue;
 			}
@@ -378,8 +403,6 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 			return;
 		}
 
-		this.lastSweepAt = now;
-
 		this.methodLogger('collectSweepHeads')?.debug('Running recovery sweep (startup:', isStartupSweep, ')');
 
 		await this.scanHeadsInto(heads, staleProcessingStatuses, {
@@ -398,6 +421,13 @@ export class KeetaAnchorQueueScheduler<QueueRequest extends JSONSerializable = J
 		await this.scanHeadsInto(heads, moveRetryStatuses, {
 			updatedAfter: new Date(now - window)
 		});
+
+		/*
+		 * Committed only after both scans succeed: a failed sweep must be
+		 * retried on the next iteration, not skipped for a full interval,
+		 * and a failed startup sweep must keep its widened window.
+		 */
+		this.lastSweepAt = now;
 	}
 
 	private async runOwningUnits(heads: Set<string>): Promise<void> {


### PR DESCRIPTION
## Summary

Deployments with tens of thousands of routes run one poll loop per runner, issuing O(routes x partitions) queries per tick against mostly empty partitions. This PR adds a single-loop scheduler that scans the backend for partitions with actionable work and runs only their owning units, activating them on demand and deactivating them when idle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core queue storage, runner pipe maintenance, and an automatic Postgres schema migration; scheduler misconfiguration or scan bugs could skip or hot-loop work at scale, though behavior is heavily test-covered.
> 
> **Overview**
> Adds a **single-loop `KeetaAnchorQueueScheduler`** that discovers partitions with actionable work via one backend scan, wakes owning **schedulable** units (`notify`, fast pass, recovery sweeps, idle deactivate), and caps per-iteration work so large backlogs do not starve other heads.
> 
> Introduces optional **`scanActivePaths`** on queue storage (with **`KeetaAnchorQueueScanFilter`**) on the memory driver and **PostgreSQL** (plus driver tests for memory/file/postgres); Redis/SQLite/Firestore do not implement it yet. Postgres gets **schema version 3** with a **`(status, path)`** index to support status-first scans, and path-prefix **`LIKE`** escaping for segments containing `%`/`_`.
> 
> Centralizes partition keys via **`EncodeQueuePath`** / **`ValidateQueuePartitionSegment`** (`.` in segment names rejected) across drivers. **Failed stage moves** now **refresh `updated`** without changing status/failures so time-bounded sweeps keep retrying pipes; batch idempotent conflicts refresh stranded members similarly.
> 
> New **`scheduler.test.ts`** and expanded queue tests cover scan behavior, partition validation, and move-refresh semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783c4bc83118688ad66be1578dc8311b61e56cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->