### PR TITLE
Add forwarding only plan support + chaining fees helper + asset pair in persistent addresses

### DIFF
--- a/src/lib/asset.ts
+++ b/src/lib/asset.ts
@@ -195,3 +195,8 @@ export function convertAssetSearchInputToCanonical(input: MovableAssetSearchInpu
 		return(input.publicKeyString.get());
 	}
 }
+
+/** Compare movable assets after canonicalizing representation (EVM casing, token public keys, currency codes). */
+export function isMovableAssetEqual(a: MovableAsset, b: MovableAsset, cache?: EVMChecksumCache): boolean {
+	return(convertAssetSearchInputToCanonical(a, cache) === convertAssetSearchInputToCanonical(b, cache));
+}

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -2,12 +2,12 @@ import { test, expect, describe } from 'vitest';
 import { createNodeAndClient } from './utils/tests/node.js';
 import { KeetaNet } from '../client/index.js';
 import { KeetaNetAssetMovementAnchorHTTPServer, type KeetaAnchorAssetMovementServerConfig } from '../services/asset-movement/server.js';
-import { type AnchorTokenLocationMetadata, convertAssetLocationToString, toAssetLocation, toAssetPair, type AssetLocationLike, type KeetaAssetMovementTransaction, type KeetaPersistentForwardingAddressDetails } from '../services/asset-movement/common.js';
+import { type AnchorTokenLocationMetadata, convertAssetLocationToString, convertAssetSearchInputToCanonical, isAssetPairLike, toAssetLocation, toAssetPair, type AssetLocationLike, type AssetOrPair, type KeetaAssetMovementTransaction, type KeetaPersistentForwardingAddressDetails } from '../services/asset-movement/common.js';
 import { KeetaNetFXAnchorHTTPServer, type KeetaAnchorFXServerConfig, type GetConversionRateAndFeeContext, type KeetaFXInternalPriceQuote } from '../services/fx/server.js';
 import type { ConversionInputCanonicalJSON } from '../services/fx/common.js';
 import { Resolver } from './index.js';
 import type { ServiceMetadataExternalizable } from './resolver.js';
-import { AnchorChaining, AnchorChainingForwardingOnlyPlan, AnchorChainingPlan, buildForwardingAdjacency, estimateForwardingValueOut, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan } from './chaining.js';
+import { AnchorChaining, AnchorChainingForwardingOnlyPlan, AnchorChainingPlan, buildForwardingAdjacency, estimateForwardingValueOut, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan, listChainingPlanFees } from './chaining.js';
 import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, Disclaimer, AnchorChainingPathInput, AnchorChainingPath, GetPlansOptions } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
@@ -3386,6 +3386,31 @@ describe('Persistent Forwarding chaining', function() {
 		expect(h.bridgeServer.addresses.size).toEqual(1);
 	});
 
+	test('plan reuses persistent forwarding address when listed assets use canonical string form', async function() {
+		await using h = await createPersistentForwardingHarness();
+
+		const destinationAccount = newDestinationAccount();
+
+		const initialPath = await getKeetaUsdcToUsdc2Path(h, 500n, destinationAccount);
+		await AnchorChainingPlan.create(initialPath);
+		expect(h.bridgeServer.addresses.size).toEqual(1);
+
+		for (const meta of h.bridgeServer.addresses.values()) {
+			if (!isAssetPairLike(meta.asset)) {
+				continue;
+			}
+
+			meta.asset = {
+				from: convertAssetSearchInputToCanonical(meta.asset.from).toLowerCase(),
+				to: convertAssetSearchInputToCanonical(meta.asset.to)
+			} as AssetOrPair;
+		}
+
+		const retryPath = await getKeetaUsdcToUsdc2Path(h, 500n, destinationAccount);
+		await AnchorChainingPlan.create(retryPath);
+		expect(h.bridgeServer.addresses.size).toEqual(1);
+	});
+
 	test('executes the chain through the persistent forwarding step end-to-end', async function() {
 		await using h = await createPersistentForwardingHarness();
 
@@ -4010,6 +4035,42 @@ describe('getPlans forwardingOnly', function() {
 		eth:  'chain:evm:1',
 		sepa: 'bank-account:iban-swift'
 	} as const satisfies { [key: string]: AssetLocationLike };
+
+	test('listChainingPlanFees reconciles fees.total with line items for persistent forwarding', function() {
+		const fees = {
+			lineItems: [
+				{ purpose: 'RAIL' as const, value: '5' },
+				{ purpose: 'NETWORK' as const, value: '3' },
+				{ purpose: 'VALUE_VARIABLE' as const, basisPoints: 100 }
+			],
+			total: '25'
+		};
+
+		const listed = listChainingPlanFees({
+			plan: {
+				steps: [{
+					type: 'forwarded',
+					valueIn: 1000n,
+					valueOut: 975n,
+					step: {
+						type: 'assetMovement',
+						providerID: 'AM1',
+						from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, rail: 'EVM_SEND' },
+						to: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, rail: 'EVM_SEND' }
+					},
+					persistentAddress: { address: 'persistentForwarding-test', fees },
+					provider: null
+				}],
+				totalValueIn: 1000n,
+				totalValueOut: 975n
+			} as unknown as Parameters<typeof listChainingPlanFees>[0]['plan']
+		});
+
+		const feeSum = listed.lineItems.reduce((sum, item) => sum + BigInt(item.value ?? 0), 0n);
+		expect(feeSum).toEqual(25n);
+		expect(listed.lineItems.at(-1)?.purpose).toEqual('OTHER');
+		expect(listed.lineItems.at(-1)?.value).toEqual('7');
+	});
 
 	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;
 	const PFR_OPS = { initiateTransfer: false, createPersistentForwarding: true } as const;

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -3953,6 +3953,7 @@ describe('getPlans forwardingOnly', function() {
 
 	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;
 	const PFR_OPS = { initiateTransfer: false, createPersistentForwarding: true } as const;
+	const DUAL_OPS = { initiateTransfer: true, createPersistentForwarding: true } as const;
 
 	type LegMode = 'managed' | 'pfr';
 
@@ -3989,7 +3990,7 @@ describe('getPlans forwardingOnly', function() {
 		const ethSide = (id: AMSide['id']): AMSide => ({
 			location: LOC.eth,
 			id,
-			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: MANAGED_OPS }] }
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: legMode === 'pfr' ? DUAL_OPS : MANAGED_OPS }] }
 		});
 		const fiatSide = (iso: AMSide['id']): AMSide => ({
 			location: LOC.sepa,
@@ -4120,8 +4121,7 @@ describe('getPlans forwardingOnly', function() {
 		}
 
 		expect(isForwardingPlan(plan)).toBe(true);
-		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'assetMovement', 'forwarded' ]);
-		expect(plan.plan.steps[0]?.type === 'assetMovement' && plan.plan.steps[0].sendingTo).toEqual('NEXT_STEP');
+		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded', 'forwarded' ]);
 		expect(getForwardingDepositAddress(plan)).toEqual(expect.any(String));
 	});
 
@@ -4227,10 +4227,91 @@ describe('getPlans forwardingOnly', function() {
 			adjacency,
 			{ asset: EXTERNAL_IDS.USDC_ETH, location: LOC.eth },
 			{ asset: w.tokens.USDC, location: w.keetaLocation }
-		)).toBe(false);
+		)).toBe(true);
 
 		const graphAdjacency = await w.anchorChaining.graph.buildForwardingAdjacency();
 		expect(graphAdjacency.size).toEqual(adjacency.size);
+	});
+
+	test('forwardingOnly uses PFR on the last leg even when initiateTransfer is also supported', async function() {
+		const DUAL_OPS = { initiateTransfer: true, createPersistentForwarding: true } as const;
+		const account = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+		const { userClient: client, fees } = await createNodeAndClient(account);
+
+		const makeToken = async () => {
+			const { account: tokenAccount } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+			await client.setInfo(
+				{ name: '', description: '', metadata: '', defaultPermission: new KeetaNet.lib.Permissions(['ACCESS']) },
+				{ account: tokenAccount }
+			);
+			return(tokenAccount.assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN));
+		};
+
+		const keetaLocation = `chain:keeta:${client.network}` satisfies AssetLocationLike;
+		const usdc = await makeToken();
+
+		type AMAssetEntry = KeetaAnchorAssetMovementServerConfig['assetMovement']['supportedAssets'][number];
+		type AMSide = AMAssetEntry['paths'][number]['pair'][number];
+		const baseSide = (id: AMSide['id']): AMSide => ({
+			location: LOC.base,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: DUAL_OPS }] }
+		});
+		const keetaSide = (token: TokenAddress): AMSide => ({
+			location: keetaLocation,
+			id: token.publicKeyString.get(),
+			rails: { common: [{ rail: 'KEETA_SEND', supportedOperations: MANAGED_OPS }] }
+		});
+
+		const am2 = new TestChainAnchorServer({
+			...(DEBUG ? { logger } : {}),
+			client,
+			convert: ({ value }) => value,
+			assetMovement: {
+				supportedAssets: [ {
+					asset: [ keetaSide(usdc).id, baseSide(EXTERNAL_IDS.USDC_BASE).id ],
+					paths: [{ pair: [ keetaSide(usdc), baseSide(EXTERNAL_IDS.USDC_BASE) ] }]
+				} ]
+			}
+		});
+
+		await am2.start();
+		fees.addFeeFreeAccount(client.account);
+
+		await client.setInfo({
+			description: 'Dual-ops forwarding-only test',
+			name: 'TEST',
+			metadata: Resolver.Metadata.formatMetadata({
+				version: 1,
+				currencyMap: { '$USDC': usdc.publicKeyString.get() },
+				services: { assetMovement: { AM2: await am2.serviceMetadata() }}
+			} satisfies ServiceMetadataExternalizable)
+		});
+
+		const anchorChaining = new AnchorChaining({
+			client,
+			resolver: new Resolver({ root: client.account, client, trustedCAs: [] })
+		});
+
+		const request = {
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' as const },
+			destination: { asset: usdc, location: keetaLocation, recipient: client.account.publicKeyString.get(), rail: 'KEETA_SEND' as const }
+		};
+
+		try {
+			const managedPlans = await anchorChaining.getPlans(request, { limit: 1 });
+			expect(managedPlans?.[0]?.plan.steps.map((s) => s.type)).toEqual([ 'assetMovement' ]);
+
+			const forwardingPlans = await anchorChaining.getPlans(request, { limit: 1, forwardingOnly: true });
+			const forwardingPlan = forwardingPlans?.[0];
+			if (!forwardingPlan) {
+				throw(new Error('Expected a forwarding plan'));
+			}
+			expect(forwardingPlan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded' ]);
+			expect(isForwardingPlan(forwardingPlan)).toBe(true);
+		} finally {
+			await am2[Symbol.asyncDispose]?.();
+		}
 	});
 });
 

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4186,7 +4186,7 @@ describe('getPlans forwardingOnly', function() {
 		expect(fees.lineItems).toHaveLength(1);
 		expect(fees.lineItems[0]?.value).toEqual('15');
 		expect(fees.lineItems[0]?.metadata.source).toEqual('persistentAddress');
-		expect(fees.lineItems[0]?.metadata.stepType).toEqual('forwarded');
+		expect(fees.lineItems[0]?.metadata.step.type).toEqual('forwarded');
 		expect(fees.lineItems[0]?.asset).toEqual(EXTERNAL_IDS.USDC_BASE);
 		expect('total' in fees).toBe(false);
 		expect(plan.plan.steps[0]?.valueOut).toEqual(985n);

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -7,8 +7,8 @@ import { KeetaNetFXAnchorHTTPServer, type KeetaAnchorFXServerConfig, type GetCon
 import type { ConversionInputCanonicalJSON } from '../services/fx/common.js';
 import { Resolver } from './index.js';
 import type { ServiceMetadataExternalizable } from './resolver.js';
-import { AnchorChaining, AnchorChainingPlan, buildForwardingAdjacency, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan } from './chaining.js';
-import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, ComputePlanOptions, Disclaimer, AnchorChainingPathInput, AnchorChainingPath } from './chaining.js';
+import { AnchorChaining, AnchorChainingForwardingOnlyPlan, AnchorChainingPlan, buildForwardingAdjacency, estimateForwardingValueOut, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan } from './chaining.js';
+import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, Disclaimer, AnchorChainingPathInput, AnchorChainingPath, GetPlansOptions } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
 import { AnchorExternal } from './anchor-external.js';
@@ -1540,7 +1540,7 @@ async function createChainingTestHarness(options: { includeSwapAnchor?: boolean 
 		return(path);
 	};
 
-	const getPlanVia = async (fxProviderID: 'FXOne' | 'FXTwo', options?: ComputePlanOptions) => {
+	const getPlanVia = async (fxProviderID: 'FXOne' | 'FXTwo', options?: GetPlansOptions) => {
 		const plans = await anchorChaining.getPlans({
 			source: { asset: tokens.USDC, location: keetaLocation, value: 100n, rail: 'KEETA_SEND' },
 			destination: { asset: 'EUR', location: 'bank-account:iban-swift', recipient: client.account.publicKeyString.get(), rail: 'SEPA_PUSH' }
@@ -3940,6 +3940,20 @@ describe('Generic Test Cases', function() {
 });
 
 describe('getPlans forwardingOnly', function() {
+	test('estimateForwardingValueOut includes fixed, variable, and total fees', function() {
+		const fees = {
+			lineItems: [
+				{ purpose: 'RAIL' as const, value: '5' },
+				{ purpose: 'NETWORK' as const, value: '3' },
+				{ purpose: 'VALUE_VARIABLE' as const, basisPoints: 100 }
+			],
+			total: '18'
+		};
+
+		expect(estimateForwardingValueOut(1000n, fees)).toEqual(982n);
+		expect(estimateForwardingValueOut(1000n, { ...fees, total: '25' })).toEqual(975n);
+	});
+
 	const EXTERNAL_IDS = {
 		USDC_BASE: 'evm:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
 		USDC_ETH:  'evm:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
@@ -4101,9 +4115,12 @@ describe('getPlans forwardingOnly', function() {
 			throw(new Error('Expected a forwarding plan'));
 		}
 
+		expect(plan).toBeInstanceOf(AnchorChainingForwardingOnlyPlan);
+		expect('execute' in plan).toBe(false);
 		expect(isForwardingPlan(plan)).toBe(true);
 		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded' ]);
-		expect(getForwardingDepositAddress(plan)).toEqual(expect.any(String));
+		expect(plan.getDepositAddress()).toEqual(expect.any(String));
+		expect(getForwardingDepositAddress(plan)).toEqual(plan.getDepositAddress());
 	});
 
 	test('returns a two-leg forwarding plan from ethereum to keeta', async function() {
@@ -4120,9 +4137,12 @@ describe('getPlans forwardingOnly', function() {
 			throw(new Error('Expected a forwarding plan'));
 		}
 
+		expect(plan).toBeInstanceOf(AnchorChainingForwardingOnlyPlan);
+		expect('execute' in plan).toBe(false);
 		expect(isForwardingPlan(plan)).toBe(true);
 		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded', 'forwarded' ]);
-		expect(getForwardingDepositAddress(plan)).toEqual(expect.any(String));
+		expect(plan.getDepositAddress()).toEqual(expect.any(String));
+		expect(getForwardingDepositAddress(plan)).toEqual(plan.getDepositAddress());
 	});
 
 	test('returns null for managed final-leg routes', async function() {
@@ -4312,6 +4332,22 @@ describe('getPlans forwardingOnly', function() {
 		} finally {
 			await am2[Symbol.asyncDispose]?.();
 		}
+	});
+
+	test('AnchorChainingPlan created with forwardingOnly cannot execute', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const paths = await w.anchorChaining.getPaths({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		});
+		const path = paths?.[0];
+		if (!path) {
+			throw(new Error('Expected path'));
+		}
+
+		const plan = await AnchorChainingPlan.create(path, { forwardingOnly: true });
+		await expect(plan.execute()).rejects.toThrow(/cannot be executed/i);
 	});
 });
 

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -7,7 +7,7 @@ import { KeetaNetFXAnchorHTTPServer, type KeetaAnchorFXServerConfig, type GetCon
 import type { ConversionInputCanonicalJSON } from '../services/fx/common.js';
 import { Resolver } from './index.js';
 import type { ServiceMetadataExternalizable } from './resolver.js';
-import { AnchorChaining, AnchorChainingPlan } from './chaining.js';
+import { AnchorChaining, AnchorChainingPlan, buildForwardingAdjacency, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan } from './chaining.js';
 import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, ComputePlanOptions, Disclaimer, AnchorChainingPathInput, AnchorChainingPath } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
@@ -3937,6 +3937,301 @@ describe('Generic Test Cases', function() {
 			}
 		}, 300_000);
 	}
+});
+
+describe('getPlans forwardingOnly', function() {
+	const EXTERNAL_IDS = {
+		USDC_BASE: 'evm:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+		USDC_ETH:  'evm:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+	} as const;
+
+	const LOC = {
+		base: 'chain:evm:8453',
+		eth:  'chain:evm:1',
+		sepa: 'bank-account:iban-swift'
+	} as const satisfies { [key: string]: AssetLocationLike };
+
+	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;
+	const PFR_OPS = { initiateTransfer: false, createPersistentForwarding: true } as const;
+
+	type LegMode = 'managed' | 'pfr';
+
+	async function buildForwardingWorld(legMode: LegMode) {
+		const account = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+		const { userClient: client, fees } = await createNodeAndClient(account);
+
+		const makeToken = async () => {
+			const { account: tokenAccount } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+			await client.setInfo(
+				{ name: '', description: '', metadata: '', defaultPermission: new KeetaNet.lib.Permissions(['ACCESS']) },
+				{ account: tokenAccount }
+			);
+			return(tokenAccount.assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN));
+		};
+
+		const keetaLocation = `chain:keeta:${client.network}` satisfies AssetLocationLike;
+		const tokens = { USDC: await makeToken(), USD: await makeToken(), EUR: await makeToken(), KTA: await makeToken() };
+		const baseEvmOps = legMode === 'pfr' ? PFR_OPS : MANAGED_OPS;
+
+		type AMAssetEntry = KeetaAnchorAssetMovementServerConfig['assetMovement']['supportedAssets'][number];
+		type AMSide = AMAssetEntry['paths'][number]['pair'][number];
+
+		const keetaSide = (token: TokenAddress): AMSide => ({
+			location: keetaLocation,
+			id: token.publicKeyString.get(),
+			rails: { common: [{ rail: 'KEETA_SEND', supportedOperations: MANAGED_OPS }] }
+		});
+		const baseSide = (id: AMSide['id']): AMSide => ({
+			location: LOC.base,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: baseEvmOps }] }
+		});
+		const ethSide = (id: AMSide['id']): AMSide => ({
+			location: LOC.eth,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: MANAGED_OPS }] }
+		});
+		const fiatSide = (iso: AMSide['id']): AMSide => ({
+			location: LOC.sepa,
+			id: iso,
+			rails: { common: [{ rail: 'SEPA_PUSH', supportedOperations: MANAGED_OPS }] }
+		});
+		const pairEntry = (a: AMSide, b: AMSide): AMAssetEntry => ({
+			asset: [ a.id, b.id ],
+			paths: [{ pair: [ a, b ] }]
+		});
+
+		const convert: ChainAnchorConvert = ({ value }) => value;
+
+		const am1 = new TestChainAnchorServer({
+			...(DEBUG ? { logger } : {}),
+			client,
+			convert,
+			assetMovement: {
+				supportedAssets: [
+					pairEntry(keetaSide(tokens.EUR), keetaSide(tokens.USD)),
+					pairEntry(baseSide(EXTERNAL_IDS.USDC_BASE), keetaSide(tokens.USD)),
+					pairEntry(keetaSide(tokens.EUR), fiatSide('EUR'))
+				]
+			}
+		});
+		const am2 = new TestChainAnchorServer({
+			...(DEBUG ? { logger } : {}),
+			client,
+			convert,
+			assetMovement: {
+				supportedAssets: [ pairEntry(keetaSide(tokens.USDC), baseSide(EXTERNAL_IDS.USDC_BASE)) ]
+			}
+		});
+		const am3 = new TestChainAnchorServer({
+			...(DEBUG ? { logger } : {}),
+			client,
+			convert,
+			assetMovement: {
+				supportedAssets: [ pairEntry(baseSide(EXTERNAL_IDS.USDC_BASE), ethSide(EXTERNAL_IDS.USDC_ETH)) ]
+			}
+		});
+		const fx1 = new TestFXServer({
+			...(DEBUG ? { logger } : {}),
+			quoteSigner: KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0),
+			accounts: new KeetaNet.lib.Account.Set([ KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0) ]),
+			signer: KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0),
+			client,
+			giveTokens: async () => {},
+			fx: {
+				from: [{
+					currencyCodes: [ tokens.USDC.publicKeyString.get(), tokens.KTA.publicKeyString.get() ],
+					to: [ tokens.USDC.publicKeyString.get(), tokens.KTA.publicKeyString.get() ]
+				}]
+			}
+		});
+
+		await Promise.all([ am1.start(), am2.start(), am3.start(), fx1.start() ]);
+		fees.addFeeFreeAccount(client.account);
+
+		await client.setInfo({
+			description: 'Forwarding-only getPlans test',
+			name: 'TEST',
+			metadata: Resolver.Metadata.formatMetadata({
+				version: 1,
+				currencyMap: Object.fromEntries(Object.entries(tokens).map(([ sym, token ]) => [ `$${sym}`, token.publicKeyString.get() ])),
+				services: {
+					fx: { FX1: await fx1.serviceMetadata() },
+					assetMovement: {
+						AM1: await am1.serviceMetadata(),
+						AM2: await am2.serviceMetadata(),
+						AM3: await am3.serviceMetadata()
+					}
+				}
+			} satisfies ServiceMetadataExternalizable)
+		});
+
+		const anchorChaining = new AnchorChaining({
+			client,
+			resolver: new Resolver({ root: client.account, client, trustedCAs: [] })
+		});
+
+		return({
+			client,
+			tokens,
+			keetaLocation,
+			anchorChaining,
+			recipient: client.account.publicKeyString.get(),
+			[Symbol.asyncDispose]: async function() {
+				await am1[Symbol.asyncDispose]?.();
+				await am2[Symbol.asyncDispose]?.();
+				await am3[Symbol.asyncDispose]?.();
+				await fx1[Symbol.asyncDispose]?.();
+			}
+		});
+	}
+
+	test('returns a single-leg forwarding plan from base to keeta', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+
+		expect(plans).not.toBeNull();
+		const plan = plans?.[0];
+		if (!plan) {
+			throw(new Error('Expected a forwarding plan'));
+		}
+
+		expect(isForwardingPlan(plan)).toBe(true);
+		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded' ]);
+		expect(getForwardingDepositAddress(plan)).toEqual(expect.any(String));
+	});
+
+	test('returns a two-leg forwarding plan from ethereum to keeta', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_ETH, location: LOC.eth, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+
+		expect(plans).not.toBeNull();
+		const plan = plans?.[0];
+		if (!plan) {
+			throw(new Error('Expected a forwarding plan'));
+		}
+
+		expect(isForwardingPlan(plan)).toBe(true);
+		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'assetMovement', 'forwarded' ]);
+		expect(plan.plan.steps[0]?.type === 'assetMovement' && plan.plan.steps[0].sendingTo).toEqual('NEXT_STEP');
+		expect(getForwardingDepositAddress(plan)).toEqual(expect.any(String));
+	});
+
+	test('returns null for managed final-leg routes', async function() {
+		await using w = await buildForwardingWorld('managed');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+
+		expect(plans).toBeNull();
+	});
+
+	test('excludes Keeta-origin and FX routes', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const keetaSwapPlans = await w.anchorChaining.getPlans({
+			source: { asset: w.tokens.USDC, location: w.keetaLocation, value: 1000n, rail: 'KEETA_SEND' },
+			destination: { asset: w.tokens.USD, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+		expect(keetaSwapPlans).toBeNull();
+
+		const fxPlans = await w.anchorChaining.getPlans({
+			source: { asset: w.tokens.KTA, location: w.keetaLocation, value: 1000n, rail: 'KEETA_SEND' },
+			destination: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, recipient: w.recipient, rail: 'EVM_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+		expect(fxPlans).toBeNull();
+	});
+
+	test('excludes bank/fiat routes', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: w.tokens.EUR, location: w.keetaLocation, value: 1000n, rail: 'KEETA_SEND' },
+			destination: { asset: 'EUR', location: LOC.sepa, recipient: w.recipient, rail: 'SEPA_PUSH' }
+		}, { limit: 1, forwardingOnly: true });
+
+		expect(plans).toBeNull();
+	});
+
+	test('getPlans without forwardingOnly still returns managed plans', async function() {
+		await using w = await buildForwardingWorld('managed');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1 });
+
+		expect(plans).not.toBeNull();
+		expect(plans?.[0]?.plan.steps.map((s) => s.type)).toEqual([ 'assetMovement' ]);
+	});
+
+	test('isForwardingPath and isForwardingPlan helpers', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const paths = await w.anchorChaining.getPaths({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		});
+		const path = paths?.[0];
+		if (!path) {
+			throw(new Error('Expected path'));
+		}
+
+		expect(isForwardingPath(path)).toBe(true);
+		expect(isForwardingPath(path, { maxLegs: 0 })).toBe(false);
+
+		const plan = await AnchorChainingPlan.create(path);
+		expect(isForwardingPlan(plan)).toBe(true);
+
+		const managedWorld = await buildForwardingWorld('managed');
+		try {
+			const managedPaths = await managedWorld.anchorChaining.getPaths({
+				source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+				destination: { asset: managedWorld.tokens.USDC, location: managedWorld.keetaLocation, recipient: managedWorld.recipient, rail: 'KEETA_SEND' }
+			});
+			const managedPath = managedPaths?.[0];
+			if (!managedPath) {
+				throw(new Error('Expected managed path'));
+			}
+
+			const managedPlan = await AnchorChainingPlan.create(managedPath);
+			expect(isForwardingPlan(managedPlan)).toBe(false);
+		} finally {
+			await managedWorld[Symbol.asyncDispose]?.();
+		}
+	});
+
+	test('buildForwardingAdjacency and hasForwardingRoute', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const nodes = await w.anchorChaining.graph.computeGraphNodes();
+		const adjacency = buildForwardingAdjacency(nodes);
+
+		expect(hasForwardingRoute(
+			adjacency,
+			{ asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+			{ asset: w.tokens.USDC, location: w.keetaLocation }
+		)).toBe(true);
+
+		expect(hasForwardingRoute(
+			adjacency,
+			{ asset: EXTERNAL_IDS.USDC_ETH, location: LOC.eth },
+			{ asset: w.tokens.USDC, location: w.keetaLocation }
+		)).toBe(false);
+
+		const graphAdjacency = await w.anchorChaining.graph.buildForwardingAdjacency();
+		expect(graphAdjacency.size).toEqual(adjacency.size);
+	});
 });
 
 describe('Keeta-to-keeta swap chaining (persistent-forwarding regression)', function() {

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -14,6 +14,7 @@ import { KeetaAnchorUserError } from './error.js';
 import { AnchorExternal } from './anchor-external.js';
 import { BlockListener } from './block-listener.js';
 import type { AnchorMetadataLegalField } from './metadata.types.js';
+import type { KeetaAssetMovementAnchorProvider } from '../services/asset-movement/client.js';
 
 const DEBUG = false;
 const logger = DEBUG ? console : undefined;
@@ -3400,6 +3401,7 @@ describe('Persistent Forwarding chaining', function() {
 				continue;
 			}
 
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 			meta.asset = {
 				from: convertAssetSearchInputToCanonical(meta.asset.from).toLowerCase(),
 				to: convertAssetSearchInputToCanonical(meta.asset.to)
@@ -4059,11 +4061,12 @@ describe('getPlans forwardingOnly', function() {
 						to: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, rail: 'EVM_SEND' }
 					},
 					persistentAddress: { address: 'persistentForwarding-test', fees },
-					provider: null
+					// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+					provider: null as unknown as KeetaAssetMovementAnchorProvider
 				}],
 				totalValueIn: 1000n,
 				totalValueOut: 975n
-			} as unknown as Parameters<typeof listChainingPlanFees>[0]['plan']
+			}
 		});
 
 		const feeSum = listed.lineItems.reduce((sum, item) => sum + BigInt(item.value ?? 0), 0n);

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -85,6 +85,7 @@ function buildTxRecord(args: {
 	toLocation: KeetaAssetMovementTransaction['to']['location'];
 	fromValue: string;
 	toValue: string;
+	additionalTransferDetails?: KeetaAssetMovementTransaction['additionalTransferDetails'];
 }): KeetaAssetMovementTransaction {
 	const now = new Date().toISOString();
 	return({
@@ -95,7 +96,8 @@ function buildTxRecord(args: {
 		to:   { location: args.toLocation,   value: args.toValue,   transactions: { ...EMPTY_TO_TRANSACTIONS }},
 		fee: null,
 		createdAt: now,
-		updatedAt: now
+		updatedAt: now,
+		...(args.additionalTransferDetails !== undefined ? { additionalTransferDetails: args.additionalTransferDetails } : {})
 	});
 }
 
@@ -450,6 +452,7 @@ type PersistentForwardingBridgeAddressMeta = {
 	destinationLocation: AssetLocationLike;
 	destinationAddress: string;
 	asset: KeetaAssetMovementTransaction['asset'];
+	fees?: KeetaPersistentForwardingAddressDetails['fees'];
 };
 
 type TestPersistentForwardingBridgeServerConfig = Omit<KeetaAnchorAssetMovementServerConfig, 'assetMovement'> & {
@@ -520,6 +523,7 @@ class TestPersistentForwardingBridgeServer extends KeetaNetAssetMovementAnchorHT
 											...existing,
 											status: 'COMPLETE',
 											updatedAt: new Date().toISOString(),
+											additionalTransferDetails: { type: 'markdown', content: 'Bridge withdraw complete' },
 											to: {
 												...existing.to,
 												transactions: { withdraw: { id: withdrawTxId, nonce: '0' }}
@@ -542,7 +546,8 @@ class TestPersistentForwardingBridgeServer extends KeetaNetAssetMovementAnchorHT
 											fromLocation: convertAssetLocationToString(meta.sourceLocation),
 											toLocation: convertAssetLocationToString(meta.destinationLocation),
 											fromValue: value.toString(),
-											toValue: value.toString()
+											toValue: value.toString(),
+											additionalTransferDetails: { type: 'markdown', content: 'Forwarded leg complete' }
 										});
 										forwarded.from.transactions = {
 											...forwarded.from.transactions,
@@ -626,14 +631,15 @@ class TestPersistentForwardingBridgeServer extends KeetaNetAssetMovementAnchorHT
 
 					/* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
 					const evmTokenHex = tokenAddress.slice('evm:'.length) as `0x${string}`;
+					const fee = 25n;
 					return({
 						instructionChoices: [{
 							type: 'EVM_SEND' as const,
 							location: request.from.location,
 							value: value.toString(),
 							tokenAddress: evmTokenHex,
-							assetFee: '0',
-							totalReceiveAmount: value.toString()
+							assetFee: fee.toString(),
+							totalReceiveAmount: (value - fee).toString()
 						}]
 					});
 				},
@@ -673,7 +679,8 @@ class TestPersistentForwardingBridgeServer extends KeetaNetAssetMovementAnchorHT
 							asset: meta.asset,
 							sourceLocation: meta.sourceLocation,
 							destinationLocation: meta.destinationLocation,
-							destinationAddress: meta.destinationAddress
+							destinationAddress: meta.destinationAddress,
+							...(meta.fees !== undefined ? { fees: meta.fees } : {})
 						});
 					}
 
@@ -990,20 +997,32 @@ class TestChainAnchorServer extends KeetaNetAssetMovementAnchorHTTPServer {
 						throw(new KeetaAnchorUserError('Test anchor only supports string destinationAddress for persistent forwarding'));
 					}
 					const address = `persistentForwarding-${Math.random().toString(36).slice(2)}`;
+					const fees = {
+						lineItems: [ { purpose: 'RAIL' as const, value: '15' } ],
+						total: '15'
+					};
 					const meta: PersistentForwardingBridgeAddressMeta = {
 						sourceLocation: request.sourceLocation,
 						destinationLocation: request.destinationLocation,
 						destinationAddress: request.destinationAddress,
-						asset: request.asset
+						asset: request.asset,
+						fees
 					};
 					addresses.set(address, meta);
-					return({ address, asset: meta.asset, sourceLocation: meta.sourceLocation, destinationLocation: meta.destinationLocation, destinationAddress: meta.destinationAddress });
+					return({ address, asset: meta.asset, sourceLocation: meta.sourceLocation, destinationLocation: meta.destinationLocation, destinationAddress: meta.destinationAddress, fees });
 				},
 
 				async listPersistentForwarding(request) {
 					const all: KeetaPersistentForwardingAddressDetails[] = [];
 					for (const [address, meta] of addresses) {
-						all.push({ address, asset: meta.asset, sourceLocation: meta.sourceLocation, destinationLocation: meta.destinationLocation, destinationAddress: meta.destinationAddress });
+						all.push({
+							address,
+							asset: meta.asset,
+							sourceLocation: meta.sourceLocation,
+							destinationLocation: meta.destinationLocation,
+							destinationAddress: meta.destinationAddress,
+							...(meta.fees !== undefined ? { fees: meta.fees } : {})
+						});
 					}
 					let filtered = all;
 					const searches = request.search;
@@ -3340,7 +3359,17 @@ describe('Persistent Forwarding chaining', function() {
 
 		expect(forwardedResolved.persistentAddress.address).toEqual(persistentAddress);
 		expect(forwardedResolved.valueIn).toEqual(1000n);
-		expect(forwardedResolved.valueOut).toEqual(1000n);
+		expect(forwardedResolved.valueOut).toEqual(975n);
+		expect(forwardedResolved.simulatedTransfer).toBeDefined();
+		expect(forwardedResolved.simulatedTransfer?.isSimulation).toBe(true);
+
+		const fees = plan.listFees();
+		const forwardedFees = fees.lineItems.filter((item) => item.metadata.stepIndex === 1);
+		expect(forwardedFees).toHaveLength(1);
+		expect(forwardedFees[0]?.value).toEqual('25');
+		expect(forwardedFees[0]?.metadata.source).toEqual('simulatedTransfer');
+		expect(forwardedFees[0]?.asset).toBeDefined();
+		expect('total' in fees).toBe(false);
 	});
 
 	test('plan reuses an existing persistent forwarding address when present', async function() {
@@ -3366,6 +3395,20 @@ describe('Persistent Forwarding chaining', function() {
 		const path = await getKeetaUsdcToUsdc2Path(h, 1000n, destinationAccount);
 
 		const plan = await AnchorChainingPlan.create(path);
+
+		const observedTransactions: {
+			stepIndex: number;
+			source: 'getTransferStatus' | 'listTransactions';
+			additionalTransferDetails?: KeetaAssetMovementTransaction['additionalTransferDetails'];
+		}[] = [];
+		plan.on('transactionObserved', (payload) => {
+			observedTransactions.push({
+				stepIndex: payload.stepIndex,
+				source: payload.source,
+				additionalTransferDetails: payload.transaction.additionalTransferDetails
+			});
+		});
+
 		const result = await plan.execute();
 		expect(result.steps).toHaveLength(2);
 
@@ -3382,6 +3425,9 @@ describe('Persistent Forwarding chaining', function() {
 		expect(forwardedExecuted.observedTransaction.status).toEqual('COMPLETE');
 		expect(forwardedExecuted.observedTransaction.from.value).toEqual('1000');
 		expect(forwardedExecuted.observedTransaction.to.location).toEqual(h.keetaLocation);
+
+		expect(observedTransactions.some((item) => item.stepIndex === 0 && item.source === 'getTransferStatus' && item.additionalTransferDetails?.content === 'Bridge withdraw complete')).toBe(true);
+		expect(observedTransactions.some((item) => item.stepIndex === 1 && item.source === 'listTransactions' && item.additionalTransferDetails?.content === 'Forwarded leg complete')).toBe(true);
 
 		expect(plan.state.status).toEqual('completed');
 	});
@@ -4121,6 +4167,29 @@ describe('getPlans forwardingOnly', function() {
 		expect(plan.plan.steps.map((s) => s.type)).toEqual([ 'forwarded' ]);
 		expect(plan.getDepositAddress()).toEqual(expect.any(String));
 		expect(getForwardingDepositAddress(plan)).toEqual(plan.getDepositAddress());
+	});
+
+	test('listFees returns persistent address fees for forwarding-only plans', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: true });
+
+		const plan = plans?.[0];
+		if (!plan) {
+			throw(new Error('Expected a forwarding plan'));
+		}
+
+		const fees = plan.listFees();
+		expect(fees.lineItems).toHaveLength(1);
+		expect(fees.lineItems[0]?.value).toEqual('15');
+		expect(fees.lineItems[0]?.metadata.source).toEqual('persistentAddress');
+		expect(fees.lineItems[0]?.metadata.stepType).toEqual('forwarded');
+		expect(fees.lineItems[0]?.asset).toEqual(EXTERNAL_IDS.USDC_BASE);
+		expect('total' in fees).toBe(false);
+		expect(plan.plan.steps[0]?.valueOut).toEqual(985n);
 	});
 
 	test('returns a two-leg forwarding plan from ethereum to keeta', async function() {

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1582,13 +1582,8 @@ export type AnchorChainingFeeLineItemSource =
 
 export type AnchorChainingFeeLineItemMetadata = {
 	stepIndex: number;
-	stepType: 'fx' | 'assetMovement' | 'forwarded';
-	providerID?: string;
+	step: Exclude<ChainStepResolution, { type: 'keetaSend' }>;
 	source: AnchorChainingFeeLineItemSource;
-	valueIn: bigint;
-	valueOut: bigint;
-	estimateMin?: bigint;
-	estimateMax?: bigint;
 };
 
 export type AnchorChainingFeeLineItem = {
@@ -1608,21 +1603,6 @@ export type AnchorChainingPlanFeeBreakdown = {
 /** List combined fees for a computed chaining plan. Keeta-send steps are omitted (treated as zero). */
 export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPlan }): AnchorChainingPlanFeeBreakdown {
 	const lineItems: AnchorChainingFeeLineItem[] = [];
-
-	const buildMetadata = (
-		step: Exclude<ChainStepResolution, { type: 'keetaSend' }>,
-		stepIndex: number,
-		source: AnchorChainingFeeLineItemSource,
-		extras?: Pick<AnchorChainingFeeLineItemMetadata, 'estimateMin' | 'estimateMax'>
-	): AnchorChainingFeeLineItemMetadata => ({
-		stepIndex,
-		stepType: step.type,
-		providerID: step.step.providerID,
-		source,
-		valueIn: step.valueIn,
-		valueOut: step.valueOut,
-		...extras
-	});
 
 	const defaultFeeAsset = (step: Exclude<ChainStepResolution, { type: 'keetaSend' }>): MovableAssetSearchCanonical => {
 		if (step.type === 'fx') {
@@ -1647,8 +1627,8 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[] },
 			source: AnchorChainingFeeLineItemSource
 		) => {
-			const metadata = buildMetadata(step, stepIndex, source);
 			const stepDefaultAsset = defaultFeeAsset(step);
+			const metadata = { stepIndex, step, source };
 
 			for (const item of breakdown.lineItems) {
 				const asset = item.asset ?? stepDefaultAsset;
@@ -1687,7 +1667,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 					purpose: 'OTHER',
 					asset: defaultFeeAsset(step),
 					value: assetFee,
-					metadata: buildMetadata(step, stepIndex, source)
+					metadata: { stepIndex, step, source }
 				});
 				return;
 			}
@@ -1701,17 +1681,14 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 					purpose: 'PROVIDER',
 					asset: step.result.quote.cost.token.publicKeyString.get(),
 					value: step.result.quote.cost.amount.toString(),
-					metadata: buildMetadata(step, stepIndex, 'fxQuote')
+					metadata: { stepIndex, step, source: 'fxQuote' }
 				});
 			} else {
 				lineItems.push({
 					purpose: 'PROVIDER',
 					asset: step.result.estimate.expectedCost.token.publicKeyString.get(),
 					value: step.result.estimate.expectedCost.max.toString(),
-					metadata: buildMetadata(step, stepIndex, 'fxEstimate', {
-						estimateMin: step.result.estimate.expectedCost.min,
-						estimateMax: step.result.estimate.expectedCost.max
-					})
+					metadata: { stepIndex, step, source: 'fxEstimate' }
 				});
 			}
 
@@ -1741,7 +1718,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 				purpose: 'OTHER',
 				asset: defaultFeeAsset(step),
 				value: (step.valueIn - step.valueOut).toString(),
-				metadata: buildMetadata(step, stepIndex, 'persistentAddress')
+				metadata: { stepIndex, step, source: 'persistentAddress' }
 			});
 		}
 	}

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,6 +1,6 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
-import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, SimulatedAssetTransferInstructions } from "../services/asset-movement/common.js";
+import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
 import { convertAssetLocationToString, convertAssetSearchInputToCanonical, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
@@ -19,6 +19,7 @@ import type { Logger } from './log/index.js';
 import type { BlockHash } from '@keetanetwork/keetanet-client/lib/block/index.js';
 import type { AnchorExternalInput } from './anchor-external.js';
 import type { AnchorMetadataLegalField } from './metadata.types.js';
+import type { ClientRenderableContent } from './metadata.types.js';
 import { AnchorExternalBuilder } from './anchor-external.js';
 
 type FXQuoteOrEstimate = NonNullable<Awaited<ReturnType<KeetaFXAnchorClient['getQuotesOrEstimates']>>>[number];
@@ -56,6 +57,8 @@ interface ChainStepResolutionKeetaSend extends ChainStepResolutionBase<'keetaSen
 interface ChainStepResolutionForwarded extends ChainStepResolutionBase<'forwarded'> {
 	persistentAddress: KeetaPersistentForwardingAddressDetails;
 	provider: AssetMovementProvider;
+	/** Present when simulateTransfer succeeded during plan computation (non-forwardingOnly). */
+	simulatedTransfer?: Awaited<ReturnType<AssetMovementProvider['simulateTransfer']>>;
 };
 
 export type Disclaimer = Exclude<AnchorMetadataLegalField['disclaimers'], undefined>[number];
@@ -140,7 +143,17 @@ type AnchorChainingPathEventMap = {
 	completed: [result: AnchorChainingPathExecuteResult];
 	failed: [error: Error, completedSteps: ExecutedStep[], failedAtStepIndex: number];
 	stepNeedsAction: [StepNeededActionEventPayload];
+	transactionObserved: [payload: AnchorChainingTransactionObservedEvent];
 }
+
+export type AnchorChainingTransactionObservedSource = 'getTransferStatus' | 'listTransactions';
+
+export type AnchorChainingTransactionObservedEvent = {
+	stepIndex: number;
+	planStep: ChainStepResolution;
+	transaction: KeetaAssetMovementTransaction;
+	source: AnchorChainingTransactionObservedSource;
+};
 
 interface RailSupportedOperations {
 	createPersistentForwarding?: boolean;
@@ -1527,11 +1540,7 @@ export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingO
 	}));
 }
 
-function estimateValueOutFromPersistentForwardingFees(valueIn: bigint, fees?: PersistentAddressAssetFeeBreakdown): bigint {
-	if (!fees) {
-		return(valueIn);
-	}
-
+function computeFeeTotalFromBreakdown(valueIn: bigint, fees: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string }): bigint {
 	let feeFromLineItems = 0n;
 
 	for (const lineItem of fees.lineItems) {
@@ -1547,13 +1556,197 @@ function estimateValueOutFromPersistentForwardingFees(valueIn: bigint, fees?: Pe
 		feeTotal = BigInt(fees.total);
 	}
 
-	const valueOut = valueIn - feeTotal;
+	return(feeTotal);
+}
+
+function estimateValueOutFromPersistentForwardingFees(valueIn: bigint, fees?: PersistentAddressAssetFeeBreakdown): bigint {
+	if (!fees) {
+		return(valueIn);
+	}
+
+	const valueOut = valueIn - computeFeeTotalFromBreakdown(valueIn, fees);
 	return(valueOut < 1n ? 1n : valueOut);
 }
 
 /** @internal Exported for unit tests. */
 export function estimateForwardingValueOut(valueIn: bigint, fees?: PersistentAddressAssetFeeBreakdown): bigint {
 	return(estimateValueOutFromPersistentForwardingFees(valueIn, fees));
+}
+
+export type AnchorChainingFeeLineItemSource =
+	| 'persistentAddress'
+	| 'simulatedTransfer'
+	| 'transferInstruction'
+	| 'fxQuote'
+	| 'fxEstimate';
+
+export type AnchorChainingFeeLineItemMetadata = {
+	stepIndex: number;
+	stepType: 'fx' | 'assetMovement' | 'forwarded';
+	providerID?: string;
+	source: AnchorChainingFeeLineItemSource;
+	valueIn: bigint;
+	valueOut: bigint;
+	estimateMin?: bigint;
+	estimateMax?: bigint;
+};
+
+export type AnchorChainingFeeLineItem = {
+	purpose: AssetFeeLineItemType;
+	asset: MovableAssetSearchCanonical;
+	value?: string;
+	basisPoints?: number;
+	details?: ClientRenderableContent;
+	metadata: AnchorChainingFeeLineItemMetadata;
+};
+
+/** Combined fee breakdown for a computed chaining plan. Does not include a total. */
+export type AnchorChainingPlanFeeBreakdown = {
+	lineItems: AnchorChainingFeeLineItem[];
+};
+
+/** List combined fees for a computed chaining plan. Keeta-send steps are omitted (treated as zero). */
+export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPlan }): AnchorChainingPlanFeeBreakdown {
+	const lineItems: AnchorChainingFeeLineItem[] = [];
+
+	const buildMetadata = (
+		step: Exclude<ChainStepResolution, { type: 'keetaSend' }>,
+		stepIndex: number,
+		source: AnchorChainingFeeLineItemSource,
+		extras?: Pick<AnchorChainingFeeLineItemMetadata, 'estimateMin' | 'estimateMax'>
+	): AnchorChainingFeeLineItemMetadata => ({
+		stepIndex,
+		stepType: step.type,
+		providerID: step.step.providerID,
+		source,
+		valueIn: step.valueIn,
+		valueOut: step.valueOut,
+		...extras
+	});
+
+	const defaultFeeAsset = (step: Exclude<ChainStepResolution, { type: 'keetaSend' }>): MovableAssetSearchCanonical => {
+		if (step.type === 'fx') {
+			const token = step.result.isQuote ? step.result.quote.cost.token : step.result.estimate.expectedCost.token;
+			return(token.publicKeyString.get());
+		}
+
+		if (KeetaNet.lib.Account.isInstance(step.step.from.asset)) {
+			return(step.step.from.asset.publicKeyString.get());
+		}
+
+		return(step.step.from.asset);
+	};
+
+	for (let stepIndex = 0; stepIndex < plan.plan.steps.length; stepIndex++) {
+		const step = plan.plan.steps[stepIndex];
+		if (!step || step.type === 'keetaSend') {
+			continue;
+		}
+
+		const appendBreakdown = (
+			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[] },
+			source: AnchorChainingFeeLineItemSource
+		) => {
+			const metadata = buildMetadata(step, stepIndex, source);
+			const stepDefaultAsset = defaultFeeAsset(step);
+
+			for (const item of breakdown.lineItems) {
+				const asset = item.asset ?? stepDefaultAsset;
+				const base = {
+					purpose: item.purpose,
+					asset,
+					metadata,
+					...(item.details !== undefined ? { details: item.details } : {})
+				};
+
+				if ('value' in item && item.value !== undefined && item.value !== '') {
+					lineItems.push({
+						...base,
+						value: item.value,
+						...(item.purpose === 'VALUE_VARIABLE' && 'basisPoints' in item && item.basisPoints !== undefined ? { basisPoints: item.basisPoints } : {})
+					});
+					continue;
+				}
+
+				if (item.purpose === 'VALUE_VARIABLE' && 'basisPoints' in item && item.basisPoints !== undefined) {
+					lineItems.push({
+						...base,
+						basisPoints: item.basisPoints,
+						value: (step.valueIn * BigInt(item.basisPoints) / 10000n).toString()
+					});
+				}
+			}
+		};
+
+		const appendAssetFee = (
+			assetFee: string | AssetFeeBreakdown | PersistentAddressAssetFeeBreakdown,
+			source: AnchorChainingFeeLineItemSource
+		) => {
+			if (typeof assetFee === 'string') {
+				lineItems.push({
+					purpose: 'OTHER',
+					asset: defaultFeeAsset(step),
+					value: assetFee,
+					metadata: buildMetadata(step, stepIndex, source)
+				});
+				return;
+			}
+
+			appendBreakdown(assetFee, source);
+		};
+
+		if (step.type === 'fx') {
+			if (step.result.isQuote) {
+				lineItems.push({
+					purpose: 'PROVIDER',
+					asset: step.result.quote.cost.token.publicKeyString.get(),
+					value: step.result.quote.cost.amount.toString(),
+					metadata: buildMetadata(step, stepIndex, 'fxQuote')
+				});
+			} else {
+				lineItems.push({
+					purpose: 'PROVIDER',
+					asset: step.result.estimate.expectedCost.token.publicKeyString.get(),
+					value: step.result.estimate.expectedCost.max.toString(),
+					metadata: buildMetadata(step, stepIndex, 'fxEstimate', {
+						estimateMin: step.result.estimate.expectedCost.min,
+						estimateMax: step.result.estimate.expectedCost.max
+					})
+				});
+			}
+
+			continue;
+		}
+
+		if (step.type === 'assetMovement') {
+			appendAssetFee(step.usingInstruction.assetFee, 'transferInstruction');
+			continue;
+		}
+
+		if (step.simulatedTransfer) {
+			const simulatedInstruction = step.simulatedTransfer.instructions.find((instr) => instr.type === step.step.from.rail);
+			if (simulatedInstruction && 'assetFee' in simulatedInstruction) {
+				appendAssetFee(simulatedInstruction.assetFee, 'simulatedTransfer');
+				continue;
+			}
+		}
+
+		if (step.persistentAddress.fees) {
+			appendBreakdown(step.persistentAddress.fees, 'persistentAddress');
+			continue;
+		}
+
+		if (step.valueIn > step.valueOut) {
+			lineItems.push({
+				purpose: 'OTHER',
+				asset: defaultFeeAsset(step),
+				value: (step.valueIn - step.valueOut).toString(),
+				metadata: buildMetadata(step, stepIndex, 'persistentAddress')
+			});
+		}
+	}
+
+	return({ lineItems });
 }
 
 /**
@@ -1701,6 +1894,10 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		}
 
 		return(this.#_plan);
+	}
+
+	listFees(): AnchorChainingPlanFeeBreakdown {
+		return(listChainingPlanFees(this));
 	}
 
 	async #computePlan() {
@@ -2038,6 +2235,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 							const { provider: forwardedProvider, persistentAddress } = forwardedInfo;
 
 							let estimatedValueOut = depositValue;
+							let simulatedTransfer: Awaited<ReturnType<typeof forwardedProvider.simulateTransfer>> | undefined;
 							if (forwardingOnly) {
 								estimatedValueOut = estimateValueOutFromPersistentForwardingFees(depositValue, persistentAddress.fees);
 							} else if (await forwardedProvider.isOperationSupported('simulateTransfer')) {
@@ -2047,7 +2245,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 										providerMethod: 'initiateTransfer',
 										provider: forwardedProvider
 									}, this.#options?.overrides);
-									const simulated = await forwardedProvider.simulateTransfer({
+									simulatedTransfer = await forwardedProvider.simulateTransfer({
 										account: forwardedSigner,
 										asset: assetPair,
 										from: { location: step.from.location },
@@ -2055,7 +2253,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 										value: depositValue
 									});
 
-									const simulatedInstruction = simulated.instructions.find((instr): instr is Extract<SimulatedAssetTransferInstructions, { type: typeof step.from.rail }> => instr.type === step.from.rail);
+									const simulatedInstruction = simulatedTransfer.instructions.find((instr): instr is Extract<SimulatedAssetTransferInstructions, { type: typeof step.from.rail }> => instr.type === step.from.rail);
 									let simulatedTotalReceive: string | undefined;
 									if (simulatedInstruction) {
 										simulatedTotalReceive = simulatedInstruction.totalReceiveAmount;
@@ -2077,7 +2275,8 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 								valueIn: depositValue,
 								valueOut: estimatedValueOut,
 								persistentAddress,
-								provider: forwardedProvider
+								provider: forwardedProvider,
+								...(simulatedTransfer !== undefined ? { simulatedTransfer } : {})
 							});
 						}
 
@@ -2498,6 +2697,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 
 	async #pollTransferStatus(
 		transfer: AssetMovementTransfer,
+		context: { stepIndex: number; planStep: ChainStepResolution },
 		options?: { intervalMs?: number; timeoutMs?: number; abortSignal?: AbortSignal; }
 	): Promise<Awaited<ReturnType<AssetMovementTransfer['getTransferStatus']>>> {
 		const intervalMs = options?.intervalMs ?? 2000;
@@ -2510,6 +2710,13 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 			}
 
 			const status = await transfer.getTransferStatus();
+			this.#emit('transactionObserved', {
+				stepIndex: context.stepIndex,
+				planStep: context.planStep,
+				transaction: status.transaction,
+				source: 'getTransferStatus'
+			});
+
 			if (status.transaction.status === 'COMPLETE') {
 				return(status);
 			}
@@ -2527,6 +2734,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 	async #pollForwardedTransaction(
 		step: ChainStepResolutionForwarded,
 		sourceTransaction: { location: AssetLocationLike; transaction: { id: string }},
+		context: { stepIndex: number; planStep: ChainStepResolution },
 		options?: { intervalMs?: number; timeoutMs?: number; abortSignal?: AbortSignal; }
 	): Promise<KeetaAssetMovementTransaction> {
 		const intervalMs = options?.intervalMs ?? 2000;
@@ -2564,6 +2772,15 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 				transactions = response.transactions;
 			} catch (error) {
 				this.logger?.debug('AnchorChainingPlan::pollForwardedTransaction', `listTransactions failed for PersistentForwardingRelay address ${pfiAddress}`, error);
+			}
+
+			for (const transaction of transactions) {
+				this.#emit('transactionObserved', {
+					stepIndex: context.stepIndex,
+					planStep: context.planStep,
+					transaction,
+					source: 'listTransactions'
+				});
 			}
 
 			const candidate = transactions.find(tx => tx.status === 'COMPLETE');
@@ -2658,6 +2875,8 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 					throw(new Error(`Step ${index} is not defined`));
 				}
 
+				const pollContext = { stepIndex: index, planStep: step };
+
 				// Verify the actual output from the previous step matches the expected
 				// input for this step. A mismatch indicates a provider delivered a
 				// different amount than was negotiated in computeSteps.
@@ -2685,7 +2904,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 						throw(new Error(`Forwarded step at index ${index} requires the prior step to produce a withdraw transaction on its destination chain`));
 					}
 
-					const observed = await this.#pollForwardedTransaction(step, prevWithdrawTx, {
+					const observed = await this.#pollForwardedTransaction(step, prevWithdrawTx, pollContext, {
 						...(options?.abortSignal ? { abortSignal: options.abortSignal } : {})
 					});
 					prevActualValueOut = BigInt(observed.to.value);
@@ -2732,7 +2951,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 					}
 
 					if (step.type === 'assetMovement') {
-						const status = await this.#pollTransferStatus(step.transfer,  {
+						const status = await this.#pollTransferStatus(step.transfer, pollContext, {
 							...(options?.abortSignal ? { abortSignal: options.abortSignal } : {})
 						});
 						prevActualValueOut = BigInt(status.transaction.to.value);
@@ -2814,6 +3033,10 @@ export class AnchorChainingForwardingOnlyPlan extends AnchorChainingPath {
 
 	getDepositAddress(): string | null {
 		return(getForwardingDepositAddress(this));
+	}
+
+	listFees(): AnchorChainingPlanFeeBreakdown {
+		return(listChainingPlanFees(this));
 	}
 
 	static async create(path: AnchorChainingPath, options?: ComputePlanOptions): Promise<AnchorChainingForwardingOnlyPlan> {

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,6 +1,6 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
-import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, SimulatedAssetTransferInstructions } from "../services/asset-movement/common.js";
+import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, SimulatedAssetTransferInstructions } from "../services/asset-movement/common.js";
 import { convertAssetLocationToString, convertAssetSearchInputToCanonical, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
@@ -1452,6 +1452,11 @@ export interface ComputePlanOptions {
 	 * Limit the number of plans to calculate, defaults to 3
 	 */
 	limit?: number;
+	/**
+	 * When true, plan computation uses persistent forwarding for the final leg
+	 * instead of initiateTransfer, even when the source rail supports both.
+	 */
+	forwardingOnly?: boolean;
 }
 
 export type ForwardingOnlyOptions = {
@@ -1459,7 +1464,7 @@ export type ForwardingOnlyOptions = {
 	maxLegs?: number;
 };
 
-export interface GetPlansOptions extends ComputePlanOptions {
+export interface GetPlansOptions extends Omit<ComputePlanOptions, 'forwardingOnly'> {
 	includeAllOutput?: boolean;
 	forwardingOnly?: boolean | ForwardingOnlyOptions;
 }
@@ -1476,6 +1481,20 @@ function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnly
 	return({
 		maxLegs: DEFAULT_FORWARDING_MAX_LEGS,
 		...forwardingOnly
+	});
+}
+
+function toComputePlanOptions(options?: GetPlansOptions, forwardingOpts?: ForwardingOnlyOptions): ComputePlanOptions | undefined {
+	const overrides = options?.overrides;
+	const forwardingOnly = forwardingOpts !== undefined;
+
+	if (overrides === undefined && !forwardingOnly) {
+		return(undefined);
+	}
+
+	return({
+		...(overrides !== undefined ? { overrides } : {}),
+		...(forwardingOnly ? { forwardingOnly: true } : {})
 	});
 }
 
@@ -1500,8 +1519,36 @@ export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingO
 			return(false);
 		}
 
-		return(!isChainLocation(toAssetLocation(step.from.location), 'keeta'));
+		if (isChainLocation(toAssetLocation(step.from.location), 'keeta')) {
+			return(false);
+		}
+
+		return(step.from.supportedOperations?.createPersistentForwarding === true);
 	}));
+}
+
+function estimateValueOutFromPersistentForwardingFees(valueIn: bigint, fees?: PersistentAddressAssetFeeBreakdown): bigint {
+	if (!fees) {
+		return(valueIn);
+	}
+
+	let feeTotal = 0n;
+
+	for (const lineItem of fees.lineItems) {
+		if (lineItem.purpose === 'VALUE_VARIABLE' && lineItem.basisPoints !== undefined) {
+			feeTotal += valueIn * BigInt(lineItem.basisPoints) / 10000n;
+		}
+	}
+
+	if (fees.total !== undefined && fees.total !== '') {
+		const declaredTotal = BigInt(fees.total);
+		if (declaredTotal > feeTotal) {
+			feeTotal = declaredTotal;
+		}
+	}
+
+	const valueOut = valueIn - feeTotal;
+	return(valueOut < 1n ? 1n : valueOut);
 }
 
 /**
@@ -1515,54 +1562,19 @@ export function isForwardingPlan(plan: AnchorChainingPlan): boolean {
 		return(false);
 	}
 
-	for (const step of steps) {
-		if (step.type === 'fx' || step.type === 'keetaSend') {
-			return(false);
-		}
-
-		if (step.type === 'assetMovement' && step.sendingTo === 'SELF') {
-			return(false);
-		}
-	}
-
-	const last = steps[steps.length - 1];
-	if (last?.type !== 'forwarded') {
-		return(false);
-	}
-
-	for (let i = 0; i < steps.length - 1; i++) {
-		const step = steps[i];
-		if (step?.type !== 'assetMovement' || step.sendingTo !== 'NEXT_STEP') {
-			return(false);
-		}
-	}
-
-	return(true);
+	return(steps.every((step) => step.type === 'forwarded'));
 }
 
 /** Deposit address for the first forwarding leg of a forwarding-only plan. */
 export function getForwardingDepositAddress(plan: AnchorChainingPlan): string | null {
 	const firstStep = plan.plan.steps[0];
 
-	if (!firstStep) {
+	if (!firstStep || firstStep.type !== 'forwarded') {
 		return(null);
 	}
 
-	if (firstStep.type === 'assetMovement') {
-		const instruction = firstStep.usingInstruction;
-		if ('sendToAddress' in instruction && typeof instruction.sendToAddress === 'string') {
-			return(instruction.sendToAddress);
-		}
-
-		return(null);
-	}
-
-	if (firstStep.type === 'forwarded') {
-		const address = firstStep.persistentAddress.address;
-		return(typeof address === 'string' ? address : null);
-	}
-
-	return(null);
+	const address = firstStep.persistentAddress.address;
+	return(typeof address === 'string' ? address : null);
 }
 
 export class AnchorChainingPath {
@@ -1738,7 +1750,132 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 		 */
 		type ForwardedStepInfo = { provider: AssetMovementProvider; persistentAddress: KeetaPersistentForwardingAddressDetails };
 		const forwardedSteps = new Map<number, ForwardedStepInfo>();
+		const forwardingOnly = this.#options?.forwardingOnly === true;
+
+		const resolvePersistentForwardingForStep = async (scanIndex: number, destinationAddress: string): Promise<void> => {
+			const scanStep = this.path[scanIndex];
+			if (!scanStep || scanStep.type !== 'assetMovement') {
+				throw(new Error(`Expected asset movement step at index ${scanIndex} for persistent forwarding`));
+			}
+
+			const forwardedAssetPair = { from: scanStep.from.asset, to: scanStep.to.asset };
+			const forwardedProviders = await assetMovementClient.getProvidersForTransfer(
+				{ asset: forwardedAssetPair, from: scanStep.from.location, to: scanStep.to.location },
+				{ providerIDs: [ scanStep.providerID ] }
+			);
+			if (!forwardedProviders?.[0] || forwardedProviders.length === 0) {
+				throw(new Error(`Could not get asset movement provider ${scanStep.providerID} for persistent-forwarding step at index ${scanIndex}`));
+			}
+
+			const forwardedProvider = forwardedProviders[0];
+			if (!await forwardedProvider.isOperationSupported('createPersistentForwarding')) {
+				throw(new Error(`Asset movement provider ${scanStep.providerID} does not support createPersistentForwarding, but the source rail ${scanStep.from.rail} at ${convertAssetLocationToString(scanStep.from.location)} requires it (initiateTransfer is unsupported)`));
+			}
+			if (!forwardingOnly && !await forwardedProvider.isOperationSupported('simulateTransfer')) {
+				throw(new Error(`Asset movement provider ${scanStep.providerID} does not support simulateTransfer, which is required to compute valueOut for a persistent-forwarding step at ${convertAssetLocationToString(scanStep.from.location)}`));
+			}
+
+			const { signer: forwardedSigner } = await this.getAccountsForAction({
+				type: 'assetMovement',
+				providerMethod: 'initiateTransfer',
+				provider: forwardedProvider
+			}, this.#options?.overrides);
+
+			let persistentAddress: KeetaPersistentForwardingAddressDetails | undefined;
+			if (await forwardedProvider.isOperationSupported('listPersistentForwarding')) {
+				try {
+					const existing = await forwardedProvider.listForwardingAddresses({
+						account: forwardedSigner,
+						search: [{
+							sourceLocation: scanStep.from.location,
+							destinationLocation: scanStep.to.location,
+							asset: scanStep.from.asset,
+							destinationAddress
+						}]
+					});
+
+					const sourceLocationString = convertAssetLocationToString(scanStep.from.location);
+					const destLocationString = convertAssetLocationToString(scanStep.to.location);
+					const match = existing.addresses.find(addr => {
+						if (addr.destinationAddress !== destinationAddress) {
+							return(false);
+						}
+						if (!addr.sourceLocation || convertAssetLocationToString(addr.sourceLocation) !== sourceLocationString) {
+							return(false);
+						}
+						if (!addr.destinationLocation || convertAssetLocationToString(addr.destinationLocation) !== destLocationString) {
+							return(false);
+						}
+
+						return(true);
+					});
+					if (match) {
+						persistentAddress = match;
+					}
+				} catch (error) {
+					this.logger?.debug('AnchorChainingPlan::computePlan', `listForwardingAddresses lookup failed for step ${scanIndex}, will create a new address`, error);
+				}
+			}
+
+			if (!persistentAddress) {
+				persistentAddress = await forwardedProvider.createPersistentForwardingAddress({
+					account: forwardedSigner,
+					sourceLocation: scanStep.from.location,
+					destinationLocation: scanStep.to.location,
+					destinationAddress,
+					asset: forwardedAssetPair
+				});
+			}
+
+			if (typeof persistentAddress.address !== 'string') {
+				throw(new Error(`Persistent forwarding address for step ${scanIndex} is not a resolved string (got ${typeof persistentAddress.address})`));
+			}
+
+			forwardedSteps.set(scanIndex, { provider: forwardedProvider, persistentAddress });
+		};
+
+		if (forwardingOnly) {
+			for (let scanIndex = this.path.length - 1; scanIndex >= 0; scanIndex--) {
+				const scanStep = this.path[scanIndex];
+				if (!scanStep || scanStep.type !== 'assetMovement') {
+					continue;
+				}
+
+				const pfrSupported = scanStep.from.supportedOperations?.createPersistentForwarding === true;
+				const sourceIsKeeta = isChainLocation(toAssetLocation(scanStep.from.location), 'keeta');
+
+				if (sourceIsKeeta || !pfrSupported) {
+					throw(new Error(`Forwarding-only plan requires persistent forwarding support on every leg, but step ${scanIndex} at ${convertAssetLocationToString(scanStep.from.location)} does not qualify`));
+				}
+
+				let destinationAddress: string;
+				if (scanIndex === this.path.length - 1) {
+					const finalRecipient = this.request.destination.recipient;
+					if (typeof finalRecipient !== 'string') {
+						throw(new Error(`Forwarding-only plan requires the destination recipient to be a resolved address string`));
+					}
+					destinationAddress = finalRecipient;
+				} else {
+					const nextForwarded = forwardedSteps.get(scanIndex + 1);
+					if (!nextForwarded) {
+						throw(new Error(`Forwarding-only plan expected persistent forwarding to be resolved for next step ${scanIndex + 1}`));
+					}
+					const nextAddress = nextForwarded.persistentAddress.address;
+					if (typeof nextAddress !== 'string') {
+						throw(new Error(`Forwarding-only plan requires the next step persistent forwarding address to be a resolved string at index ${scanIndex + 1}`));
+					}
+					destinationAddress = nextAddress;
+				}
+
+				await resolvePersistentForwardingForStep(scanIndex, destinationAddress);
+			}
+		}
+
 		for (let scanIndex = 0; scanIndex < this.path.length; scanIndex++) {
+			if (forwardingOnly) {
+				continue;
+			}
+
 			const scanStep = this.path[scanIndex];
 			if (!scanStep || scanStep.type !== 'assetMovement') {
 				continue;
@@ -1783,83 +1920,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 				throw(new Error(`Persistent-forwarding step at index ${scanIndex} requires the chain's destination recipient to be a resolved address string`));
 			}
 
-			const forwardedAssetPair = { from: scanStep.from.asset, to: scanStep.to.asset };
-			const forwardedProviders = await assetMovementClient.getProvidersForTransfer(
-				{ asset: forwardedAssetPair, from: scanStep.from.location, to: scanStep.to.location },
-				{ providerIDs: [ scanStep.providerID ] }
-			);
-			if (!forwardedProviders?.[0] || forwardedProviders.length === 0) {
-				throw(new Error(`Could not get asset movement provider ${scanStep.providerID} for persistent-forwarding step at index ${scanIndex}`));
-			}
-
-			const forwardedProvider = forwardedProviders[0];
-			if (!await forwardedProvider.isOperationSupported('createPersistentForwarding')) {
-				throw(new Error(`Asset movement provider ${scanStep.providerID} does not support createPersistentForwarding, but the source rail ${scanStep.from.rail} at ${convertAssetLocationToString(scanStep.from.location)} requires it (initiateTransfer is unsupported)`));
-			}
-			if (!await forwardedProvider.isOperationSupported('simulateTransfer')) {
-				throw(new Error(`Asset movement provider ${scanStep.providerID} does not support simulateTransfer, which is required to compute valueOut for a persistent-forwarding step at ${convertAssetLocationToString(scanStep.from.location)}`));
-			}
-
-			const { signer: forwardedSigner } = await this.getAccountsForAction({
-				type: 'assetMovement',
-				providerMethod: 'initiateTransfer',
-				provider: forwardedProvider
-			}, this.#options?.overrides);
-
-			let persistentAddress: KeetaPersistentForwardingAddressDetails | undefined;
-			if (await forwardedProvider.isOperationSupported('listPersistentForwarding')) {
-				try {
-					const existing = await forwardedProvider.listForwardingAddresses({
-						account: forwardedSigner,
-						search: [{
-							sourceLocation: scanStep.from.location,
-							destinationLocation: scanStep.to.location,
-							asset: scanStep.from.asset,
-							destinationAddress
-						}]
-					});
-
-					/*
-					 * Filter to the exact address this step requires.
-					 */
-					const sourceLocationString = convertAssetLocationToString(scanStep.from.location);
-					const destLocationString = convertAssetLocationToString(scanStep.to.location);
-					const match = existing.addresses.find(addr => {
-						if (addr.destinationAddress !== destinationAddress) {
-							return(false);
-						}
-						if (!addr.sourceLocation || convertAssetLocationToString(addr.sourceLocation) !== sourceLocationString) {
-							return(false);
-						}
-						if (!addr.destinationLocation || convertAssetLocationToString(addr.destinationLocation) !== destLocationString) {
-							return(false);
-						}
-
-						return(true);
-					});
-					if (match) {
-						persistentAddress = match;
-					}
-				} catch (error) {
-					this.logger?.debug('AnchorChainingPlan::computePlan', `listForwardingAddresses lookup failed for step ${scanIndex}, will create a new address`, error);
-				}
-			}
-
-			if (!persistentAddress) {
-				persistentAddress = await forwardedProvider.createPersistentForwardingAddress({
-					account: forwardedSigner,
-					sourceLocation: scanStep.from.location,
-					destinationLocation: scanStep.to.location,
-					destinationAddress,
-					asset: forwardedAssetPair
-				});
-			}
-
-			if (typeof persistentAddress.address !== 'string') {
-				throw(new Error(`Persistent forwarding address for step ${scanIndex} is not a resolved string (got ${typeof persistentAddress.address})`));
-			}
-
-			forwardedSteps.set(scanIndex, { provider: forwardedProvider, persistentAddress });
+			await resolvePersistentForwardingForStep(scanIndex, destinationAddress);
 		}
 
 		const stepPromises: Promise<ChainStepResolution>[] = [];
@@ -1971,12 +2032,10 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 						if (forwardedInfo) {
 							const { provider: forwardedProvider, persistentAddress } = forwardedInfo;
 
-							/*
-							 * Best-effort plan-time valueOut: simulateTransfer if available,
-							 * otherwise assume no rail fee.
-							 */
 							let estimatedValueOut = depositValue;
-							if (await forwardedProvider.isOperationSupported('simulateTransfer')) {
+							if (forwardingOnly) {
+								estimatedValueOut = estimateValueOutFromPersistentForwardingFees(depositValue, persistentAddress.fees);
+							} else if (await forwardedProvider.isOperationSupported('simulateTransfer')) {
 								try {
 									const { signer: forwardedSigner } = await this.getAccountsForAction({
 										type: 'assetMovement',
@@ -2015,6 +2074,10 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 								persistentAddress,
 								provider: forwardedProvider
 							});
+						}
+
+						if (this.#options?.forwardingOnly) {
+							throw(new Error(`Forwarding-only plan requires persistent forwarding for step at index ${index}, but none was resolved`));
 						}
 
 						const providers = await assetMovementClient.getProvidersForTransfer(
@@ -2846,7 +2909,7 @@ export class AnchorChaining {
 			}
 
 			const currentTry = await Promise.allSettled(pathsToTry.map(async function(path) {
-				return(await AnchorChainingPlan.create(path, options));
+				return(await AnchorChainingPlan.create(path, toComputePlanOptions(options, forwardingOpts)));
 			}));
 
 			allOutput.push(...currentTry);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,7 +1,7 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
 import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
-import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isAssetPairLike, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
+import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
 import type { ISOCurrencyCode } from '@keetanetwork/currency-info';

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1361,6 +1361,10 @@ class AnchorGraph {
 			return(result.to);
 		}
 	}
+
+	async buildForwardingAdjacency(): Promise<Map<string, ForwardingAssetRef[]>> {
+		return(buildForwardingAdjacency(await this.computeGraphNodes()));
+	}
 }
 
 export interface ComputePlanOptions {
@@ -1369,6 +1373,196 @@ export interface ComputePlanOptions {
 	 * Limit the number of plans to calculate, defaults to 3
 	 */
 	limit?: number;
+}
+
+export type ForwardingOnlyOptions = {
+	/** Max asset-movement legs (default 2, matching deposit UX). */
+	maxLegs?: number;
+};
+
+export interface GetPlansOptions extends ComputePlanOptions {
+	includeAllOutput?: boolean;
+	forwardingOnly?: boolean | ForwardingOnlyOptions;
+}
+
+export type ForwardingAssetRef = {
+	asset: AnchorChainingAsset;
+	location: AssetLocationLike;
+};
+
+const DEFAULT_FORWARDING_MAX_LEGS = 2;
+const forwardingAssetKeyCache: EVMChecksumCache = new Map();
+
+function forwardingAssetKey(asset: AnchorChainingAsset, location: AssetLocationLike): string {
+	return(`${convertAssetSearchInputToCanonical(asset, forwardingAssetKeyCache)}@${convertAssetLocationToString(location)}`);
+}
+
+function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
+	if (!forwardingOnly) {
+		return(undefined);
+	}
+
+	if (forwardingOnly === true) {
+		return({ maxLegs: DEFAULT_FORWARDING_MAX_LEGS });
+	}
+
+	return({
+		maxLegs: DEFAULT_FORWARDING_MAX_LEGS,
+		...forwardingOnly
+	});
+}
+
+function isCryptoChainLocation(location: AssetLocationLike): boolean {
+	return(toAssetLocation(location).type === 'chain');
+}
+
+/**
+ * Whether a discovered path is eligible for forwarding-only plan resolution:
+ * crypto chain hops only, no Keeta-origin legs, no FX, within maxLegs.
+ */
+export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingOnlyOptions): boolean {
+	const maxLegs = options?.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS;
+	const legs = path.path;
+
+	if (legs.length < 1 || legs.length > maxLegs) {
+		return(false);
+	}
+
+	return(legs.every((step) => {
+		if (step.type !== 'assetMovement') {
+			return(false);
+		}
+
+		if (!isCryptoChainLocation(step.from.location) || !isCryptoChainLocation(step.to.location)) {
+			return(false);
+		}
+
+		return(!isChainLocation(toAssetLocation(step.from.location), 'keeta'));
+	}));
+}
+
+/**
+ * Whether a resolved plan is anchor-to-anchor with no user intermediary steps.
+ * The user may still fund the initial deposit address once.
+ */
+export function isForwardingPlan(plan: AnchorChainingPlan): boolean {
+	const steps = plan.plan.steps;
+
+	if (steps.length === 0) {
+		return(false);
+	}
+
+	for (const step of steps) {
+		if (step.type === 'fx' || step.type === 'keetaSend') {
+			return(false);
+		}
+
+		if (step.type === 'assetMovement' && step.sendingTo === 'SELF') {
+			return(false);
+		}
+	}
+
+	const last = steps[steps.length - 1];
+	if (last?.type !== 'forwarded') {
+		return(false);
+	}
+
+	for (let i = 0; i < steps.length - 1; i++) {
+		const step = steps[i];
+		if (step?.type !== 'assetMovement' || step.sendingTo !== 'NEXT_STEP') {
+			return(false);
+		}
+	}
+
+	return(true);
+}
+
+/**
+ * Adjacency over crypto persistent-forwarding edges only — excludes FX edges and
+ * any hop that starts on Keeta.
+ */
+export function buildForwardingAdjacency(nodes: GraphNodeLike[]): Map<string, ForwardingAssetRef[]> {
+	const adjacency = new Map<string, ForwardingAssetRef[]>();
+
+	for (const node of nodes) {
+		if (node.type !== 'assetMovement') {
+			continue;
+		}
+
+		if (node.from.supportedOperations?.createPersistentForwarding !== true) {
+			continue;
+		}
+
+		if (!isCryptoChainLocation(node.from.location) || !isCryptoChainLocation(node.to.location)) {
+			continue;
+		}
+
+		if (isChainLocation(toAssetLocation(node.from.location), 'keeta')) {
+			continue;
+		}
+
+		const key = forwardingAssetKey(node.from.asset, node.from.location);
+		const list = adjacency.get(key) ?? [];
+		list.push({ asset: node.to.asset, location: node.to.location });
+		adjacency.set(key, list);
+	}
+
+	return(adjacency);
+}
+
+/** Whether `dest` is reachable from `source` over ≤`maxLegs` forwarding edges. */
+export function hasForwardingRoute(
+	adjacency: Map<string, ForwardingAssetRef[]>,
+	source: ForwardingAssetRef,
+	dest: ForwardingAssetRef,
+	maxLegs: number = DEFAULT_FORWARDING_MAX_LEGS
+): boolean {
+	const destKey = forwardingAssetKey(dest.asset, dest.location);
+	let frontier = [ forwardingAssetKey(source.asset, source.location) ];
+
+	for (let depth = 0; depth < maxLegs; depth++) {
+		const next: string[] = [];
+
+		for (const key of frontier) {
+			for (const edge of adjacency.get(key) ?? []) {
+				const edgeKey = forwardingAssetKey(edge.asset, edge.location);
+				if (edgeKey === destKey) {
+					return(true);
+				}
+
+				next.push(edgeKey);
+			}
+		}
+
+		frontier = next;
+	}
+
+	return(false);
+}
+
+/** Deposit address for the first forwarding leg of a forwarding-only plan. */
+export function getForwardingDepositAddress(plan: AnchorChainingPlan): string | null {
+	const firstStep = plan.plan.steps[0];
+
+	if (!firstStep) {
+		return(null);
+	}
+
+	if (firstStep.type === 'assetMovement') {
+		const instruction = firstStep.usingInstruction;
+		if ('sendToAddress' in instruction && typeof instruction.sendToAddress === 'string') {
+			return(instruction.sendToAddress);
+		}
+
+		return(null);
+	}
+
+	if (firstStep.type === 'forwarded') {
+		const address = firstStep.persistentAddress.address;
+		return(typeof address === 'string' ? address : null);
+	}
+
+	return(null);
 }
 
 export class AnchorChainingPath {
@@ -2608,13 +2802,21 @@ export class AnchorChaining {
 		return(retval);
 	}
 
-	async getPlans(input: AnchorChainingPathInput, options?: ComputePlanOptions & { includeAllOutput?: false }): Promise<AnchorChainingPlan[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options: ComputePlanOptions & { includeAllOutput: true }): Promise<AnchorChainingFullPlanResult[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options?: ComputePlanOptions & { includeAllOutput?: boolean }): Promise<(AnchorChainingPlan | AnchorChainingFullPlanResult)[] | null> {
-		const paths = await this.getPaths(input);
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions & { includeAllOutput?: false }): Promise<AnchorChainingPlan[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<AnchorChainingFullPlanResult[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingFullPlanResult)[] | null> {
+		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
+		let paths = await this.getPaths(input);
 
 		if (!paths) {
 			return(null);
+		}
+
+		if (forwardingOpts) {
+			paths = paths.filter((path) => isForwardingPath(path, forwardingOpts));
+			if (paths.length === 0) {
+				return(null);
+			}
 		}
 
 		const limit = options?.limit ?? 3;
@@ -2658,9 +2860,12 @@ export class AnchorChaining {
 				}
 
 				if (result.status === 'fulfilled') {
-					successCount++;
-					if (path && path.path.length < lowestStepsSuccessCount) {
-						lowestStepsSuccessCount = path.path.length;
+					const qualifies = !forwardingOpts || isForwardingPlan(result.value);
+					if (qualifies) {
+						successCount++;
+						if (path && path.path.length < lowestStepsSuccessCount) {
+							lowestStepsSuccessCount = path.path.length;
+						}
 					}
 				}
 			}
@@ -2681,16 +2886,24 @@ export class AnchorChaining {
 			if (options?.includeAllOutput) {
 				if (plan.status === 'rejected') {
 					ret.push({ success: false, error: plan.reason, path });
+				} else if (forwardingOpts && !isForwardingPlan(plan.value)) {
+					ret.push({ success: false, error: new Error('Plan does not qualify as a forwarding-only route'), path });
 				} else {
 					ret.push({ success: true, plan: plan.value, path });
 				}
 			} else {
 				if (plan.status === 'rejected') {
 					this.logger?.debug(`AnchorChaining::getPlans`, `Error computing plan for a path:`, plan.reason);
+				} else if (forwardingOpts && !isForwardingPlan(plan.value)) {
+					this.logger?.debug(`AnchorChaining::getPlans`, `Skipping plan that does not qualify as forwarding-only`);
 				} else {
 					ret.push(plan.value);
 				}
 			}
+		}
+
+		if (forwardingOpts && !options?.includeAllOutput && ret.length === 0) {
+			return(null);
 		}
 
 		return(ret);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -361,6 +361,85 @@ interface ResolveIndex {
 	railInfo: Map<string, { asset: AnchorChainingAsset; location: AssetLocationLike; inbound: Set<Rail>; outbound: Set<Rail> }>;
 }
 
+export type ForwardingAssetRef = {
+	asset: AnchorChainingAsset;
+	location: AssetLocationLike;
+};
+
+const DEFAULT_FORWARDING_MAX_LEGS = 2;
+const forwardingAssetKeyCache: EVMChecksumCache = new Map();
+
+function forwardingAssetKey(asset: AnchorChainingAsset, location: AssetLocationLike): string {
+	return(`${convertAssetSearchInputToCanonical(asset, forwardingAssetKeyCache)}@${convertAssetLocationToString(location)}`);
+}
+
+function isCryptoChainLocation(location: AssetLocationLike): boolean {
+	return(toAssetLocation(location).type === 'chain');
+}
+
+/**
+ * Adjacency over crypto persistent-forwarding edges only - excludes FX edges and
+ * any hop that starts on Keeta.
+ */
+export function buildForwardingAdjacency(nodes: GraphNodeLike[]): Map<string, ForwardingAssetRef[]> {
+	const adjacency = new Map<string, ForwardingAssetRef[]>();
+
+	for (const node of nodes) {
+		if (node.type !== 'assetMovement') {
+			continue;
+		}
+
+		if (node.from.supportedOperations?.createPersistentForwarding !== true) {
+			continue;
+		}
+
+		if (!isCryptoChainLocation(node.from.location) || !isCryptoChainLocation(node.to.location)) {
+			continue;
+		}
+
+		if (isChainLocation(toAssetLocation(node.from.location), 'keeta')) {
+			continue;
+		}
+
+		const key = forwardingAssetKey(node.from.asset, node.from.location);
+		const list = adjacency.get(key) ?? [];
+		list.push({ asset: node.to.asset, location: node.to.location });
+		adjacency.set(key, list);
+	}
+
+	return(adjacency);
+}
+
+/** Whether `dest` is reachable from `source` over <=`maxLegs` forwarding edges. */
+export function hasForwardingRoute(
+	adjacency: Map<string, ForwardingAssetRef[]>,
+	source: ForwardingAssetRef,
+	dest: ForwardingAssetRef,
+	maxLegs: number = DEFAULT_FORWARDING_MAX_LEGS
+): boolean {
+	const destKey = forwardingAssetKey(dest.asset, dest.location);
+	let frontier = [ forwardingAssetKey(source.asset, source.location) ];
+
+	for (let depth = 0; depth < maxLegs; depth++) {
+		const next: string[] = [];
+
+		for (const key of frontier) {
+			for (const edge of adjacency.get(key) ?? []) {
+				const edgeKey = forwardingAssetKey(edge.asset, edge.location);
+				if (edgeKey === destKey) {
+					return(true);
+				}
+
+				next.push(edgeKey);
+			}
+		}
+
+		frontier = next;
+	}
+
+	return(false);
+}
+
 class AnchorGraph {
 	client: KeetaNet.UserClient;
 	resolver: Resolver;
@@ -1385,18 +1464,6 @@ export interface GetPlansOptions extends ComputePlanOptions {
 	forwardingOnly?: boolean | ForwardingOnlyOptions;
 }
 
-export type ForwardingAssetRef = {
-	asset: AnchorChainingAsset;
-	location: AssetLocationLike;
-};
-
-const DEFAULT_FORWARDING_MAX_LEGS = 2;
-const forwardingAssetKeyCache: EVMChecksumCache = new Map();
-
-function forwardingAssetKey(asset: AnchorChainingAsset, location: AssetLocationLike): string {
-	return(`${convertAssetSearchInputToCanonical(asset, forwardingAssetKeyCache)}@${convertAssetLocationToString(location)}`);
-}
-
 function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
 	if (!forwardingOnly) {
 		return(undefined);
@@ -1410,10 +1477,6 @@ function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnly
 		maxLegs: DEFAULT_FORWARDING_MAX_LEGS,
 		...forwardingOnly
 	});
-}
-
-function isCryptoChainLocation(location: AssetLocationLike): boolean {
-	return(toAssetLocation(location).type === 'chain');
 }
 
 /**
@@ -1475,69 +1538,6 @@ export function isForwardingPlan(plan: AnchorChainingPlan): boolean {
 	}
 
 	return(true);
-}
-
-/**
- * Adjacency over crypto persistent-forwarding edges only — excludes FX edges and
- * any hop that starts on Keeta.
- */
-export function buildForwardingAdjacency(nodes: GraphNodeLike[]): Map<string, ForwardingAssetRef[]> {
-	const adjacency = new Map<string, ForwardingAssetRef[]>();
-
-	for (const node of nodes) {
-		if (node.type !== 'assetMovement') {
-			continue;
-		}
-
-		if (node.from.supportedOperations?.createPersistentForwarding !== true) {
-			continue;
-		}
-
-		if (!isCryptoChainLocation(node.from.location) || !isCryptoChainLocation(node.to.location)) {
-			continue;
-		}
-
-		if (isChainLocation(toAssetLocation(node.from.location), 'keeta')) {
-			continue;
-		}
-
-		const key = forwardingAssetKey(node.from.asset, node.from.location);
-		const list = adjacency.get(key) ?? [];
-		list.push({ asset: node.to.asset, location: node.to.location });
-		adjacency.set(key, list);
-	}
-
-	return(adjacency);
-}
-
-/** Whether `dest` is reachable from `source` over ≤`maxLegs` forwarding edges. */
-export function hasForwardingRoute(
-	adjacency: Map<string, ForwardingAssetRef[]>,
-	source: ForwardingAssetRef,
-	dest: ForwardingAssetRef,
-	maxLegs: number = DEFAULT_FORWARDING_MAX_LEGS
-): boolean {
-	const destKey = forwardingAssetKey(dest.asset, dest.location);
-	let frontier = [ forwardingAssetKey(source.asset, source.location) ];
-
-	for (let depth = 0; depth < maxLegs; depth++) {
-		const next: string[] = [];
-
-		for (const key of frontier) {
-			for (const edge of adjacency.get(key) ?? []) {
-				const edgeKey = forwardingAssetKey(edge.asset, edge.location);
-				if (edgeKey === destKey) {
-					return(true);
-				}
-
-				next.push(edgeKey);
-			}
-		}
-
-		frontier = next;
-	}
-
-	return(false);
 }
 
 /** Deposit address for the first forwarding leg of a forwarding-only plan. */

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,7 +1,7 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
 import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
-import { convertAssetLocationToString, convertAssetSearchInputToCanonical, isAssetPairLike, isChainLocation, toAssetLocation, toAssetPair } from "../services/asset-movement/common.js";
+import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isAssetPairLike, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
 import type { ISOCurrencyCode } from '@keetanetwork/currency-info';
@@ -14,7 +14,7 @@ import { assertNever } from './utils/never.js';
 import KeetaFXAnchorClient from '../services/fx/client.js';
 import KeetaAssetMovementAnchorClient from '../services/asset-movement/client.js';
 import type { ExternalChainAsset, EVMChecksumCache } from './asset.js';
-import { isExternalChainAsset, normalizeChainAssetCasing } from './asset.js';
+import { isExternalChainAsset, isMovableAssetEqual } from './asset.js';
 import type { Logger } from './log/index.js';
 import type { BlockHash } from '@keetanetwork/keetanet-client/lib/block/index.js';
 import type { AnchorExternalInput } from './anchor-external.js';
@@ -219,33 +219,8 @@ export type AnchorChainingStepLike = GraphNodeLike | KeetaSendStepLike;
 
 export type AnchorChainingAsset = TokenAddress | ISOCurrencyCode | ExternalChainAsset;
 
-function areBothTokenAndEqual(a: string | TokenAddress, b: string | TokenAddress): boolean {
-	try {
-		const aParsed = KeetaNet.lib.Account.toAccount(a);
-		const bParsed = KeetaNet.lib.Account.toAccount(b);
-
-		if (!aParsed.isToken() || !bParsed.isToken()) {
-			return(false);
-		}
-
-
-		return(aParsed.comparePublicKey(bParsed));
-	} catch {
-		return(false);
-	}
-}
-
 function isAnchorChainingAssetEqual(a: AnchorChainingAsset, b: AnchorChainingAsset): boolean {
-	// Compare string assets (currency codes, external-chain assets) with EVM
-	// casing normalized, so the same token reported by two providers in
-	// different EIP-55 casings is treated as equal.
-	if (typeof a === 'string' && typeof b === 'string' && normalizeChainAssetCasing(a) === normalizeChainAssetCasing(b)) {
-		return(true);
-	} else if (areBothTokenAndEqual(a, b)) {
-		return(true);
-	} else {
-		return(false);
-	}
+	return(isMovableAssetEqual(a, b));
 }
 
 /**
@@ -1624,11 +1599,12 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 		}
 
 		const appendBreakdown = (
-			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[] },
+			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string },
 			source: AnchorChainingFeeLineItemSource
 		) => {
 			const stepDefaultAsset = defaultFeeAsset(step);
 			const metadata = { stepIndex, step, source };
+			const startLength = lineItems.length;
 
 			for (const item of breakdown.lineItems) {
 				const asset = item.asset ?? stepDefaultAsset;
@@ -1653,6 +1629,35 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 						...base,
 						basisPoints: item.basisPoints,
 						value: (step.valueIn * BigInt(item.basisPoints) / 10000n).toString()
+					});
+				}
+			}
+
+			if (breakdown.total !== undefined && breakdown.total !== '') {
+				const authoritativeTotal = computeFeeTotalFromBreakdown(step.valueIn, breakdown);
+				let lineItemSum = 0n;
+
+				for (let i = startLength; i < lineItems.length; i++) {
+					const emitted = lineItems[i];
+					if (emitted?.value !== undefined && emitted.value !== '') {
+						lineItemSum += BigInt(emitted.value);
+					}
+				}
+
+				if (authoritativeTotal > lineItemSum) {
+					lineItems.push({
+						purpose: 'OTHER',
+						asset: stepDefaultAsset,
+						value: (authoritativeTotal - lineItemSum).toString(),
+						metadata
+					});
+				} else if (authoritativeTotal < lineItemSum) {
+					lineItems.splice(startLength);
+					lineItems.push({
+						purpose: 'OTHER',
+						asset: stepDefaultAsset,
+						value: authoritativeTotal.toString(),
+						metadata
 					});
 				}
 			}
@@ -1975,7 +1980,6 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 
 					const sourceLocationString = convertAssetLocationToString(scanStep.from.location);
 					const destLocationString = convertAssetLocationToString(scanStep.to.location);
-					const expectedAssetPair = toAssetPair(forwardedAssetPair);
 					const match = existing.addresses.find(addr => {
 						if (addr.destinationAddress !== destinationAddress) {
 							return(false);
@@ -1986,14 +1990,8 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 						if (!addr.destinationLocation || convertAssetLocationToString(addr.destinationLocation) !== destLocationString) {
 							return(false);
 						}
-						if (addr.asset) {
-							if (isAssetPairLike(addr.asset)) {
-								if (addr.asset.from !== expectedAssetPair.from || addr.asset.to !== expectedAssetPair.to) {
-									return(false);
-								}
-							} else if (addr.asset !== expectedAssetPair.from && addr.asset !== expectedAssetPair.to) {
-								return(false);
-							}
+						if (addr.asset && !doesAssetOrPairMatch(addr.asset, forwardedAssetPair)) {
+							return(false);
 						}
 
 						return(true);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,7 +1,7 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
 import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
-import { convertAssetLocationToString, convertAssetSearchInputToCanonical, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
+import { convertAssetLocationToString, convertAssetSearchInputToCanonical, isAssetPairLike, isChainLocation, toAssetLocation, toAssetPair } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
 import type { ISOCurrencyCode } from '@keetanetwork/currency-info';
@@ -1991,13 +1991,14 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 						search: [{
 							sourceLocation: scanStep.from.location,
 							destinationLocation: scanStep.to.location,
-							asset: scanStep.from.asset,
+							asset: forwardedAssetPair,
 							destinationAddress
 						}]
 					});
 
 					const sourceLocationString = convertAssetLocationToString(scanStep.from.location);
 					const destLocationString = convertAssetLocationToString(scanStep.to.location);
+					const expectedAssetPair = toAssetPair(forwardedAssetPair);
 					const match = existing.addresses.find(addr => {
 						if (addr.destinationAddress !== destinationAddress) {
 							return(false);
@@ -2007,6 +2008,15 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 						}
 						if (!addr.destinationLocation || convertAssetLocationToString(addr.destinationLocation) !== destLocationString) {
 							return(false);
+						}
+						if (addr.asset) {
+							if (isAssetPairLike(addr.asset)) {
+								if (addr.asset.from !== expectedAssetPair.from || addr.asset.to !== expectedAssetPair.to) {
+									return(false);
+								}
+							} else if (addr.asset !== expectedAssetPair.from && addr.asset !== expectedAssetPair.to) {
+								return(false);
+							}
 						}
 
 						return(true);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1466,10 +1466,10 @@ export type ForwardingOnlyOptions = {
 
 export interface GetPlansOptions extends Omit<ComputePlanOptions, 'forwardingOnly'> {
 	includeAllOutput?: boolean;
-	forwardingOnly?: boolean | ForwardingOnlyOptions;
+	forwardingOnly?: true | ForwardingOnlyOptions;
 }
 
-function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
+function normalizeForwardingOnlyOptions(forwardingOnly: true | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
 	if (!forwardingOnly) {
 		return(undefined);
 	}
@@ -1532,30 +1532,35 @@ function estimateValueOutFromPersistentForwardingFees(valueIn: bigint, fees?: Pe
 		return(valueIn);
 	}
 
-	let feeTotal = 0n;
+	let feeFromLineItems = 0n;
 
 	for (const lineItem of fees.lineItems) {
-		if (lineItem.purpose === 'VALUE_VARIABLE' && lineItem.basisPoints !== undefined) {
-			feeTotal += valueIn * BigInt(lineItem.basisPoints) / 10000n;
+		if ('value' in lineItem && lineItem.value !== undefined && lineItem.value !== '') {
+			feeFromLineItems += BigInt(lineItem.value);
+		} else if (lineItem.purpose === 'VALUE_VARIABLE' && lineItem.basisPoints !== undefined) {
+			feeFromLineItems += valueIn * BigInt(lineItem.basisPoints) / 10000n;
 		}
 	}
 
+	let feeTotal = feeFromLineItems;
 	if (fees.total !== undefined && fees.total !== '') {
-		const declaredTotal = BigInt(fees.total);
-		if (declaredTotal > feeTotal) {
-			feeTotal = declaredTotal;
-		}
+		feeTotal = BigInt(fees.total);
 	}
 
 	const valueOut = valueIn - feeTotal;
 	return(valueOut < 1n ? 1n : valueOut);
 }
 
+/** @internal Exported for unit tests. */
+export function estimateForwardingValueOut(valueIn: bigint, fees?: PersistentAddressAssetFeeBreakdown): bigint {
+	return(estimateValueOutFromPersistentForwardingFees(valueIn, fees));
+}
+
 /**
  * Whether a resolved plan is anchor-to-anchor with no user intermediary steps.
  * The user may still fund the initial deposit address once.
  */
-export function isForwardingPlan(plan: AnchorChainingPlan): boolean {
+export function isForwardingPlan(plan: { plan: AnchorChainingPathComputedPlan }): boolean {
 	const steps = plan.plan.steps;
 
 	if (steps.length === 0) {
@@ -1566,7 +1571,7 @@ export function isForwardingPlan(plan: AnchorChainingPlan): boolean {
 }
 
 /** Deposit address for the first forwarding leg of a forwarding-only plan. */
-export function getForwardingDepositAddress(plan: AnchorChainingPlan): string | null {
+export function getForwardingDepositAddress(plan: { plan: AnchorChainingPathComputedPlan }): string | null {
 	const firstStep = plan.plan.steps[0];
 
 	if (!firstStep || firstStep.type !== 'forwarded') {
@@ -2603,6 +2608,10 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 	}
 
 	async execute(options?: { requireSendAuth?: boolean; abortSignal?: AbortSignal; }): Promise<AnchorChainingPathExecuteResult> {
+		if (this.#options?.forwardingOnly) {
+			throw(new Error('Forwarding-only plans cannot be executed. Use getPlans({ forwardingOnly: true }), which returns AnchorChainingForwardingOnlyPlan, and fund the deposit address externally.'));
+		}
+
 		if (this.#state.status !== 'idle') {
 			throw(new Error(`Cannot execute: path is already in state "${this.#state.status}"`));
 		}
@@ -2786,7 +2795,39 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 	}
 }
 
+/**
+ * Forwarding-only chaining plan for persistent-forwarding routes. Resolves deposit
+ * addresses and fee estimates but cannot be executed: the user funds the
+ * external deposit address directly.
+ */
+export class AnchorChainingForwardingOnlyPlan extends AnchorChainingPath {
+	readonly #plan: AnchorChainingPathComputedPlan;
+
+	private constructor(path: AnchorChainingPath, plan: AnchorChainingPathComputedPlan) {
+		super({ request: path.request, path: path.path, parent: path.parent });
+		this.#plan = plan;
+	}
+
+	get plan(): AnchorChainingPathComputedPlan {
+		return(this.#plan);
+	}
+
+	getDepositAddress(): string | null {
+		return(getForwardingDepositAddress(this));
+	}
+
+	static async create(path: AnchorChainingPath, options?: ComputePlanOptions): Promise<AnchorChainingForwardingOnlyPlan> {
+		const computed = await AnchorChainingPlan.create(path, { ...options, forwardingOnly: true });
+		if (!isForwardingPlan(computed)) {
+			throw(new Error('Computed plan does not qualify as a forwarding-only route'));
+		}
+
+		return(new AnchorChainingForwardingOnlyPlan(path, computed.plan));
+	}
+}
+
 type AnchorChainingFullPlanResult = (({ success: true; plan: AnchorChainingPlan; } | { success: false; error: unknown; }) & { path: AnchorChainingPath; });
+type AnchorChainingFullForwardingOnlyPlanResult = (({ success: true; plan: AnchorChainingForwardingOnlyPlan; } | { success: false; error: unknown; }) & { path: AnchorChainingPath; });
 
 export class AnchorChaining {
 	private client: KeetaNet.UserClient;
@@ -2865,9 +2906,10 @@ export class AnchorChaining {
 		return(retval);
 	}
 
-	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions & { includeAllOutput?: false }): Promise<AnchorChainingPlan[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<AnchorChainingFullPlanResult[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingFullPlanResult)[] | null> {
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<(AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingForwardingOnlyPlan[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
 		let paths = await this.getPaths(input);
 
@@ -2893,7 +2935,7 @@ export class AnchorChaining {
 		const maxAttemptLoops = 3;
 		let currentAttemptLoop = 0;
 
-		const allOutput: PromiseSettledResult<AnchorChainingPlan>[] = [];
+		const allOutput: PromiseSettledResult<AnchorChainingPlan | AnchorChainingForwardingOnlyPlan>[] = [];
 
 		while (successCount < limit && lastAttemptedPathIdx < sortedPaths.length - 1 && currentAttemptLoop < maxAttemptLoops) {
 			currentAttemptLoop++;
@@ -2909,7 +2951,12 @@ export class AnchorChaining {
 			}
 
 			const currentTry = await Promise.allSettled(pathsToTry.map(async function(path) {
-				return(await AnchorChainingPlan.create(path, toComputePlanOptions(options, forwardingOpts)));
+				const computeOptions = toComputePlanOptions(options, forwardingOpts);
+				if (forwardingOpts) {
+					return(await AnchorChainingForwardingOnlyPlan.create(path, computeOptions));
+				}
+
+				return(await AnchorChainingPlan.create(path, computeOptions));
 			}));
 
 			allOutput.push(...currentTry);
@@ -2936,7 +2983,7 @@ export class AnchorChaining {
 			lastAttemptedPathIdx += pathsToTry.length;
 		}
 
-		const ret: (AnchorChainingPlan | AnchorChainingFullPlanResult)[] = [];
+		const ret: (AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] = [];
 
 		for (let i = 0; i < allOutput.length; i++) {
 			const path = sortedPaths[i];
@@ -2951,7 +2998,9 @@ export class AnchorChaining {
 					ret.push({ success: false, error: plan.reason, path });
 				} else if (forwardingOpts && !isForwardingPlan(plan.value)) {
 					ret.push({ success: false, error: new Error('Plan does not qualify as a forwarding-only route'), path });
-				} else {
+				} else if (plan.value instanceof AnchorChainingForwardingOnlyPlan) {
+					ret.push({ success: true, plan: plan.value, path });
+				} else if (plan.value instanceof AnchorChainingPlan) {
 					ret.push({ success: true, plan: plan.value, path });
 				}
 			} else {

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -5,8 +5,8 @@ import { createNodeAndClient } from '../../lib/utils/tests/node.js';
 import type { ServiceMetadataExternalizable } from '../../lib/resolver.js';
 import KeetaAnchorResolver from '../../lib/resolver.js';
 import { type KeetaAnchorAssetMovementServerConfig, KeetaNetAssetMovementAnchorHTTPServer } from './server.js';
-import { Errors, toAssetPair } from './common.js';
-import type { AssetOrPair, RailWithExtendedDetails, KeetaAssetMovementAnchorCreatePersistentForwardingRequest, KeetaAssetMovementAnchorCreatePersistentForwardingResponse, KeetaAssetMovementAnchorGetTransferStatusResponse, KeetaAssetMovementAnchorInitiateTransferClientRequest, KeetaAssetMovementAnchorInitiateTransferRequest, KeetaAssetMovementAnchorInitiateTransferResponse, KeetaAssetMovementAnchorlistPersistentForwardingTransactionsResponse, KeetaAssetMovementAnchorlistTransactionsRequest, KeetaAssetMovementTransaction, ProviderSearchInput, KeetaPersistentForwardingAddressDetails, PersistentAddressTemplateData, PersistentAddressOrTemplateReference, KeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateResponse, PersistentForwardingTemplateSessionData, AnchorCustomLocationMetadata, SolanaAsset, KeetaAssetMovementAnchorSimulateTransferRequest, KeetaAssetMovementAnchorSimulateTransferResponse, KeetaAssetMovementAnchorUserAction, PersistentAddressAssetFeeBreakdown } from './common.js';
+import { Errors, toAssetPair, isMovableAssetEqual, doesAssetOrPairMatch } from './common.js';
+import type { AssetOrPair, AssetPair, EVMAsset, RailWithExtendedDetails, KeetaAssetMovementAnchorCreatePersistentForwardingRequest, KeetaAssetMovementAnchorCreatePersistentForwardingResponse, KeetaAssetMovementAnchorGetTransferStatusResponse, KeetaAssetMovementAnchorInitiateTransferClientRequest, KeetaAssetMovementAnchorInitiateTransferRequest, KeetaAssetMovementAnchorInitiateTransferResponse, KeetaAssetMovementAnchorlistPersistentForwardingTransactionsResponse, KeetaAssetMovementAnchorlistTransactionsRequest, KeetaAssetMovementTransaction, ProviderSearchInput, KeetaPersistentForwardingAddressDetails, PersistentAddressTemplateData, PersistentAddressOrTemplateReference, KeetaAssetMovementAnchorInitiatePersistentForwardingAddressTemplateResponse, PersistentForwardingTemplateSessionData, AnchorCustomLocationMetadata, SolanaAsset, KeetaAssetMovementAnchorSimulateTransferRequest, KeetaAssetMovementAnchorSimulateTransferResponse, KeetaAssetMovementAnchorUserAction, PersistentAddressAssetFeeBreakdown } from './common.js';
 import { Certificate, CertificateBuilder, SensitiveAttribute, SharableCertificateAttributes } from '../../lib/certificates.js';
 import type { Routes } from '../../lib/http-server/index.js';
 import { KeetaAnchorUserValidationError } from '../../lib/error.js';
@@ -1510,4 +1510,26 @@ test('Asset Movement Anchor Authenticated Client Test', async function() {
 			expect(toJSONSerializable(userActionNeededError.actionsNeeded)).toEqual(toJSONSerializable(testCase.actions));
 		}
 	}
+});
+
+test('isMovableAssetEqual normalizes EVM address casing', function() {
+	expect(isMovableAssetEqual(
+		'evm:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+		'evm:0x833589fcd6edb6e08f4c7c32d4f71b54bdA02913'
+	)).toBe(true);
+});
+
+test('doesAssetOrPairMatch compares pair legs with mixed representations', async function() {
+	const account = KeetaNet.lib.Account.fromSeed(seed, 0);
+	const { userClient: client } = await createNodeAndClient(account);
+	const { account: tokenAccount } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+	const token = tokenAccount.assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+
+	const evmLower = 'evm:0x833589fcd6edb6e08f4c7c32d4f71b54bdA02913' satisfies EVMAsset;
+	const evmChecksum = 'evm:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' satisfies EVMAsset;
+
+	const expected: AssetPair = { from: evmLower, to: token };
+	const listed: AssetPair = { from: evmChecksum, to: token.publicKeyString.get() };
+
+	expect(doesAssetOrPairMatch(listed, expected)).toBe(true);
 });

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -1334,6 +1334,22 @@ test('Asset Movement Anchor Authenticated Client Test', async function() {
 			],
 			total: 1
 		});
+
+		const listedWithAssetPair = await usdcProvider.listForwardingAddresses({
+			account,
+			search: [
+				{
+					asset: { from: testCurrencyUSDC.publicKeyString.get(), to: testCurrencyUSDC.publicKeyString.get() },
+					sourceLocation: 'chain:evm:100',
+					destinationLocation: `chain:keeta:${client.network}`,
+					destinationAddress: account.publicKeyString.get()
+				}
+			]
+		});
+		expect(listedWithAssetPair.addresses[0]?.asset).toEqual({
+			from: testCurrencyUSDC.publicKeyString.get(),
+			to: testCurrencyUSDC.publicKeyString.get()
+		});
 	}
 
 	{

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -1075,7 +1075,7 @@ export class KeetaAssetMovementAnchorProvider extends KeetaAssetMovementAnchorBa
 					search: body.search ? body.search.map(function(searchItem) {
 						return({
 							...searchItem,
-							asset: searchItem.asset ? convertAssetSearchInputToCanonical(searchItem.asset) : undefined,
+							asset: searchItem.asset ? convertAssetOrPairSearchInputToCanonical(searchItem.asset) : undefined,
 							sourceLocation: searchItem.sourceLocation ? convertAssetLocationToString(searchItem.sourceLocation) : undefined,
 							destinationLocation: searchItem.destinationLocation ? convertAssetLocationToString(searchItem.destinationLocation) : undefined
 						})

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -234,7 +234,7 @@ export type AssetOrPair = MovableAsset | AssetPair;
 export type AssetPairCanonical<From extends MovableAssetSearchCanonical = MovableAssetSearchCanonical, To extends MovableAssetSearchCanonical = MovableAssetSearchCanonical> = { from: From; to: To; };
 export type AssetOrPairCanonical = MovableAssetSearchCanonical | AssetPairCanonical;
 
-function isAssetPairLike(input: unknown): input is AssetPair {
+export function isAssetPairLike(input: unknown): input is AssetPair {
 	return(typeof input === 'object' && input !== null && 'from' in input && 'to' in input);
 }
 
@@ -1081,7 +1081,7 @@ export type KeetaAssetMovementAnchorListPersistentForwardingClientRequest = {
 	search?: {
 		sourceLocation?: AssetLocationLike;
 		destinationLocation?: AssetLocationLike;
-		asset?: MovableAsset;
+		asset?: AssetOrPair;
 		destinationAddress?: string;
 		persistentAddressTemplateId?: string;
 	}[];
@@ -1094,7 +1094,7 @@ export type KeetaAssetMovementAnchorListPersistentForwardingRequest = {
 	search?: {
 		sourceLocation?: AssetLocationCanonical | undefined;
 		destinationLocation?: AssetLocationCanonical | undefined;
-		asset?: MovableAssetSearchCanonical | undefined;
+		asset?: AssetOrPairCanonical | undefined;
 		destinationAddress?: string | undefined;
 		persistentAddressTemplateId?: string | undefined;
 	}[] | undefined;

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -255,16 +255,10 @@ export function doesAssetOrPairMatch(asset: AssetOrPair, expected: AssetOrPair, 
 	const expectedPair = toAssetPair(expected);
 
 	if (isAssetPairLike(asset)) {
-		return(
-			isMovableAssetEqual(asset.from, expectedPair.from, cache) &&
-			isMovableAssetEqual(asset.to, expectedPair.to, cache)
-		);
+		return(isMovableAssetEqual(asset.from, expectedPair.from, cache) && isMovableAssetEqual(asset.to, expectedPair.to, cache));
+	} else {
+		return(isMovableAssetEqual(asset, expectedPair.from, cache) || isMovableAssetEqual(asset, expectedPair.to, cache));
 	}
-
-	return(
-		isMovableAssetEqual(asset, expectedPair.from, cache) ||
-		isMovableAssetEqual(asset, expectedPair.to, cache)
-	);
 }
 
 

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -10,8 +10,8 @@ import { KeetaAnchorUserError, type KeetaAnchorError } from '../../lib/error.js'
 import type { AssetLocationLike, AssetLocationString, AssetLocationInput, AssetLocationCanonical, ChainLocationString } from './lib/location.js';
 import { convertAssetLocationInputToCanonical } from './lib/location.js';
 import type { BankAccountAddressObfuscated, BankAccountAddressResolved, MobileWalletAddressObfuscated, MobileWalletAddressResolved } from './lib/data/addresses/types.generated.js';
-import type { HexString, KeetaNetAccount, MovableAsset, MovableAssetSearchCanonical, CurrencySearchCanonical, ExternalChainLocationType, ExternalChainAsset } from '../../lib/asset.js';
-import { convertAssetSearchInputToCanonical } from '../../lib/asset.js';
+import type { HexString, KeetaNetAccount, MovableAsset, MovableAssetSearchCanonical, CurrencySearchCanonical, ExternalChainLocationType, ExternalChainAsset, EVMChecksumCache } from '../../lib/asset.js';
+import { convertAssetSearchInputToCanonical, isMovableAssetEqual } from '../../lib/asset.js';
 import { assertKeetaAssetMovementAnchorAdditionalKYCNeededErrorJSONProperties, assertKeetaAssetMovementAnchorKYCShareNeededErrorJSONProperties, assertKeetaAssetMovementAnchorOperationNotSupportedErrorJSONProperties, assertKeetaAssetMovementAnchorUserActionNeededErrorJSONProperties, assertKeetaAssetMovementAnchorAccountStatusEntry } from './common.generated.js';
 import type { ClientRenderableContent } from '../../lib/metadata.types.js';
 import type { TokenMetadata } from '../../lib/token-metadata.js';
@@ -56,7 +56,8 @@ export {
 	parseSolanaAsset,
 	isSolanaAsset,
 	convertAssetSearchInputToCanonical,
-	isExternalChainAsset
+	isExternalChainAsset,
+	isMovableAssetEqual
 } from '../../lib/asset.js';
 
 export type ISOCountryCode = CurrencyInfo.ISOCountryCode;
@@ -244,6 +245,26 @@ export function toAssetPair(input: AssetOrPair): AssetPair {
 	}
 
 	return({ from: input, to: input });
+}
+
+/**
+ * Returns true when `asset` matches `expected`.
+ * A single asset matches either leg of an expected pair; pairs require both legs to match.
+ */
+export function doesAssetOrPairMatch(asset: AssetOrPair, expected: AssetOrPair, cache?: EVMChecksumCache): boolean {
+	const expectedPair = toAssetPair(expected);
+
+	if (isAssetPairLike(asset)) {
+		return(
+			isMovableAssetEqual(asset.from, expectedPair.from, cache) &&
+			isMovableAssetEqual(asset.to, expectedPair.to, cache)
+		);
+	}
+
+	return(
+		isMovableAssetEqual(asset, expectedPair.from, cache) ||
+		isMovableAssetEqual(asset, expectedPair.to, cache)
+	);
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches plan computation, fee/out amount estimation, and persistent-forwarding address reuse on asset-movement paths; mistakes could misquote deposits or duplicate addresses, though execution is blocked for forwarding-only plans.
> 
> **Overview**
> Adds **forwarding-only** routing via `getPlans({ forwardingOnly: true })`, which filters to crypto persistent-forwarding paths and returns `AnchorChainingForwardingOnlyPlan` instances with a deposit address and fee estimates but **no** `execute()` (external funding only). Plan computation can resolve **multiple** forwarding legs (chaining deposit addresses) and prefers persistent-address fee metadata for `valueOut` when simulating is skipped.
> 
> Introduces **`listChainingPlanFees` / `plan.listFees()`** to aggregate per-step fees (FX quotes, transfer instructions, simulated transfers, persistent-address breakdowns) and reconcile authoritative `fees.total` with line items. Forwarded steps now attach optional **`simulatedTransfer`** during normal planning so fees and `valueOut` reflect rail simulation.
> 
> **Asset identity** is centralized with `isMovableAssetEqual` / `doesAssetOrPairMatch`; persistent forwarding **list/create search** accepts **`AssetOrPair`** (canonicalized on the client), and address reuse matches pairs instead of a single asset string. Execution emits **`transactionObserved`** when polling transfer status or listing forwarding transactions.
> 
> Also exports forwarding graph helpers (`buildForwardingAdjacency`, `hasForwardingRoute`, `isForwardingPath`, `isForwardingPlan`, `getForwardingDepositAddress`, `estimateForwardingValueOut`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56159ba1f26d9267823eb62eb34b0b71f7ebcde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->