### PR TITLE
Keeta Network Anchor SDK v0.0.89

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.88",
+	"version": "0.0.89",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.88",
+			"version": "0.0.89",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.88",
+	"version": "0.0.89",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
This is the Keeta Network Anchor SDK v0.0.89 which includes the following changes:
- 0ea443fcf9c49bcf67d01f7d07f65bd24b98b471 (#406)
- 1997c289871852e0a35dbe8f96a4f4e2b75cac1c (#407)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release metadata with no runtime or dependency changes in the diff.
> 
> **Overview**
> **Release v0.0.89** for `@keetanetwork/anchor`: bumps the package version from `0.0.88` to `0.0.89` in `package.json` and the root entry in `package-lock.json`.
> 
> No dependency, script, or source changes appear in this diff—only the semver fields for publishing the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aebd091a610755049b5d5ce85a16e7702af16a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->