### PR TITLE
Add a queue log when jobs are finished

### DIFF
--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1008,6 +1008,8 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 				by = undefined;
 			}
 
+			logger?.debug(`Finished processing entry request with id ${String(entry.id)} with new status`, setEntryStatus.status);
+
 			await this.queue.setStatus(entry.id, setEntryStatus.status, { oldStatus: 'processing', by: by, output: this.encodeResponse(setEntryStatus.output), error: setEntryStatus.error });
 
 			return(processJobOk);
@@ -1365,6 +1367,13 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 	}
 
 	async maintain(): Promise<void> {
+		/*
+		 * Only the worker with ID 0 should perform maintenance tasks on requests
+		 */
+		if (this.workers.id !== 0) {
+			return;
+		}
+
 		const logger = this.methodLogger('maintain');
 
 		await this.initialize();
@@ -1378,13 +1387,6 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 			logger?.debug('Failed to maintain runner lock:', error);
 		}
 
-		if (this.workers.id !== 0) {
-			return;
-		}
-
-		/*
-		 * Only the worker with ID 0 should perform maintenance tasks on requests
-		 */
 		try {
 			await this.markStuckRequestsAsStuck();
 		} catch (error: unknown) {


### PR DESCRIPTION
This change adds support for logging when a queue entry is finished processing, which is useful to look at for timestamp as well as auditing purposes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logging and control-flow change in queue maintenance; multi-worker maintain behavior shifts only if workers with id ≠ 0 call maintain, which is currently limited by runner configuration.
> 
> **Overview**
> Adds a **debug** log when a queue entry finishes processing, recording the entry id and the **new status** right before `setStatus` persists the outcome—useful for timestamps and auditing job lifecycles.
> 
> In `maintain()`, the **worker id !== 0** early return is moved to the **top** of the method so only worker 0 runs maintenance (stuck marking, retries, piping, etc.). Non-zero workers no longer run `initialize()` or `maintainRunnerLock()` on the maintain path; previously they still did those steps before returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e62a6d5bf1f58ac67dba4c603babe452b947be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->