### PR TITLE
Upgrade to KeetaNet v0.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",
-				"@keetanetwork/keetanet-client": "0.18.2",
+				"@keetanetwork/keetanet-client": "0.18.3",
 				"@noble/hashes": "1.5.0",
 				"typia": "9.5.0"
 			},
@@ -19,7 +19,7 @@
 				"@cspell/dict-typescript": "3.2.3",
 				"@google-cloud/firestore": "8.2.0",
 				"@keetanetwork/eslint-config-typescript": "1.4.7",
-				"@keetanetwork/keetanet-node": "0.18.2",
+				"@keetanetwork/keetanet-node": "0.18.3",
 				"@ryoppippi/unplugin-typia": "2.6.5",
 				"@types/asn1js": "2.0.2",
 				"@types/node": "20.16.10",
@@ -3010,7 +3010,6 @@
 		},
 		"node_modules/@keetanetwork/asn1-napi-rs": {
 			"version": "1.2.3",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/asn1-napi-rs/1.2.3/9efe6a98c1934b0058b39719e9a4100b8459117e",
 			"integrity": "sha512-3Uao9FFrzAl6SEMHMiTTF2IGqd1c7N9ZAkKECV0g9jrrqxg75yDYsFhbO2X/uYsZaAuGp0cYVoC6JJCTvp/z4A==",
 			"devOptional": true,
 			"license": "SEE LICENSE IN LICENSE",
@@ -3020,13 +3019,11 @@
 		},
 		"node_modules/@keetanetwork/currency-info": {
 			"version": "1.2.5",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/currency-info/1.2.5/c95cfedc57676d74f55130f2318d88cd80018b2b",
 			"integrity": "sha512-3IJz864AY46ng3Di84gSxqGV/DzzQzjJwOkm4BPefWkMYpA61/7411p5xCjzkFsC8mfR9ChXfI01m4xRgrKskw==",
 			"license": "ISC"
 		},
 		"node_modules/@keetanetwork/eslint-config-typescript": {
 			"version": "1.4.7",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/eslint-config-typescript/1.4.7/4d7fee49366a21277c057370ef765104415f05db",
 			"integrity": "sha512-2Mh0N0ljLw0vamq80CAEQRGquG55LdxvIunP/7n90l2OVHDVuBuHNP0eRN8WI7WM/uucByhakCVX2xSLV/YIpQ==",
 			"dev": true,
 			"license": "ISC",
@@ -3072,9 +3069,8 @@
 			}
 		},
 		"node_modules/@keetanetwork/keetanet-client": {
-			"version": "0.18.2",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-client/0.18.2/c8afe1be6507c91b72dbb5c2a0a3117a464a7d56",
-			"integrity": "sha512-UiuNO74j7EmDGuZkWfNMDb5vnQqLIH5Y68GcTDU6KwK4ZO3DB7WKjUnQMTw1tO4nZidqizgRrT4vUaSzJ0PJPw==",
+			"version": "0.18.3",
+			"integrity": "sha512-MgeUMnFIB3DNnF611KmTRQ4ME1rfwUVE5HBeUTeD06/szurd7+aALcwQCBOIbtfy7YhyGR2K6HRqktMel11DpQ==",
 			"license": "see LICENSE",
 			"dependencies": {
 				"secp256k1": "5.0.1"
@@ -3085,9 +3081,8 @@
 			}
 		},
 		"node_modules/@keetanetwork/keetanet-node": {
-			"version": "0.18.2",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.18.2/bd8d017b6e45e2c5c482d3493b7afa5f86cfe4f8",
-			"integrity": "sha512-0OwRcZ4FjP7xZUxkzivLb/W25RL42yI9N7dXc+ANmKFm4vdkVbbWr30hnLcrW2ulN2Vh5KvDEf/yNC4Lqyn1bA==",
+			"version": "0.18.3",
+			"integrity": "sha512-8yjaPuvQPSMVuHNH0vQGXtthU47cP6kHjjPlgumvFB976bMQnkpKbp6GHTVwpaMmY1DDAfaxgGbwndMizctBkg==",
 			"dev": true,
 			"license": "see LICENSE",
 			"dependencies": {
@@ -3182,7 +3177,6 @@
 		},
 		"node_modules/@keetanetwork/pulumi-components": {
 			"version": "1.0.78",
-			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/pulumi-components/1.0.78/0cc59ccc9daec249a3d8c9047e975cc541280517",
 			"integrity": "sha512-XgUnNBSQ8rZL/FBQKm7m/szYiKWsEErTN9ZWXQeiIESTI9KpQ40+3VGuFool4VFNANT+0M488TTllUUYHNq+Sg==",
 			"dev": true,
 			"license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3010,6 +3010,7 @@
 		},
 		"node_modules/@keetanetwork/asn1-napi-rs": {
 			"version": "1.2.3",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/asn1-napi-rs/1.2.3/9efe6a98c1934b0058b39719e9a4100b8459117e",
 			"integrity": "sha512-3Uao9FFrzAl6SEMHMiTTF2IGqd1c7N9ZAkKECV0g9jrrqxg75yDYsFhbO2X/uYsZaAuGp0cYVoC6JJCTvp/z4A==",
 			"devOptional": true,
 			"license": "SEE LICENSE IN LICENSE",
@@ -3019,11 +3020,13 @@
 		},
 		"node_modules/@keetanetwork/currency-info": {
 			"version": "1.2.5",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/currency-info/1.2.5/c95cfedc57676d74f55130f2318d88cd80018b2b",
 			"integrity": "sha512-3IJz864AY46ng3Di84gSxqGV/DzzQzjJwOkm4BPefWkMYpA61/7411p5xCjzkFsC8mfR9ChXfI01m4xRgrKskw==",
 			"license": "ISC"
 		},
 		"node_modules/@keetanetwork/eslint-config-typescript": {
 			"version": "1.4.7",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/eslint-config-typescript/1.4.7/4d7fee49366a21277c057370ef765104415f05db",
 			"integrity": "sha512-2Mh0N0ljLw0vamq80CAEQRGquG55LdxvIunP/7n90l2OVHDVuBuHNP0eRN8WI7WM/uucByhakCVX2xSLV/YIpQ==",
 			"dev": true,
 			"license": "ISC",
@@ -3070,6 +3073,7 @@
 		},
 		"node_modules/@keetanetwork/keetanet-client": {
 			"version": "0.18.3",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-client/0.18.3/d1b7f0d37520bebeb2db7bc35aa512ab36ea6aef",
 			"integrity": "sha512-MgeUMnFIB3DNnF611KmTRQ4ME1rfwUVE5HBeUTeD06/szurd7+aALcwQCBOIbtfy7YhyGR2K6HRqktMel11DpQ==",
 			"license": "see LICENSE",
 			"dependencies": {
@@ -3082,6 +3086,7 @@
 		},
 		"node_modules/@keetanetwork/keetanet-node": {
 			"version": "0.18.3",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/keetanet-node/0.18.3/fe7cfec8d9f1119e7f5bd2e3f94bb1809fab1a45",
 			"integrity": "sha512-8yjaPuvQPSMVuHNH0vQGXtthU47cP6kHjjPlgumvFB976bMQnkpKbp6GHTVwpaMmY1DDAfaxgGbwndMizctBkg==",
 			"dev": true,
 			"license": "see LICENSE",
@@ -3177,6 +3182,7 @@
 		},
 		"node_modules/@keetanetwork/pulumi-components": {
 			"version": "1.0.78",
+			"resolved": "https://npm.pkg.github.com/download/@KeetaNetwork/pulumi-components/1.0.78/0cc59ccc9daec249a3d8c9047e975cc541280517",
 			"integrity": "sha512-XgUnNBSQ8rZL/FBQKm7m/szYiKWsEErTN9ZWXQeiIESTI9KpQ40+3VGuFool4VFNANT+0M488TTllUUYHNq+Sg==",
 			"dev": true,
 			"license": "ISC",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@cspell/dict-typescript": "3.2.3",
 		"@google-cloud/firestore": "8.2.0",
 		"@keetanetwork/eslint-config-typescript": "1.4.7",
-		"@keetanetwork/keetanet-node": "0.18.2",
+		"@keetanetwork/keetanet-node": "0.18.3",
 		"@ryoppippi/unplugin-typia": "2.6.5",
 		"@types/asn1js": "2.0.2",
 		"@types/node": "20.16.10",
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@keetanetwork/currency-info": "1.2.5",
-		"@keetanetwork/keetanet-client": "0.18.2",
+		"@keetanetwork/keetanet-client": "0.18.3",
 		"@noble/hashes": "1.5.0",
 		"typia": "9.5.0"
 	},


### PR DESCRIPTION
This change upgrades to [KeetaNet v0.18.3](https://github.com/KeetaNetwork/node/releases/tag/releases%2Fv0.18.3) which improves the `Log.sync()` method.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency upgrade with no application code changes; risk is limited to upstream KeetaNet behavior in log sync.
> 
> **Overview**
> Bumps **`@keetanetwork/keetanet-client`** (runtime) and **`@keetanetwork/keetanet-node`** (dev) from **0.18.2** to **0.18.3**, with matching **`package-lock.json`** resolution and integrity updates.
> 
> This pulls in KeetaNet **v0.18.3**, which improves **`Log.sync()`** behavior used by anchor via the client stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5113ffc8235d84232dc53d87abad2fa50dbbeb87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->