### PR TITLE
Add minimum transfer value to persistent address

### DIFF
--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -1038,6 +1038,10 @@ export type KeetaPersistentForwardingAddressDetails = {
 	destinationAddress?: AddressResolved | AddressObfuscated;
 	outgoingRail?: Rail;
 	incomingRail?: Rail[];
+	minimumTransferValue?: {
+		asset: MovableAssetSearchCanonical;
+		value: string;
+	}
 	fees?: PersistentAddressAssetFeeBreakdown;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional field on a shared type only; no runtime or enforcement logic in this diff.
> 
> **Overview**
> Adds an optional **`minimumTransferValue`** field on **`KeetaPersistentForwardingAddressDetails`**, so create/list persistent forwarding responses can expose a floor transfer amount (canonical asset + value string in smallest units), alongside existing fields like fees and rails.
> 
> This is a **type-only** API contract extension in `common.ts`; callers can surface minimums in the UI without inferring them from rail metadata alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2297553f8a8fa7028297ba6fec85fe468225e092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->