### PR TITLE
Release 0.0.87

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.86",
+	"version": "0.0.87",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.86",
+			"version": "0.0.87",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.86",
+	"version": "0.0.87",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
Includes changes from:
 - #399 
 - #401 
 - #403 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only manifest version fields change; no runtime or dependency updates in the shown diff.
> 
> **Overview**
> **Release 0.0.87** — bumps `@keetanetwork/anchor` from **0.0.86** to **0.0.87** in `package.json` and `package-lock.json`.
> 
> No dependency, script, or source changes appear in this diff; the PR description notes bundled work from #399, #401, and #403 that may already be on the release branch outside this patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab9d96ecec06e0ddc7a25ff559b0a1786c58957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->