### PR TITLE
Improve Queue Logging Slightly

### DIFF
--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -953,13 +953,18 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 
 			let setEntryStatus: { status: KeetaAnchorQueueStatus; output: UserResult | null; error?: string | undefined; } = { status: 'failed_temporarily', output: null };
 
-			logger?.debug(`Processing entry request with id ${String(entry.id)}`);
+			logger?.debug(`Trying to acquire process lock for entry request with id ${String(entry.id)}`);
 
 			try {
 				/*
 				 * Get a lock by setting it to 'processing'
 				 */
 				await this.queue.setStatus(entry.id, 'processing', { oldStatus: startingStatus, by: this.workerID });
+
+				/*
+				 * Log an info-level log when we start and finish processing an entry
+				 */
+				logger?.info(`Processing entry request with id ${String(entry.id)}`);
 
 				/*
 				 * Process the entry with a timeout, if the timeout is reached
@@ -1008,7 +1013,7 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 				by = undefined;
 			}
 
-			logger?.debug(`Finished processing entry request with id ${String(entry.id)} with new status`, setEntryStatus.status);
+			logger?.info(`Finished processing entry request with id ${String(entry.id)} with new status`, setEntryStatus.status);
 
 			await this.queue.setStatus(entry.id, setEntryStatus.status, { oldStatus: 'processing', by: by, output: this.encodeResponse(setEntryStatus.output), error: setEntryStatus.error });
 

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -992,7 +992,7 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 				]);
 			} catch (error: unknown) {
 				if (Errors.IncorrectStateAssertedError.isInstance(error)) {
-					logger?.info(`Skipping request with id ${String(entry.id)} because it is no longer in the expected state "${startingStatus}"`, error);
+					logger?.debug(`Skipping request with id ${String(entry.id)} because it is no longer in the expected state "${startingStatus}"`, error);
 
 					return(processJobOk);
 				}


### PR DESCRIPTION
This change moves the queue processing entry logs to the "info" level and changes the start logging to only occur when the entry lock is actually acquired.  Additionally, logs about jobs being skipped because they are no longer in the expected state are moved to the debug level since they are common with multiple workers each fighting to get a job.

This will help when using a logger that filters out debug logs allowing job information to continue to get logged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to log levels and message timing; no queue processing or locking behavior changes.
> 
> **Overview**
> Adjusts **queue runner** logging in `processJob` so operators see real work at **info** when debug is filtered out.
> 
> **Start** logging no longer implies a job is running: a **debug** line runs before `setStatus(..., 'processing')`, and **info** `Processing entry request` runs only after the entry lock is acquired. **Finish** moves from debug to **info** (`Finished processing entry request ... with new status`).
> 
> When another worker already took the job (`IncorrectStateAssertedError`), the skip message drops from **info** to **debug**, since that race is expected with multiple workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6ad20d3f8d14feb7185596e06d541dc6a6b900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->