### PR TITLE
Add Stuck and Aborted Queue helpers

### DIFF
--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -782,6 +782,102 @@ test('Queue Runner Aborted and Stuck Jobs Tests', async function() {
 	}
 });
 
+test('Queue Runner Aborted and Stuck Jobs Helpers Tests', async function() {
+	type RequestType = {
+		key: string;
+		newStatus: KeetaAnchorQueueStatus;
+	};
+
+	type ResponseType = string;
+
+	await using cleanup = new AsyncDisposableStack();
+	vi.useFakeTimers();
+	cleanup.defer(function() {
+		vi.useRealTimers();
+	});
+
+	await using queue = new KeetaAnchorQueueStorageDriverMemory({
+		id: 'aborted-stuck-test',
+		logger: logger
+	});
+
+	const processCallCountByKey = new Map<string, number>();
+	await using runner = new KeetaAnchorQueueRunnerJSONConfigProc<RequestType, ResponseType>({
+		id: 'aborted-stuck-test-runner',
+		queue: queue,
+		logger: logger,
+		processor: async function(entry) {
+			const key = entry.request.key;
+			if (key.startsWith('timedout_early')) {
+				await asleep(500);
+			}
+
+			const callCount = processCallCountByKey.get(key) ?? 0;
+			processCallCountByKey.set(key, callCount + 1);
+
+			if (key.startsWith('timedout_late')) {
+				await asleep(500);
+			}
+
+			if (key.startsWith('error')) {
+				throw(new Error('Processing error'));
+			}
+
+			return({ status: entry.request.newStatus, output: 'OK' });
+		},
+		processorAborted: 'RETRY',
+		processorStuck: 'RETRY'
+	});
+
+	runner._Testing(TestingKey).setParams({ batchSize: 100, processTimeout: 50, maxRetries: 3 });
+
+	const id_aborted = await runner.add({ key: 'timedout_late_forward_aborted', newStatus: 'completed' });
+
+	/**
+	 * Test that aborted jobs are handled by the aborted processor (Retry)
+	 */
+	{
+		logger?.debug('aborted', '> Test that aborted jobs are handled by the aborted retry processor');
+
+		/*
+		 * Run the job, it should be aborted and then processed by the
+		 * aborted processor which will complete it (since the key contains 'forward')
+		 */
+		{
+			/*
+			 * First run to pick up the job -- it will timeout and consume the
+			 * entire time budget for the `run` call so it will not transition
+			 * from aborted to processing to completed in the same run
+			 */
+			vi.useRealTimers();
+			await runner.run({ timeoutMs: 50 });
+			vi.useFakeTimers();
+
+			const status_aborted = await runner.get(id_aborted);
+			expect(status_aborted?.status).toBe('aborted');
+
+			/* The main processor was called once -- resulting a timeout, leading to the aborted status */
+			expect(processCallCountByKey.get('timedout_late_forward_aborted')).toBe(1);
+		}
+
+		{
+			/*
+			 * Next, run the process again and this time it
+			 * should be processed by the aborted processor
+			 */
+			vi.useRealTimers();
+			await runner.run();
+			vi.useFakeTimers();
+
+			const status_aborted = await runner.get(id_aborted);
+			expect(status_aborted?.status).toBe('failed_temporarily');
+
+			/* The main processor was already called above and not called again, so should remain 1 */
+			expect(processCallCountByKey.get('timedout_late_forward_aborted')).toBe(1);
+		}
+	}
+});
+
 
 for (const singleWorkerID of [true, false]) {
 	let mode = 'Multiple Workers IDs';

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -809,14 +809,14 @@ test('Queue Runner Aborted and Stuck Jobs Helpers Tests', async function() {
 		processor: async function(entry) {
 			const key = entry.request.key;
 			if (key.startsWith('timedout_early')) {
-				await asleep(500);
+				await asleep(5000);
 			}
 
 			const callCount = processCallCountByKey.get(key) ?? 0;
 			processCallCountByKey.set(key, callCount + 1);
 
 			if (key.startsWith('timedout_late')) {
-				await asleep(500);
+				await asleep(5000);
 			}
 
 			if (key.startsWith('error')) {
@@ -829,7 +829,7 @@ test('Queue Runner Aborted and Stuck Jobs Helpers Tests', async function() {
 		processorStuck: 'RETRY'
 	});
 
-	runner._Testing(TestingKey).setParams({ batchSize: 100, processTimeout: 50, maxRetries: 3 });
+	runner._Testing(TestingKey).setParams({ batchSize: 100, processTimeout: 100, maxRetries: 3 });
 
 	const id_aborted = await runner.add({ key: 'timedout_late_forward_aborted', newStatus: 'completed' });
 
@@ -850,7 +850,7 @@ test('Queue Runner Aborted and Stuck Jobs Helpers Tests', async function() {
 			 * from aborted to processing to completed in the same run
 			 */
 			vi.useRealTimers();
-			await runner.run({ timeoutMs: 50 });
+			await runner.run({ timeoutMs: 90 });
 			vi.useFakeTimers();
 
 			const status_aborted = await runner.get(id_aborted);

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -664,7 +664,7 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 		 * care about the type, we can handle any type because we
 		 * simply return the existing value
 		 */
-		// @eslint-disable-next-line @typescript-eslint/no-explicit-any
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		[key in 'RETRY']: NonNullable<KeetaAnchorQueueRunner<unknown, any>['processorAborted']> | NonNullable<KeetaAnchorQueueRunner<unknown, any>['processorStuck']>;
 	} = {
 			RETRY: async (entry) => {

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -659,16 +659,28 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 	 * Helpful common handlers for the processorAborted and processorStuck methods
 	 */
 	static processorHandlerHelpers: {
-		[key in 'RETRY']: NonNullable<KeetaAnchorQueueRunner<any, any>['processorAborted']> | NonNullable<KeetaAnchorQueueRunner<any, any>['processorStuck']>;
+		/*
+		 * Because we are just passing the value through we do not
+		 * care about the type, we can handle any type because we
+		 * simply return the existing value
+		 */
+		// @eslint-disable-next-line @typescript-eslint/no-explicit-any
+		[key in 'RETRY']: NonNullable<KeetaAnchorQueueRunner<unknown, any>['processorAborted']> | NonNullable<KeetaAnchorQueueRunner<unknown, any>['processorStuck']>;
 	} = {
-		RETRY: async (entry) => {
-			return({
-				status: 'failed_temporarily',
-				output: entry.output,
-				error: `Job was ${entry.status} after ${entry.failures} failures, retrying`
-			});
-		}
-	}
+			RETRY: async (entry) => {
+				return({
+					status: 'failed_temporarily',
+					/*
+					 * This is safe because we are not
+					 * doing any operations on the value
+					 * and it just being copied over itself
+					 */
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					output: entry.output,
+					error: `Job was ${entry.status} after ${entry.failures} failures, retrying`
+				});
+			}
+		};
 
 	private async initialize(): Promise<void> {
 		if (this.initializePromise) {

--- a/src/lib/queue/index.ts
+++ b/src/lib/queue/index.ts
@@ -655,6 +655,21 @@ export abstract class KeetaAnchorQueueRunner<UserRequest = unknown, UserResult =
 		this.methodLogger('new')?.debug('Created new queue runner attached to queue', this.queue.id);
 	}
 
+	/**
+	 * Helpful common handlers for the processorAborted and processorStuck methods
+	 */
+	static processorHandlerHelpers: {
+		[key in 'RETRY']: NonNullable<KeetaAnchorQueueRunner<any, any>['processorAborted']> | NonNullable<KeetaAnchorQueueRunner<any, any>['processorStuck']>;
+	} = {
+		RETRY: async (entry) => {
+			return({
+				status: 'failed_temporarily',
+				output: entry.output,
+				error: `Job was ${entry.status} after ${entry.failures} failures, retrying`
+			});
+		}
+	}
+
 	private async initialize(): Promise<void> {
 		if (this.initializePromise) {
 			return(await this.initializePromise);
@@ -1529,8 +1544,8 @@ export class KeetaAnchorQueueRunnerJSONConfigProc<UserRequest extends JSONSerial
 
 	constructor(config: ConstructorParameters<typeof KeetaAnchorQueueRunner>[0] & {
 		processor: KeetaAnchorQueueRunner<UserRequest, UserResult>['processor'];
-		processorStuck?: KeetaAnchorQueueRunner<UserRequest, UserResult>['processorStuck'] | undefined;
-		processorAborted?: KeetaAnchorQueueRunner<UserRequest, UserResult>['processorAborted'] | undefined;
+		processorStuck?: KeetaAnchorQueueRunner<UserRequest, UserResult>['processorStuck'] | keyof typeof KeetaAnchorQueueRunnerJSONConfigProc.processorHandlerHelpers | undefined;
+		processorAborted?: KeetaAnchorQueueRunner<UserRequest, UserResult>['processorAborted'] | keyof typeof KeetaAnchorQueueRunnerJSONConfigProc.processorHandlerHelpers | undefined;
 	} & Partial<KeetaAnchorQueueRunnerConfigurationObject>) {
 		super(config);
 
@@ -1539,10 +1554,18 @@ export class KeetaAnchorQueueRunnerJSONConfigProc<UserRequest extends JSONSerial
 		this.processor = processor;
 
 		if (processorStuck) {
-			this.processorStuck = processorStuck;
+			if (typeof processorStuck === 'string') {
+				this.processorStuck = KeetaAnchorQueueRunnerJSONConfigProc.processorHandlerHelpers[processorStuck];
+			} else {
+				this.processorStuck = processorStuck;
+			}
 		}
 		if (processorAborted) {
-			this.processorAborted = processorAborted;
+			if (typeof processorAborted === 'string') {
+				this.processorAborted = KeetaAnchorQueueRunnerJSONConfigProc.processorHandlerHelpers[processorAborted];
+			} else {
+				this.processorAborted = processorAborted;
+			}
 		}
 
 		this.setConfiguration(parameters);


### PR DESCRIPTION
This change adds some static helpers for queues for the Aborted and Stuck processors to be able to be configured to retry easily.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-focused configuration sugar on the queue runner with no changes to core job processing or storage drivers.
> 
> **Overview**
> Adds a **`RETRY`** preset for `processorAborted` and `processorStuck` on `KeetaAnchorQueueRunnerJSONConfigProc`, so runners can opt into re-queueing timed-out or stuck jobs without writing custom handlers.
> 
> The helper lives on the base runner as `processorHandlerHelpers.RETRY`: it returns **`failed_temporarily`**, keeps the existing output, and sets an error message that includes the prior status and failure count. The config constructor now accepts either a full handler function or the string **`'RETRY'`**, which is resolved to that helper.
> 
> A new Vitest case exercises the flow: a job that times out becomes **`aborted`**, then on the next run the aborted processor moves it to **`failed_temporarily`** for the normal retry path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6838bc7bf3710744aaf483a5136041393612a1b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->