### PR TITLE
Fix queue maintenance, again

### DIFF
--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -1367,24 +1367,28 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 	}
 
 	async maintain(): Promise<void> {
-		/*
-		 * Only the worker with ID 0 should perform maintenance tasks on requests
-		 */
-		if (this.workers.id !== 0) {
-			return;
-		}
-
 		const logger = this.methodLogger('maintain');
 
 		await this.initialize();
 
 		/*
-		 * Each worker should maintain its own lock
+		 * Call `maintainRunnerLock` for every worker ID (not just 0)
+		 * so that we can ensure the runner lock is maintained and not
+		 * stale as part of maintain()
 		 */
 		try {
 			await this.maintainRunnerLock();
 		} catch (error: unknown) {
 			logger?.debug('Failed to maintain runner lock:', error);
+		}
+
+		/*
+		 * Only the worker with ID 0 should the rest of the maintenance tasks
+		 * so that we don't have multiple workers trying to do the same
+		 * maintenance tasks at the same time on the same queues
+		 */
+		if (this.workers.id !== 0) {
+			return;
 		}
 
 		try {


### PR DESCRIPTION
As fixed in #149 (and broken in #403), this change fixes and better documents why the `maintainRunnerLock` is performed on every worker and not just worker 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multi-worker queue coordination and stale-lock recovery; wrong ordering could duplicate maintenance or leave locks stale, but scope is limited to `maintain()` flow.
> 
> **Overview**
> **Reorders `KeetaAnchorQueueRunner.maintain()`** so per-worker runner locks are refreshed on every worker, not only worker 0.
> 
> Previously, non-zero workers exited `maintain()` immediately, so only worker 0 called `maintainRunnerLock()`—restoring the behavior from #149 that #403 regressed. **Worker 0 still alone** runs queue-wide maintenance (stuck jobs, failed requeues, pipe moves, piped `maintain()`), after the early return for `workers.id !== 0`.
> 
> Comments now spell out why lock maintenance is per-worker while other tasks stay single-leader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01eca847f414324b28035fe5786cddf2c7760a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->