### PR TITLE
Fix one bad metadata entry breaking entire resolver

### DIFF
--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4070,3 +4070,54 @@ describe('Keeta-to-keeta swap chaining (persistent-forwarding regression)', func
 		expect(sends[1]?.token).toEqual(h.tokens.USD.publicKeyString.get());
 	});
 });
+
+describe('invalid anchor metadata', function() {
+	test('computeGraphNodes ignores providers whose metadata cannot be parsed', async function() {
+		const testRoot = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+		const fromToken = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0, KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+		const toToken = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0, KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+
+		const { userClient, fees } = await createNodeAndClient(testRoot);
+		fees.disable();
+
+		await userClient.setInfo({
+			name: '',
+			description: '',
+			metadata: Resolver.Metadata.formatMetadata(toJSONSerializable({
+				version: 1,
+				currencyMap: {},
+				services: {
+					fx: {
+						good_fx: {
+							operations: {
+								createExchange: 'https://fx.good.com/createExchange'
+							},
+							from: [{
+								currencyCodes: [fromToken.publicKeyString.get()],
+								to: [toToken.publicKeyString.get()]
+							}]
+						},
+						broken_fx: {
+							from: 'not-an-array'
+						}
+					}
+				}
+			}))
+		});
+
+		fees.enable();
+
+		const anchorChaining = new AnchorChaining({
+			client: userClient,
+			resolver: new Resolver({
+				root: testRoot,
+				client: userClient,
+				trustedCAs: []
+			})
+		});
+
+		const nodes = await anchorChaining.graph.computeGraphNodes();
+		expect(nodes.some(n => n.type === 'fx' && n.providerID === 'good_fx')).toBe(true);
+		expect(nodes.some(n => n.providerID === 'broken_fx')).toBe(false);
+	});
+});

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -477,61 +477,66 @@ class AnchorGraph {
 		const networkLocation = `chain:keeta:${this.client.network}` satisfies AssetLocationLike;
 
 		const providerLookupResult = await Promise.all(Object.entries(fxServices).map(async ([ providerID, service ]) => {
-			const fromEntries = await service.from('array');
+			try {
+				const fromEntries = await service.from('array');
 
-			if (!fromEntries) {
-				return(null);
-			}
-
-			const operations = await service.operations('object');
-			if (!operations.createExchange) {
-				this.logger?.debug('AnchorGraph::computeFXNodes', `FX service ${providerID} does not support createExchange operation, skipping`);
-				return(null);
-			}
-
-			const pathNodes = await Promise.all(fromEntries.map(async function(fromEntry) {
-				const pathNodesResult: GraphNodeLike[] = [];
-
-				const parsedEntry = await fromEntry('object');
-
-				const [ fromCodes, toCodes ] = await Promise.all([
-					parsedEntry.currencyCodes('array'),
-					parsedEntry.to('array')
-				]);
-
-				for (const from of fromCodes) {
-					const fromResolved = await from('string');
-					if (!fromResolved) {
-						continue;
-					}
-
-					const fromAccount = KeetaNet.lib.Account.fromPublicKeyString(fromResolved).assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
-
-					for (const to of toCodes) {
-						const toResolved = await to('string');
-						if (!toResolved) {
-							continue;
-						}
-
-						const toAccount = KeetaNet.lib.Account.fromPublicKeyString(toResolved).assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
-
-						if (fromAccount.comparePublicKey(toAccount)) {
-							continue;
-						}
-
-						pathNodesResult.push({
-							type: 'fx',
-							providerID: providerID,
-							from: { asset: fromAccount, location: networkLocation, rail: 'KEETA_SEND' },
-							to: { asset: toAccount, location: networkLocation, rail: 'KEETA_SEND' }
-						});
-					}
+				if (!fromEntries) {
+					return(null);
 				}
 
-				return(pathNodesResult);
-			}));
+				const operations = await service.operations('object');
+				if (!operations.createExchange) {
+					this.logger?.debug('AnchorGraph::computeFXNodes', `FX service ${providerID} does not support createExchange operation, skipping`);
+					return(null);
+				}
 
-			return(pathNodes.flat());
+				const pathNodes = await Promise.all(fromEntries.map(async function(fromEntry) {
+					const pathNodesResult: GraphNodeLike[] = [];
+
+					const parsedEntry = await fromEntry('object');
+
+					const [ fromCodes, toCodes ] = await Promise.all([
+						parsedEntry.currencyCodes('array'),
+						parsedEntry.to('array')
+					]);
+
+					for (const from of fromCodes) {
+						const fromResolved = await from('string');
+						if (!fromResolved) {
+							continue;
+						}
+
+						const fromAccount = KeetaNet.lib.Account.fromPublicKeyString(fromResolved).assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+
+						for (const to of toCodes) {
+							const toResolved = await to('string');
+							if (!toResolved) {
+								continue;
+							}
+
+							const toAccount = KeetaNet.lib.Account.fromPublicKeyString(toResolved).assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+
+							if (fromAccount.comparePublicKey(toAccount)) {
+								continue;
+							}
+
+							pathNodesResult.push({
+								type: 'fx',
+								providerID: providerID,
+								from: { asset: fromAccount, location: networkLocation, rail: 'KEETA_SEND' },
+								to: { asset: toAccount, location: networkLocation, rail: 'KEETA_SEND' }
+							});
+						}
+					}
+
+					return(pathNodesResult);
+				}));
+
+				return(pathNodes.flat());
+			} catch (error) {
+				this.logger?.warn('AnchorGraph::computeFXNodes', `Failed to parse FX service metadata for provider ${providerID} -- ignoring:`, error);
+				return(null);
+			}
 		}));
 
 		return(providerLookupResult.flat().filter((node): node is GraphNodeLike => !!node));
@@ -686,99 +691,104 @@ class AnchorGraph {
 		}
 
 		const providerResults = await Promise.all(Object.entries(assetMovementServices).map(async ([ providerID, service ]) => {
-			const supportedOperationsMetadata = await service.operations('object');
+			try {
+				const supportedOperationsMetadata = await service.operations('object');
 
-			const supportedAssetsEntries = await service.supportedAssets('array');
+				const supportedAssetsEntries = await service.supportedAssets('array');
 
-			if (!supportedAssetsEntries) {
-				this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `No supported assets found for provider ${providerID}`);
-				return(null);
-			}
-
-			const pathNodesResult = await Promise.all(supportedAssetsEntries.map(async (assetEntry): Promise<GraphNodeLike[]> => {
-				const parsedEntry = await assetEntry('object');
-
-				const pathsResolved = await parsedEntry.paths('array');
-				const pathPromises = await Promise.allSettled(pathsResolved.map(async (pathResolvedInput): Promise<GraphNodeLike[]> => {
-					const pathResolved = await pathResolvedInput('object');
-
-					const pairResolved = await pathResolved.pair('array');
-
-					const [ fromResolved, toResolved ] = await Promise.all([
-						this.#computeAssetMovementPairSide(pairResolved[0]),
-						this.#computeAssetMovementPairSide(pairResolved[1])
-					]);
-
-					function getProviderSupportedOperationsForRail(railSpecific?: RailSupportedOperations): RailSupportedOperations {
-						const retval: RailSupportedOperations = {
-							createPersistentForwarding: supportedOperationsMetadata.createPersistentForwarding !== undefined,
-							initiateTransfer: supportedOperationsMetadata.initiateTransfer !== undefined
-						};
-
-						if (railSpecific) {
-							retval.createPersistentForwarding = railSpecific.createPersistentForwarding ?? false;
-							retval.initiateTransfer = railSpecific.initiateTransfer ?? false;
-						}
-
-						return(retval);
-					}
-
-					const pathNodes: GraphNodeLike[] = [];
-					for (const [ src, dest ] of [
-						[ fromResolved, toResolved ],
-						[ toResolved, fromResolved ]
-					] as const) {
-						for (const inboundRail of [ ...(src.rails.common ?? []), ...(src.rails.inbound ?? []) ]) {
-							/*
-							 * Drop edges whose source rail explicitly cannot
-							 * initiate a transfer and also cannot create a
-							 * persistent forwarding address.
-							 */
-							const inboundSupportedOperations = getProviderSupportedOperationsForRail(inboundRail.supportedOperations);
-							if (inboundSupportedOperations.initiateTransfer === false && inboundSupportedOperations.createPersistentForwarding === false) {
-								this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `Skipping ${providerID} edge from ${convertAssetLocationToString(src.location)} via rail ${inboundRail.rail}: neither initiateTransfer nor createPersistentForwarding supported`);
-								continue;
-							}
-
-							for (const outboundRail of [ ...(dest.rails.common ?? []), ...(dest.rails.outbound ?? []) ]) {
-								pathNodes.push({
-									type: 'assetMovement',
-									providerID: providerID,
-									from: {
-										asset: src.id,
-										location: src.location,
-										rail: inboundRail.rail,
-										supportedOperations: getProviderSupportedOperationsForRail(inboundRail.supportedOperations)
-									},
-									to: {
-										asset: dest.id,
-										location: dest.location,
-										rail: outboundRail.rail,
-										supportedOperations: getProviderSupportedOperationsForRail(outboundRail.supportedOperations)
-									}
-								});
-							}
-						}
-
-					}
-
-					return(pathNodes);
-				}));
-
-				const allPaths = [];
-
-				for (const resolved of pathPromises) {
-					if (resolved.status === 'rejected') {
-						this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `error fetching nodes for ... TODO`, resolved.reason);
-					} else {
-						allPaths.push(...resolved.value);
-					}
+				if (!supportedAssetsEntries) {
+					this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `No supported assets found for provider ${providerID}`);
+					return(null);
 				}
 
-				return(allPaths);
-			}));
+				const pathNodesResult = await Promise.all(supportedAssetsEntries.map(async (assetEntry): Promise<GraphNodeLike[]> => {
+					const parsedEntry = await assetEntry('object');
 
-			return(pathNodesResult.flat());
+					const pathsResolved = await parsedEntry.paths('array');
+					const pathPromises = await Promise.allSettled(pathsResolved.map(async (pathResolvedInput): Promise<GraphNodeLike[]> => {
+						const pathResolved = await pathResolvedInput('object');
+
+						const pairResolved = await pathResolved.pair('array');
+
+						const [ fromResolved, toResolved ] = await Promise.all([
+							this.#computeAssetMovementPairSide(pairResolved[0]),
+							this.#computeAssetMovementPairSide(pairResolved[1])
+						]);
+
+						function getProviderSupportedOperationsForRail(railSpecific?: RailSupportedOperations): RailSupportedOperations {
+							const retval: RailSupportedOperations = {
+								createPersistentForwarding: supportedOperationsMetadata.createPersistentForwarding !== undefined,
+								initiateTransfer: supportedOperationsMetadata.initiateTransfer !== undefined
+							};
+
+							if (railSpecific) {
+								retval.createPersistentForwarding = railSpecific.createPersistentForwarding ?? false;
+								retval.initiateTransfer = railSpecific.initiateTransfer ?? false;
+							}
+
+							return(retval);
+						}
+
+						const pathNodes: GraphNodeLike[] = [];
+						for (const [ src, dest ] of [
+							[ fromResolved, toResolved ],
+							[ toResolved, fromResolved ]
+						] as const) {
+							for (const inboundRail of [ ...(src.rails.common ?? []), ...(src.rails.inbound ?? []) ]) {
+								/*
+								 * Drop edges whose source rail explicitly cannot
+								 * initiate a transfer and also cannot create a
+								 * persistent forwarding address.
+								 */
+								const inboundSupportedOperations = getProviderSupportedOperationsForRail(inboundRail.supportedOperations);
+								if (inboundSupportedOperations.initiateTransfer === false && inboundSupportedOperations.createPersistentForwarding === false) {
+									this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `Skipping ${providerID} edge from ${convertAssetLocationToString(src.location)} via rail ${inboundRail.rail}: neither initiateTransfer nor createPersistentForwarding supported`);
+									continue;
+								}
+
+								for (const outboundRail of [ ...(dest.rails.common ?? []), ...(dest.rails.outbound ?? []) ]) {
+									pathNodes.push({
+										type: 'assetMovement',
+										providerID: providerID,
+										from: {
+											asset: src.id,
+											location: src.location,
+											rail: inboundRail.rail,
+											supportedOperations: getProviderSupportedOperationsForRail(inboundRail.supportedOperations)
+										},
+										to: {
+											asset: dest.id,
+											location: dest.location,
+											rail: outboundRail.rail,
+											supportedOperations: getProviderSupportedOperationsForRail(outboundRail.supportedOperations)
+										}
+									});
+								}
+							}
+
+						}
+
+						return(pathNodes);
+					}));
+
+					const allPaths = [];
+
+					for (const resolved of pathPromises) {
+						if (resolved.status === 'rejected') {
+							this.logger?.debug('AnchorGraph::computeAssetMovementNodes', `error fetching nodes for provider ${providerID}:`, resolved.reason);
+						} else {
+							allPaths.push(...resolved.value);
+						}
+					}
+
+					return(allPaths);
+				}));
+
+				return(pathNodesResult.flat());
+			} catch (error) {
+				this.logger?.warn('AnchorGraph::computeAssetMovementNodes', `Failed to parse asset movement service metadata for provider ${providerID} -- ignoring:`, error);
+				return(null);
+			}
 		}));
 
 		return(providerResults.flat().filter((node): node is GraphNodeLike => !!node));

--- a/src/lib/resolver.test.ts
+++ b/src/lib/resolver.test.ts
@@ -7,6 +7,7 @@ import type { ServiceMetadata, ServiceMetadataExternalizable, ServiceSearchCrite
 import { createNodeAndClient, setResolverInfo as setInfo } from './utils/tests/node.js';
 import { SignData, objectToSignable } from './utils/signing.js';
 import { extractSignedFields } from './anchor-metadata-server.js';
+import { toJSONSerializable } from './utils/json.js';
 
 async function setupForResolverTests() {
 	const testAccountSeed = KeetaNetClient.lib.Account.generateRandomSeed();
@@ -978,4 +979,256 @@ test('SharedLookupCriteria.accounts: filters banking entries by signing account'
 		const result = await resolver.lookup('banking', testCase.criteria, testCase.shared);
 		expect(summarizeBankingLookup(result), testCase.name).toEqual(testCase.expected);
 	}
+});
+
+test('ignores unparsable anchor metadata', async function() {
+	const validRoot = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
+	const invalidRoot = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
+	const brokenKeetaAnchor = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0);
+	const fromToken = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
+	const toToken = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
+	const ampToken = KeetaNetClient.lib.Account.fromSeed(KeetaNetClient.lib.Account.generateRandomSeed(), 0, KeetaNetClient.lib.Account.AccountKeyAlgorithm.TOKEN);
+
+	const { userClient, fees } = await createNodeAndClient(validRoot);
+	fees.disable();
+
+	for (const [account, metadata] of [
+		[invalidRoot, 'not-valid-root-metadata'],
+		[brokenKeetaAnchor, 'not-valid-anchor-metadata']
+	] as const) {
+		const accountClient = new KeetaNetClient.UserClient({
+			client: userClient.client,
+			signer: account,
+			usePublishAid: false,
+			network: userClient.network,
+			networkAlias: 'test'
+		});
+		await accountClient.setInfo({
+			name: '',
+			description: '',
+			metadata
+		});
+	}
+
+	const keetaLocation = `chain:keeta:${userClient.network}`;
+	const ampPathSideKeeta = {
+		id: ampToken.publicKeyString.get(),
+		location: keetaLocation,
+		rails: { common: ['KEETA_SEND'], outbound: ['KEETA_SEND'] }
+	};
+	const ampPathSideBank = {
+		id: 'USD',
+		location: 'bank-account:us',
+		rails: { common: ['ACH'], inbound: ['ACH'] }
+	};
+	const ampGoodPath = {
+		pair: [ampPathSideKeeta, ampPathSideBank]
+	};
+	const ampSupportedAssetsEntry = {
+		asset: [ampToken.publicKeyString.get(), 'USD'],
+		paths: [ampGoodPath]
+	};
+
+	const malformedRootMetadata = toJSONSerializable({
+		version: 1,
+		currencyMap: {},
+		services: {
+			banking: {
+				good_bank: {
+					operations: {
+						createAccount: 'https://bank.good.com/api/v1/createAccount'
+					},
+					countryCodes: ['US'],
+					currencyCodes: ['USD'],
+					kycProviders: []
+				},
+				broken_bank_keeta: {
+					external: '2b828e33-2692-46e9-817e-9b93d63f28fd',
+					url: `keetanet://${brokenKeetaAnchor.publicKeyString.get()}/metadata`
+				},
+				broken_bank_https: {
+					external: '2b828e33-2692-46e9-817e-9b93d63f28fd',
+					url: 'https://keeta.com/__TEST__/metadata'
+				},
+				broken_bank_schema: {
+					operations: {
+						createAccount: 'https://bank.bad-schema.com/api/v1/createAccount'
+					},
+					countryCodes: 'USD'
+				},
+				broken_bank_empty: {}
+			},
+			fx: {
+				good_fx: {
+					operations: {
+						createExchange: 'https://fx.good.com/createExchange'
+					},
+					from: [{
+						currencyCodes: [fromToken.publicKeyString.get()],
+						to: [toToken.publicKeyString.get()]
+					}]
+				},
+				broken_fx: {
+					from: 'not-an-array'
+				}
+			},
+			kyc: {
+				good_kyc: {
+					operations: {
+						createVerification: 'https://kyc.good.com/createVerification'
+					},
+					countryCodes: ['US'],
+					ca: 'TEST'
+				},
+				broken_kyc: {
+					operations: {
+						createVerification: 'https://kyc.bad.com/createVerification'
+					},
+					countryCodes: ['US']
+				}
+			},
+			assetMovement: {
+				good_amp: {
+					operations: {
+						initiateTransfer: 'https://amp.good.com/initiateTransfer'
+					},
+					supportedAssets: [ampSupportedAssetsEntry]
+				},
+				good_amp_partial_paths: {
+					operations: {
+						initiateTransfer: 'https://amp.partial.com/initiateTransfer'
+					},
+					supportedAssets: [{
+						asset: [ampToken.publicKeyString.get(), 'USD'],
+						paths: [
+							ampGoodPath,
+							{
+								pair: [
+									{
+										id: ampToken.publicKeyString.get(),
+										location: keetaLocation,
+										rails: {}
+									},
+									ampPathSideBank
+								]
+							}
+						]
+					}]
+				},
+				good_amp_partial_entries: {
+					operations: {
+						initiateTransfer: 'https://amp.partial-entry.com/initiateTransfer'
+					},
+					supportedAssets: [
+						ampSupportedAssetsEntry,
+						'not-a-supported-assets-entry'
+					]
+				},
+				broken_amp: {
+					supportedAssets: 'not-an-array'
+				},
+				broken_amp_keeta: {
+					external: '2b828e33-2692-46e9-817e-9b93d63f28fd',
+					url: `keetanet://${brokenKeetaAnchor.publicKeyString.get()}/metadata`
+				}
+			}
+		}
+	});
+
+	await userClient.setInfo({
+		name: '',
+		description: '',
+		metadata: Resolver.Metadata.formatMetadata(malformedRootMetadata)
+	});
+
+	fees.enable();
+
+	const warnLogs: unknown[][] = [];
+	const resolver = new Resolver({
+		root: [invalidRoot, validRoot],
+		client: userClient,
+		trustedCAs: [],
+		logger: {
+			log: () => {},
+			debug: () => {},
+			info: () => {},
+			warn: (...args: unknown[]) => { warnLogs.push(args); },
+			error: () => {}
+		}
+	});
+
+	const malformedMetadataLookupCases = [
+		{
+			name: 'banking survives invalid root metadata',
+			service: 'banking',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_bank']
+		},
+		{
+			name: 'banking ignores keetanet external anchor with unparsable metadata',
+			service: 'banking',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_bank']
+		},
+		{
+			name: 'banking ignores unreachable HTTPS external metadata',
+			service: 'banking',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_bank']
+		},
+		{
+			name: 'banking ignores schema-invalid provider metadata',
+			service: 'banking',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_bank']
+		},
+		{
+			name: 'banking ignores empty provider metadata',
+			service: 'banking',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_bank']
+		},
+		{
+			name: 'fx ignores provider with unparsable from paths',
+			service: 'fx',
+			criteria: {},
+			expectedProviderIDs: ['good_fx']
+		},
+		{
+			name: 'kyc ignores provider missing required ca field',
+			service: 'kyc',
+			criteria: { countryCodes: ['US'] },
+			expectedProviderIDs: ['good_kyc']
+		},
+		{
+			name: 'assetMovement keeps provider when another path has no usable rails',
+			service: 'assetMovement',
+			criteria: {},
+			expectedProviderIDs: ['good_amp', 'good_amp_partial_paths', 'good_amp_partial_entries']
+		},
+		{
+			name: 'assetMovement ignores provider with unparsable supportedAssets',
+			service: 'assetMovement',
+			criteria: {},
+			expectedProviderIDs: ['good_amp', 'good_amp_partial_paths', 'good_amp_partial_entries']
+		},
+		{
+			name: 'assetMovement ignores keetanet external anchor with unparsable metadata',
+			service: 'assetMovement',
+			criteria: {},
+			expectedProviderIDs: ['good_amp', 'good_amp_partial_paths', 'good_amp_partial_entries']
+		}
+	] satisfies {
+		name: string;
+		service: keyof NonNullable<ServiceMetadata['services']>;
+		criteria: ServiceSearchCriteria<keyof NonNullable<ServiceMetadata['services']>>;
+		expectedProviderIDs: string[];
+	}[];
+
+	for (const testCase of malformedMetadataLookupCases) {
+		const result = await resolver.lookup(testCase.service, testCase.criteria);
+		expect(Object.keys(result ?? {}).sort(), testCase.name).toEqual([...testCase.expectedProviderIDs].sort());
+	}
+
+	expect(warnLogs.length).toBeGreaterThan(0);
 });

--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -7,7 +7,7 @@ import type { DeepPartial } from './utils/types.ts';
 import { assertNever } from './utils/never.js';
 import { Buffer } from './utils/buffer.js';
 import crypto from './utils/crypto.js';
-import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCanonical, assertKeetaSupportedAssetsMetadata } from '../services/asset-movement/common.js';
+import { convertAssetLocationInputToCanonical, convertAssetOrPairSearchInputToCanonical, assertKeetaSupportedAssetsMetadataItem } from '../services/asset-movement/common.js';
 import type { AssetLocationString, Rail, SupportedAssetsMetadata, RailOrRailWithExtendedDetails, AssetMovementRailSearchInput, AnchorCustomLocationMetadata } from '../services/asset-movement/common.js';
 import type { MovableAssetSearchInput, KeetaNetTokenPublicKeyString, EVMChecksumCache } from './asset.js';
 import { checksumEVMAsset, isEVMAsset } from './asset.js';
@@ -1142,12 +1142,20 @@ class Metadata implements ValuizableInstance {
 		const metadataBytes = Buffer.from(metadataUncompressed);
 		const metadataDecoded = metadataBytes.toString('utf-8');
 
-		/*
-		 * JSON.parse() will always return a JSONSerializable,
-		 * and not `unknown`, so we can safely cast it.
-		 */
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-		const retval = await this.resolveValue(JSON.parse(metadataDecoded) as JSONSerializable);
+		let parsed: JSONSerializable;
+		try {
+			/*
+			 * JSON.parse() will always return a JSONSerializable,
+			 * and not `unknown`, so we can safely cast it.
+			 */
+			// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+			parsed = JSON.parse(metadataDecoded) as JSONSerializable;
+		} catch (parseError) {
+			this.#logger?.warn(`Resolver:${this.#resolver.id}`, 'Failed to parse metadata JSON from', this.#url.toString(), ':', parseError);
+			throw(parseError);
+		}
+
+		const retval = await this.resolveValue(parsed);
 
 		return(retval);
 	}
@@ -2049,109 +2057,125 @@ class Resolver {
 		const toCanonical = criteria.to ? convertAssetLocationInputToCanonical(criteria.to) : undefined;
 
 		const resolvedService = await Metadata.fullyResolveValuizable(assetService.supportedAssets);
-		const supportedAssets = assertKeetaSupportedAssetsMetadata(resolvedService);
+		if (!Array.isArray(resolvedService)) {
+			throw(new Error('Expected "supportedAssets" to be an array'));
+		}
+
+		const supportedAssets: SupportedAssetsMetadata[] = [];
+		for (let supportedAssetIndex = 0; supportedAssetIndex < resolvedService.length; supportedAssetIndex++) {
+			const resolvedSupportedAsset = resolvedService[supportedAssetIndex];
+			try {
+				supportedAssets.push(assertKeetaSupportedAssetsMetadataItem(resolvedSupportedAsset));
+			} catch (assertError) {
+				this.#logger?.warn(`Resolver:${this.id}`, 'Error parsing supportedAssets entry', supportedAssetIndex, ':', assertError, '-- ignoring entry');
+			}
+		}
 
 		const filteredAssetMovement: SupportedAssetsMetadata[] = [];
 		for (const supportedAsset of supportedAssets) {
 			let matchFound = false;
 
 			for (const path of supportedAsset.paths) {
-				for (const [ fromAsset, toAsset ] of [ [ path.pair[0], path.pair[1] ], [ path.pair[1], path.pair[0] ] ] as const) {
-					const fromId = this.#canonicalizeMetadataAssetId(fromAsset.id);
-					const toId = this.#canonicalizeMetadataAssetId(toAsset.id);
+				try {
+					for (const [ fromAsset, toAsset ] of [ [ path.pair[0], path.pair[1] ], [ path.pair[1], path.pair[0] ] ] as const) {
+						const fromId = this.#canonicalizeMetadataAssetId(fromAsset.id);
+						const toId = this.#canonicalizeMetadataAssetId(toAsset.id);
 
-					if (fromCanonical && fromCanonical !== fromAsset.location) {
-						continue;
-					}
-
-					if (toCanonical && toCanonical !== toAsset.location) {
-						continue;
-					}
-
-					if (assetCanonical) {
-						if (typeof assetCanonical === 'string') {
-							if (!([ fromId, toId ].includes(assetCanonical))) {
-								continue;
-							}
-						} else if (fromId !== assetCanonical.from || toId !== assetCanonical.to) {
+						if (fromCanonical && fromCanonical !== fromAsset.location) {
 							continue;
 						}
-					}
 
-					const supportedRails = {
-						inbound: [ ...(fromAsset.rails.inbound ?? []), ...(fromAsset.rails.common ?? []) ],
-						outbound: [ ...(toAsset.rails.outbound ?? []), ...(toAsset.rails.common ?? []) ]
-					}
+						if (toCanonical && toCanonical !== toAsset.location) {
+							continue;
+						}
 
-					if ((supportedRails.inbound.length + supportedRails.outbound.length) === 0) {
-						continue;
-					}
-
-					const checkSupportedRailIncludes = (searchFor: Rail, searchIn: RailOrRailWithExtendedDetails[]): boolean => {
-						for (const checkRail of searchIn) {
-							if (typeof checkRail === 'string') {
-								if (checkRail === searchFor) {
-									return(true);
+						if (assetCanonical) {
+							if (typeof assetCanonical === 'string') {
+								if (!([ fromId, toId ].includes(assetCanonical))) {
+									continue;
 								}
-							} else {
-								if (checkRail.rail === searchFor) {
-									return(true);
-								}
+							} else if (fromId !== assetCanonical.from || toId !== assetCanonical.to) {
+								continue;
 							}
 						}
 
-						return(false);
-					}
+						const supportedRails = {
+							inbound: [ ...(fromAsset.rails.inbound ?? []), ...(fromAsset.rails.common ?? []) ],
+							outbound: [ ...(toAsset.rails.outbound ?? []), ...(toAsset.rails.common ?? []) ]
+						}
 
-					if (criteria.rail !== undefined) {
-						let railMatchFound = false;
-						for (const direction of ['inbound', 'outbound'] as const) {
-							let searchFor;
-							let searchIn;
-							let eitherDirectionSharedSearch;
+						if ((supportedRails.inbound.length + supportedRails.outbound.length) === 0) {
+							continue;
+						}
 
-							if (typeof criteria.rail === 'object' && !Array.isArray(criteria.rail)) {
-								searchFor = criteria.rail[direction];
-								searchIn = supportedRails[direction];
-								eitherDirectionSharedSearch = false;
-							} else {
-								searchFor = criteria.rail;
-								searchIn = [ ...supportedRails.inbound, ...supportedRails.outbound ];
-								eitherDirectionSharedSearch = true;
-							}
-
-
-							if (searchFor !== undefined) {
-								if (typeof searchFor === 'string') {
-									railMatchFound = checkSupportedRailIncludes(searchFor, searchIn);
+						const checkSupportedRailIncludes = (searchFor: Rail, searchIn: RailOrRailWithExtendedDetails[]): boolean => {
+							for (const checkRail of searchIn) {
+								if (typeof checkRail === 'string') {
+									if (checkRail === searchFor) {
+										return(true);
+									}
 								} else {
-									for (const checkRail of searchFor) {
-										railMatchFound = checkSupportedRailIncludes(checkRail, searchIn);
-
-										if (railMatchFound) {
-											break;
-										}
+									if (checkRail.rail === searchFor) {
+										return(true);
 									}
 								}
 							}
 
-							// If we are doing a shared search across both directions, then we only need to find a match in one direction, so we can break early. If we are doing separate searches for each direction, then we need to continue and check the next direction if we don't find a match in the first direction.
-							if (eitherDirectionSharedSearch) {
-								break;
+							return(false);
+						}
+
+						if (criteria.rail !== undefined) {
+							let railMatchFound = false;
+							for (const direction of ['inbound', 'outbound'] as const) {
+								let searchFor;
+								let searchIn;
+								let eitherDirectionSharedSearch;
+
+								if (typeof criteria.rail === 'object' && !Array.isArray(criteria.rail)) {
+									searchFor = criteria.rail[direction];
+									searchIn = supportedRails[direction];
+									eitherDirectionSharedSearch = false;
+								} else {
+									searchFor = criteria.rail;
+									searchIn = [ ...supportedRails.inbound, ...supportedRails.outbound ];
+									eitherDirectionSharedSearch = true;
+								}
+
+
+								if (searchFor !== undefined) {
+									if (typeof searchFor === 'string') {
+										railMatchFound = checkSupportedRailIncludes(searchFor, searchIn);
+									} else {
+										for (const checkRail of searchFor) {
+											railMatchFound = checkSupportedRailIncludes(checkRail, searchIn);
+
+											if (railMatchFound) {
+												break;
+											}
+										}
+									}
+								}
+
+								// If we are doing a shared search across both directions, then we only need to find a match in one direction, so we can break early. If we are doing separate searches for each direction, then we need to continue and check the next direction if we don't find a match in the first direction.
+								if (eitherDirectionSharedSearch) {
+									break;
+								}
+
+								if (railMatchFound) {
+									break;
+								}
 							}
 
-							if (railMatchFound) {
-								break;
+							if (!railMatchFound) {
+								continue;
 							}
 						}
 
-						if (!railMatchFound) {
-							continue;
-						}
+						matchFound = true;
+						break;
 					}
-
-					matchFound = true;
-					break;
+				} catch (pathError) {
+					this.#logger?.warn(`Resolver:${this.id}`, 'Error parsing asset movement path:', pathError, '-- ignoring path');
 				}
 
 				if (matchFound) {
@@ -2174,24 +2198,24 @@ class Resolver {
 
 		const retval: ResolverLookupServiceResults<'assetMovement'> = {};
 		for (const checkAssetMovementServiceID in assetServices) {
-			const checkAssetMovementService = await assetServices[checkAssetMovementServiceID]?.('object');
-
-			if (checkAssetMovementService === undefined) {
-				return(undefined);
-			}
-
-			if (!('operations' in checkAssetMovementService)) {
-				return(undefined);
-			}
-
 			try {
+				const checkAssetMovementService = await assetServices[checkAssetMovementServiceID]?.('object');
+
+				if (checkAssetMovementService === undefined) {
+					continue;
+				}
+
+				if (!('operations' in checkAssetMovementService)) {
+					continue;
+				}
+
 				const supportedAssets = await this.filterSupportedAssets(checkAssetMovementService, criteria);
 				if (supportedAssets.length === 0) {
 					continue;
 				}
 				retval[checkAssetMovementServiceID] = await assertResolverLookupAssetMovementResults(checkAssetMovementService);
 			} catch (parseError) {
-				this.#logger?.debug(`Resolver:${this.id}`, 'Error checking AssetMovement service', checkAssetMovementServiceID, ':', parseError, ' -- ignoring');
+				this.#logger?.warn(`Resolver:${this.id}`, 'Error checking AssetMovement service', checkAssetMovementServiceID, ':', parseError, '-- ignoring');
 			}
 		}
 
@@ -2278,23 +2302,24 @@ class Resolver {
 				this.#logger?.debug(`Resolver:${this.id}`, 'Root Metadata for', root.publicKeyString.get(), ':', rootMetadata);
 
 				if (!('version' in rootMetadata)) {
-					this.#logger?.debug(`Resolver:${this.id}`, 'Root metadata for', root.publicKeyString.get(), 'is missing "version" property, skipping');
+					this.#logger?.warn(`Resolver:${this.id}`, 'Root metadata for', root.publicKeyString.get(), 'is missing "version" property -- ignoring root');
 					continue;
 				}
 
 				const rootMetadataVersion = await rootMetadata.version?.('primitive');
 				if (rootMetadataVersion !== 1) {
-					this.#logger?.debug(`Resolver:${this.id}`, 'Unsupported metadata version', rootMetadataVersion, 'for', root.publicKeyString.get(), ', skipping');
+					this.#logger?.warn(`Resolver:${this.id}`, 'Unsupported metadata version', rootMetadataVersion, 'for', root.publicKeyString.get(), '-- ignoring root');
 					continue;
 				}
 
 				allRootMetadata.push(rootMetadata);
 			} catch (error) {
-				this.#logger?.debug(`Resolver:${this.id}`, 'Error fetching metadata for', root.publicKeyString.get(), ':', error, ' -- skipping');
+				this.#logger?.warn(`Resolver:${this.id}`, 'Error fetching metadata for', root.publicKeyString.get(), ':', error, '-- ignoring root');
 			}
 		}
 
 		if (allRootMetadata.length === 0) {
+			this.#logger?.warn(`Resolver:${this.id}`, 'No valid root metadata found among', this.#roots.length, 'configured root(s)');
 			throw(new Error('No valid root metadata found'));
 		}
 
@@ -2337,9 +2362,13 @@ class Resolver {
 					continue;
 				}
 				if ('currencyMap' in metadata && metadata.currencyMap !== undefined) {
-					const currencyMap = await metadata.currencyMap('object');
-					for (const [currencyCode, tokenValue] of Object.entries(currencyMap)) {
-						mergedCurrencyMap[currencyCode] = tokenValue;
+					try {
+						const currencyMap = await metadata.currencyMap('object');
+						for (const [currencyCode, tokenValue] of Object.entries(currencyMap)) {
+							mergedCurrencyMap[currencyCode] = tokenValue;
+						}
+					} catch (mergeError) {
+						this.#logger?.warn(`Resolver:${this.id}`, 'Error merging currencyMap from root index', i, ':', mergeError, '-- ignoring root currencyMap');
 					}
 				}
 			}
@@ -2367,7 +2396,13 @@ class Resolver {
 					continue;
 				}
 				if ('services' in metadata && metadata.services !== undefined) {
-					const services = await metadata.services('object');
+					let services: ValuizableObject;
+					try {
+						services = await metadata.services('object');
+					} catch (mergeError) {
+						this.#logger?.warn(`Resolver:${this.id}`, 'Error merging services from root index', i, ':', mergeError, '-- ignoring root services');
+						continue;
+					}
 					for (const [serviceType, serviceValue] of Object.entries(services)) {
 						if (serviceValue === undefined) {
 							continue;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core service discovery and routing graph construction; behavior shifts from fail-fast to best-effort, which could hide misconfigured providers until logs are checked.
> 
> **Overview**
> **Resolver and anchor graph building no longer fail wholesale when a single provider or metadata fragment is invalid**—valid services keep resolving while bad entries are skipped with warnings.
> 
> The **resolver** now tolerates failures at finer granularity: invalid JSON when reading metadata, invalid root anchors (skipped instead of aborting the whole root set), per-entry `supportedAssets` validation, per-path errors during asset-movement filtering, and per-provider errors in asset-movement lookup (including continuing past missing `operations` instead of returning `undefined` for all providers). Multi-root merge of `currencyMap` and `services` is also guarded so one bad root slice does not break the merge.
> 
> **Anchor graph node computation** (`#computeFXNodes`, `#computeAssetMovementNodes`) wraps each provider in `try/catch` so malformed FX or asset-movement metadata drops only that provider’s edges.
> 
> Tests add broad **malformed-metadata lookup** coverage across banking, FX, KYC, and asset movement, plus a chaining test that a broken FX provider is omitted from `computeGraphNodes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db3d4ba8f528721256de04ec8d3d44f75dc4415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->