### PR TITLE
Add market prices endpoint

### DIFF
--- a/src/lib/resolver.ts
+++ b/src/lib/resolver.ts
@@ -149,6 +149,11 @@ type ServiceMetadata = {
 					 * which was previously created
 					 */
 					getExchangeStatus?: string;
+					/**
+					 * Get current market prices for a set of
+					 * quote assets against a base asset (optional)
+					 */
+					getMarketPrices?: string;
 				};
 				/**
 				 * Path for which can be used to identify which
@@ -343,7 +348,7 @@ type ServiceSearchCriteria<T extends Services> = {
 		/**
 		 * Search for a provider which supports ALL of the following FX operations
 		 */
-		requiredOperations?: Extract<keyof NonNullable<ServiceMetadata['services']['fx']>[string]['operations'], 'getEstimate' | 'getQuote' | 'createExchange' | 'getExchangeStatus'>[];
+		requiredOperations?: Extract<keyof NonNullable<ServiceMetadata['services']['fx']>[string]['operations'], 'getEstimate' | 'getQuote' | 'createExchange' | 'getExchangeStatus' | 'getMarketPrices'>[];
 
 		/**
 		 * Search for a provider which supports the specified affinity

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -1825,13 +1825,13 @@ test('FX Server Pricing test', async function() {
 			base: eurString,
 			quoteAssets: {
 				[usdString]: {
-					current: {
+					valueRatio: {
 						quote: '1000',
 						base: '1002'
 					}
 				},
 				[gbpString]: {
-					current: {
+					valueRatio: {
 						quote: '1000',
 						base: '1250'
 					}

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -1841,6 +1841,91 @@ test('FX Server Pricing test', async function() {
 	}
 });
 
+test('getPrices omits or throws invalid market price ratios based on onInvalidRatio', async function() {
+	const userAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+	await using nodeAndClient = await createNodeAndClient(userAccount);
+	const client = nodeAndClient.userClient;
+
+	const { account: testCurrencyUSD } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+	const { account: testCurrencyEUR } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+	if (!testCurrencyUSD.isToken() || !testCurrencyEUR.isToken()) {
+		throw(new Error('Test currencies not tokens'));
+	}
+
+	await using server = new KeetaNetFXAnchorEstimateHTTPServer({
+		logger: logger,
+		fx: {
+			from: [{
+				currencyCodes: [testCurrencyUSD.publicKeyString.get()],
+				to: [testCurrencyEUR.publicKeyString.get()]
+			}],
+			performExchanges: false,
+			estimateRateAndFee: async function() {
+				return({
+					convertedAmount: 100n,
+					cost: { amount: 0n, token: testCurrencyUSD }
+				});
+			},
+			getMarketPrices: {
+				get: async function(request) {
+					return({
+						base: request.base,
+						quoteAssets: Object.fromEntries(request.quoteAssets.map(function(quoteAsset) {
+							return([quoteAsset, {
+								valueRatio: {
+									quote: '0',
+									base: '100'
+								}
+							}]);
+						}))
+					});
+				}
+			}
+		}
+	});
+
+	await server.start();
+
+	await client.setInfo({
+		name: 'TEST',
+		description: '',
+		metadata: KeetaAnchorResolver.Metadata.formatMetadata({
+			version: 1,
+			currencyMap: {
+				USD: testCurrencyUSD.publicKeyString.get(),
+				EUR: testCurrencyEUR.publicKeyString.get()
+			},
+			services: {
+				fx: {
+					InvalidRatio: await server.serviceMetadata()
+				}
+			}
+		})
+	});
+
+	const fxClient = new KeetaNetAnchor.FX.Client(client, {
+		root: userAccount,
+		signer: userAccount,
+		account: userAccount,
+		logger: logger
+	});
+
+	const omitted = await fxClient.getPrices({
+		assets: [testCurrencyUSD],
+		priceIn: testCurrencyEUR,
+		conversionValue: 100n,
+		onInvalidRatio: 'omit'
+	});
+	expect(omitted.get(testCurrencyUSD)).toBeNull();
+
+	await expect(fxClient.getPrices({
+		assets: [testCurrencyUSD],
+		priceIn: testCurrencyEUR,
+		conversionValue: 100n,
+		onInvalidRatio: 'throw'
+	})).rejects.toThrow(/Invalid market price ratio/);
+});
+
 
 test('FX Server Queue extensions', async function() {
 	const userAccount = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -1732,14 +1732,14 @@ test('FX Server Pricing test', async function() {
 			throw(new Error('No result for GBP'));
 		}
 		expect(gbpResult.averageConvertedAmount).toBe(12500);
-		expect(gbpResult.providerEstimates.length).toBe(1);
+		expect(gbpResult.providerMarketPrices.length + gbpResult.providerEstimates.length).toBe(1);
 
 		const usdResult = retval.get(testCurrencyUSD);
 		if (!usdResult) {
 			throw(new Error('No result for USD'));
 		}
 		expect(usdResult.averageConvertedAmount).toBe(10025);
-		expect(usdResult.providerEstimates.length).toBe(2);
+		expect(usdResult.providerMarketPrices.length + usdResult.providerEstimates.length).toBe(2);
 	}
 
 	{
@@ -1807,9 +1807,37 @@ test('FX Server Pricing test', async function() {
 					throw(new Error(`No result for ${toJSONSerializable(expectedEntry.asset)}`));
 				}
 				expect(Math.round(result.averageConvertedAmount)).toBe(Math.round(expectedEntry.average));
-				expect(result.providerEstimates.length).toBe(expectedEntry.providerCount);
+				expect(result.providerMarketPrices.length + result.providerEstimates.length).toBe(expectedEntry.providerCount);
 			}
 		}
+	}
+
+	{
+		const usdString = testCurrencyUSD.publicKeyString.get();
+		const eurString = testCurrencyEUR.publicKeyString.get();
+		const gbpString = testCurrencyGBP.publicKeyString.get();
+
+		const marketPrices = await fxClient.getMarketPrices('TestServer0', {
+			quoteAssets: [usdString, gbpString],
+			base: eurString
+		});
+		expect(marketPrices).toEqual({
+			base: eurString,
+			quoteAssets: {
+				[usdString]: {
+					current: {
+						quote: '1000',
+						base: '1002'
+					}
+				},
+				[gbpString]: {
+					current: {
+						quote: '1000',
+						base: '1250'
+					}
+				}
+			}
+		});
 	}
 });
 

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -14,6 +14,7 @@ import {
 	assertKeetaNetTokenPublicKeyString,
 	isKeetaFXAnchorEstimateResponse,
 	isKeetaFXAnchorExchangeResponse,
+	isKeetaFXAnchorMarketPricesResponse,
 	isKeetaFXAnchorQuoteResponse,
 	Errors as FXErrors
 } from './common.js';
@@ -23,6 +24,9 @@ import type {
 	ConversionInputCanonicalJSON,
 	KeetaFXAnchorEstimate,
 	KeetaFXAnchorExchange,
+	KeetaFXAnchorMarketPrices,
+	KeetaFXAnchorMarketPricesRequest,
+	KeetaFXAnchorMarketPriceRatio,
 	KeetaFXAnchorQuote,
 	KeetaNetTokenPublicKeyString
 } from './common.ts';
@@ -530,6 +534,34 @@ export class KeetaFXAnchorProviderBase extends KeetaFXAnchorBase {
 		return(requestInformationJSON);
 	}
 
+	async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices> {
+		const serviceURL = await this.#getEndpoint('getMarketPrices');
+		serviceURL.searchParams.set('quoteAssets', request.quoteAssets.join(','));
+		serviceURL.searchParams.set('base', request.base);
+
+		const requestInformation = await fetch(serviceURL, {
+			method: 'GET',
+			headers: {
+				'Accept': 'application/json'
+			}
+		});
+
+		const requestInformationJSON: unknown = await requestInformation.json();
+		if (!isKeetaFXAnchorMarketPricesResponse(requestInformationJSON)) {
+			throw(new Error(`Invalid response from FX market prices service: ${JSON.stringify(requestInformationJSON)}`));
+		}
+
+		if (!requestInformationJSON.ok) {
+			throw(await this.#parseResponseError(requestInformationJSON));
+		}
+
+		this.logger?.debug(`FX market prices request successful, to provider ${serviceURL} for quoteAssets=${request.quoteAssets.join(',')} base=${request.base}`);
+		return({
+			base: requestInformationJSON.base,
+			quoteAssets: requestInformationJSON.quoteAssets
+		});
+	}
+
 	async getExchangeStatus(exchangeID: string): Promise<KeetaFXAnchorExchange> {
 		const serviceURL = await this.#getEndpoint('getExchangeStatus', { id: exchangeID });
 		const requestInformation = await fetch(serviceURL, {
@@ -663,7 +695,33 @@ interface GetProvidersOptions extends AccountOptions {
 interface GetPricesAssetReturnValue {
 	value: bigint;
 	averageConvertedAmount: number;
+	providerMarketPrices: {
+		provider: KeetaFXAnchorProviderBase;
+		price: KeetaFXAnchorMarketPriceRatio;
+	}[];
 	providerEstimates: KeetaFXAnchorEstimateWithProvider[];
+}
+
+function providerSupportsGetMarketPrices(provider: KeetaFXAnchorProviderBase): boolean {
+	return(Object.prototype.hasOwnProperty.call(provider.serviceInfo.operations, 'getMarketPrices'));
+}
+
+function convertUsingMarketPriceRatio(
+	ratio: KeetaFXAnchorMarketPriceRatio,
+	conversionValue: bigint,
+	affinity: 'from' | 'to'
+): bigint {
+	const quote = BigInt(ratio.quote);
+	const base = BigInt(ratio.base);
+	if (quote === 0n || base === 0n) {
+		throw(new Error('Invalid market price ratio'));
+	}
+
+	if (affinity === 'from') {
+		return(conversionValue * base / quote);
+	}
+
+	return(conversionValue * quote / base);
 }
 
 export interface GetPricesArgs<Asset extends ConversionInput['from']> {
@@ -990,13 +1048,23 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 		return(retval);
 	}
 
-	async getPrices<Asset extends ConversionInput['from']>(input: GetPricesArgs<Asset>): Promise<Map<Asset, GetPricesAssetReturnValue | null>> {
-		const priceInAsset: ConversionInput['from'] = input.priceIn ?? 'USD';
+	async getPrices<Asset extends ConversionInput['from']>(input: GetPricesArgs<Asset>, options: Omit<GetProvidersOptions, 'requiredOperations'> = {}, sharedCriteria?: SharedLookupCriteria): Promise<Map<Asset, GetPricesAssetReturnValue | null>> {
+		const priceInCanonical = await this.canonicalizeConversionTokens({ to: input.priceIn ?? 'USD' });
+		if (priceInCanonical.to === undefined) {
+			throw(new Error('Could not canonicalize priceIn asset'));
+		}
 
-		const retval = new Map<Asset, GetPricesAssetReturnValue | null>();
+		const base = priceInCanonical.to.publicKeyString.get();
+		const affinity = input.conversionAffinity ?? 'from';
+		const priceIn = input.priceIn ?? 'USD';
 
-		await Promise.all(input.assets.map(async (asset) => {
-			let conversionValue;
+		const assetEntries = await Promise.all(input.assets.map(async (asset) => {
+			const canonical = await this.canonicalizeConversionTokens({ from: asset });
+			if (canonical.from === undefined) {
+				throw(new Error(`Could not canonicalize asset: ${String(asset)}`));
+			}
+
+			let conversionValue: bigint;
 			if (input.conversionValue !== undefined) {
 				if (typeof input.conversionValue === 'function') {
 					conversionValue = await input.conversionValue(asset);
@@ -1007,29 +1075,155 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 				conversionValue = 1n;
 			}
 
-			const estimates = await this.getEstimates({
+			const providers = await this.getBaseProvidersForConversion({
 				from: asset,
-				to: priceInAsset,
+				to: priceIn,
 				amount: conversionValue,
-				affinity: input.conversionAffinity ?? 'from'
+				affinity
+			}, options, sharedCriteria);
+
+			return({
+				asset,
+				quoteAsset: canonical.from.publicKeyString.get(),
+				conversionValue,
+				providers
 			});
+		}));
 
-			if (estimates === null || estimates.length === 0) {
-				retval.set(asset, null);
-			} else {
-				const convertedAmountSum = estimates.reduce(function(sum, estimate) {
-					return(sum + estimate.estimate.convertedAmount);
-				}, 0n);
+		type ProviderAssetEntry = {
+			asset: Asset;
+			quoteAsset: KeetaNetTokenPublicKeyString;
+			conversionValue: bigint;
+			provider: KeetaFXAnchorProviderBase;
+		};
 
-				const averageConvertedAmount = Number(convertedAmountSum) / estimates.length;
+		type EstimateAssetEntry = {
+			asset: Asset;
+			conversionValue: bigint;
+			provider: KeetaFXAnchorProviderBase;
+		};
 
-				retval.set(asset, {
-					value: conversionValue,
-					averageConvertedAmount,
-					providerEstimates: estimates
-				});
+		const providerAssets = new Map<ProviderID, ProviderAssetEntry[]>();
+		const estimateEntries: EstimateAssetEntry[] = [];
+		for (const entry of assetEntries) {
+			if (entry.providers === null) {
+				continue;
+			}
+
+			for (const provider of entry.providers) {
+				if (providerSupportsGetMarketPrices(provider)) {
+					const existing = providerAssets.get(provider.providerID) ?? [];
+					existing.push({
+						asset: entry.asset,
+						quoteAsset: entry.quoteAsset,
+						conversionValue: entry.conversionValue,
+						provider
+					});
+					providerAssets.set(provider.providerID, existing);
+				} else {
+					estimateEntries.push({
+						asset: entry.asset,
+						conversionValue: entry.conversionValue,
+						provider
+					});
+				}
+			}
+		}
+
+		const providerPriceResults = await Promise.all([...providerAssets.entries()].map(async ([_providerID, entries]) => {
+			const firstEntry = entries[0];
+			if (firstEntry === undefined) {
+				return(null);
+			}
+
+			const provider = firstEntry.provider;
+			const quoteAssets = [...new Set(entries.map(function(entry) {
+				return(entry.quoteAsset);
+			}))];
+
+			try {
+				const marketPrices = await provider.getMarketPrices({ quoteAssets, base });
+				return({ provider, marketPrices, entries });
+			} catch (error) {
+				this.logger?.error(`Failed to get market prices from provider ${String(provider.providerID)}:`, error);
+				return(null);
 			}
 		}));
+
+		const assetProviderPrices = new Map<Asset, GetPricesAssetReturnValue['providerMarketPrices']>();
+		for (const result of providerPriceResults) {
+			if (result === null) {
+				continue;
+			}
+
+			for (const entry of result.entries) {
+				const priceEntry = result.marketPrices.quoteAssets[entry.quoteAsset];
+				if (priceEntry === undefined) {
+					continue;
+				}
+
+				const prices = assetProviderPrices.get(entry.asset) ?? [];
+				prices.push({
+					provider: result.provider,
+					price: priceEntry.current
+				});
+				assetProviderPrices.set(entry.asset, prices);
+			}
+		}
+
+		const estimateResults = await Promise.all(estimateEntries.map(async (entry) => {
+			try {
+				const estimate = await entry.provider.getEstimate();
+				return({
+					asset: entry.asset,
+					estimate: new KeetaFXAnchorEstimateWithProvider(entry.provider, estimate)
+				});
+			} catch (error) {
+				this.logger?.error(`Failed to get estimate from provider ${String(entry.provider.providerID)}:`, error);
+				return(null);
+			}
+		}));
+
+		const assetProviderEstimates = new Map<Asset, KeetaFXAnchorEstimateWithProvider[]>();
+		for (const result of estimateResults) {
+			if (result === null) {
+				continue;
+			}
+
+			const estimates = assetProviderEstimates.get(result.asset) ?? [];
+			estimates.push(result.estimate);
+			assetProviderEstimates.set(result.asset, estimates);
+		}
+
+		const retval = new Map<Asset, GetPricesAssetReturnValue | null>();
+		for (const entry of assetEntries) {
+			const providerMarketPrices = assetProviderPrices.get(entry.asset) ?? [];
+			const providerEstimates = assetProviderEstimates.get(entry.asset) ?? [];
+			if (providerMarketPrices.length === 0 && providerEstimates.length === 0) {
+				retval.set(entry.asset, null);
+				continue;
+			}
+
+			const convertedAmountSum = [
+				...providerMarketPrices.map(function(providerPrice) {
+					return(convertUsingMarketPriceRatio(providerPrice.price, entry.conversionValue, affinity));
+				}),
+				...providerEstimates.map(function(providerEstimate) {
+					return(providerEstimate.estimate.convertedAmount);
+				})
+			].reduce(function(sum, convertedAmount) {
+				return(sum + convertedAmount);
+			}, 0n);
+
+			const providerCount = providerMarketPrices.length + providerEstimates.length;
+
+			retval.set(entry.asset, {
+				value: entry.conversionValue,
+				averageConvertedAmount: Number(convertedAmountSum) / providerCount,
+				providerMarketPrices,
+				providerEstimates
+			});
+		}
 
 		return(retval);
 	}
@@ -1051,6 +1245,30 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 		}
 
 		return(disclaimers);
+	}
+
+	async getMarketPrices(providerID: string, request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices | null> {
+		const endpoints = await getEndpoints(this.resolver, {
+			requiredOperations: ['getMarketPrices']
+		}, this.#account, { providerIDs: [providerID] }, { logger: this.logger });
+		if (endpoints === null) {
+			return(null);
+		}
+
+		const serviceEntry = typedFxServiceEntries(endpoints)[0];
+		if (!serviceEntry) {
+			return(null);
+		}
+
+		const [ resolvedProviderID, serviceInfo ] = serviceEntry;
+		const provider = new KeetaFXAnchorProviderBase(serviceInfo, resolvedProviderID, {
+			from: KeetaNetLib.Account.fromPublicKeyString(request.quoteAssets[0] ?? request.base),
+			to: KeetaNetLib.Account.fromPublicKeyString(request.base),
+			amount: 1n,
+			affinity: 'from'
+		}, this);
+
+		return(await provider.getMarketPrices(request));
 	}
 
 	/** @internal */

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -1130,7 +1130,7 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 			}
 		}
 
-		const providerPriceResults = await Promise.all([...providerAssets.entries()].map(async ([_providerID, entries]) => {
+		const providerPriceResults = await Promise.all([...providerAssets.entries()].map(async ([_ignore_providerID, entries]) => {
 			const firstEntry = entries[0];
 			if (firstEntry === undefined) {
 				return(null);
@@ -1165,7 +1165,7 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 				const prices = assetProviderPrices.get(entry.asset) ?? [];
 				prices.push({
 					provider: result.provider,
-					price: priceEntry.current
+					price: priceEntry.valueRatio
 				});
 				assetProviderPrices.set(entry.asset, prices);
 			}

--- a/src/services/fx/client.ts
+++ b/src/services/fx/client.ts
@@ -714,7 +714,7 @@ function convertUsingMarketPriceRatio(
 	const quote = BigInt(ratio.quote);
 	const base = BigInt(ratio.base);
 	if (quote === 0n || base === 0n) {
-		throw(new Error('Invalid market price ratio'));
+		throw(new Error(`Invalid market price ratio: quote=${ratio.quote} base=${ratio.base}`));
 	}
 
 	if (affinity === 'from') {
@@ -729,6 +729,13 @@ export interface GetPricesArgs<Asset extends ConversionInput['from']> {
 	priceIn: ConversionInput['from'],
 	conversionValue?: bigint | ((input: Asset) => bigint | Promise<bigint>)
 	conversionAffinity?: ConversionInput['affinity']
+	/**
+	 * Behavior when a provider returns an invalid market price ratio
+	 * (e.g. zero quote/base). Defaults to `'omit'`.
+	 *
+	 * Invalid ratios are always logged regardless of this setting.
+	 */
+	onInvalidRatio?: 'omit' | 'throw';
 }
 
 class KeetaFXAnchorClient extends KeetaFXAnchorBase {
@@ -1057,6 +1064,7 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 		const base = priceInCanonical.to.publicKeyString.get();
 		const affinity = input.conversionAffinity ?? 'from';
 		const priceIn = input.priceIn ?? 'USD';
+		const onInvalidRatio = input.onInvalidRatio ?? 'omit';
 
 		const assetEntries = await Promise.all(input.assets.map(async (asset) => {
 			const canonical = await this.canonicalizeConversionTokens({ from: asset });
@@ -1159,6 +1167,17 @@ class KeetaFXAnchorClient extends KeetaFXAnchorBase {
 			for (const entry of result.entries) {
 				const priceEntry = result.marketPrices.quoteAssets[entry.quoteAsset];
 				if (priceEntry === undefined) {
+					continue;
+				}
+
+				try {
+					// Validate ratio early so convertUsingMarketPriceRatio cannot crash the batch later.
+					convertUsingMarketPriceRatio(priceEntry.valueRatio, entry.conversionValue, affinity);
+				} catch (error) {
+					this.logger?.error(`Invalid market price ratio from provider ${String(result.provider.providerID)} for quote asset ${entry.quoteAsset} against base ${base}:`, error, priceEntry.valueRatio);
+					if (onInvalidRatio === 'throw') {
+						throw(error);
+					}
 					continue;
 				}
 

--- a/src/services/fx/common.ts
+++ b/src/services/fx/common.ts
@@ -187,46 +187,6 @@ export type KeetaFXAnchorMarketPrices = {
 	};
 };
 
-/**
- * Controls Cache-Control for GET /api/getMarketPrices responses.
- */
-export type KeetaFXAnchorMarketPricesCacheControl = {
-	/**
-	 * Cache freshness interval. Sets the `max-age` Cache-Control directive.
-	 */
-	maxAge: {
-		seconds: number;
-	};
-};
-
-/**
- * Configuration for the optional GET /api/getMarketPrices endpoint.
- *
- * Set to `false` to disable the endpoint. When enabled (or omitted for
- * the default enabled behavior), prices are derived from estimate rate
- * data unless `get` is provided.
- */
-export type KeetaFXAnchorMarketPricesConfig = {
-	/**
-	 * Cache policy for getMarketPrices responses.
-	 *
-	 * Example: `{ maxAge: { seconds: 30 } }`
-	 */
-	cacheControl?: KeetaFXAnchorMarketPricesCacheControl;
-
-	/**
-	 * Reference quote amount used when deriving prices from estimate
-	 * rate data. Defaults to `1000n`. Ignored when `get` is provided.
-	 */
-	referenceAmount?: bigint;
-
-	/**
-	 * Optional custom price provider. When omitted, prices are derived
-	 * from estimate/rate data using {@link referenceAmount}.
-	 */
-	get?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices>;
-};
-
 export type KeetaFXAnchorMarketPricesResponse = ({
 	ok: true;
 } & KeetaFXAnchorMarketPrices) | {

--- a/src/services/fx/common.ts
+++ b/src/services/fx/common.ts
@@ -182,8 +182,20 @@ export type KeetaFXAnchorMarketPrices = {
 	 */
 	quoteAssets: {
 		[quoteAsset in KeetaNetTokenPublicKeyString]?: {
-			current: KeetaFXAnchorMarketPriceRatio;
+			valueRatio: KeetaFXAnchorMarketPriceRatio;
 		};
+	};
+};
+
+/**
+ * Controls Cache-Control for GET /api/getMarketPrices responses.
+ */
+export type KeetaFXAnchorMarketPricesCacheControl = {
+	/**
+	 * Cache freshness interval. Sets the `max-age` Cache-Control directive.
+	 */
+	maxAge: {
+		seconds: number;
 	};
 };
 

--- a/src/services/fx/common.ts
+++ b/src/services/fx/common.ts
@@ -199,6 +199,34 @@ export type KeetaFXAnchorMarketPricesCacheControl = {
 	};
 };
 
+/**
+ * Configuration for the optional GET /api/getMarketPrices endpoint.
+ *
+ * Set to `false` to disable the endpoint. When enabled (or omitted for
+ * the default enabled behavior), prices are derived from estimate rate
+ * data unless `get` is provided.
+ */
+export type KeetaFXAnchorMarketPricesConfig = {
+	/**
+	 * Cache policy for getMarketPrices responses.
+	 *
+	 * Example: `{ maxAge: { seconds: 30 } }`
+	 */
+	cacheControl?: KeetaFXAnchorMarketPricesCacheControl;
+
+	/**
+	 * Reference quote amount used when deriving prices from estimate
+	 * rate data. Defaults to `1000n`. Ignored when `get` is provided.
+	 */
+	referenceAmount?: bigint;
+
+	/**
+	 * Optional custom price provider. When omitted, prices are derived
+	 * from estimate/rate data using {@link referenceAmount}.
+	 */
+	get?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices>;
+};
+
 export type KeetaFXAnchorMarketPricesResponse = ({
 	ok: true;
 } & KeetaFXAnchorMarketPrices) | {

--- a/src/services/fx/common.ts
+++ b/src/services/fx/common.ts
@@ -150,6 +150,50 @@ export type KeetaFXAnchorEstimateResponse = ({
 	error: string;
 });
 
+export type KeetaFXAnchorMarketPriceRatio = {
+	/**
+	 * Amount of the base (destination) token in the price ratio
+	 */
+	base: string;
+	/**
+	 * Amount of the quote (source) token in the price ratio
+	 */
+	quote: string;
+};
+
+export type KeetaFXAnchorMarketPricesRequest = {
+	/**
+	 * Source tokens to price against the base asset
+	 */
+	quoteAssets: KeetaNetTokenPublicKeyString[];
+	/**
+	 * Destination token against which quote asset prices are expressed
+	 */
+	base: KeetaNetTokenPublicKeyString;
+};
+
+export type KeetaFXAnchorMarketPrices = {
+	/**
+	 * The destination token against which quote asset prices are expressed
+	 */
+	base: KeetaNetTokenPublicKeyString;
+	/**
+	 * Current market prices for each requested quote asset, keyed by token public key
+	 */
+	quoteAssets: {
+		[quoteAsset in KeetaNetTokenPublicKeyString]?: {
+			current: KeetaFXAnchorMarketPriceRatio;
+		};
+	};
+};
+
+export type KeetaFXAnchorMarketPricesResponse = ({
+	ok: true;
+} & KeetaFXAnchorMarketPrices) | {
+	ok: false;
+	error: string;
+};
+
 export type KeetaFXAnchorQuote = {
 	/**
 	 * Conversion request that was provided
@@ -262,6 +306,7 @@ export type KeetaFXAnchorExchangeResponse = (KeetaFXAnchorExchange & {
 export const isKeetaFXAnchorEstimateResponse: (input: unknown) => input is KeetaFXAnchorEstimateResponse = createIs<KeetaFXAnchorEstimateResponse>();
 export const isKeetaFXAnchorQuoteResponse: (input: unknown) => input is KeetaFXAnchorQuoteResponse = createIs<KeetaFXAnchorQuoteResponse>();
 export const isKeetaFXAnchorExchangeResponse: (input: unknown) => input is KeetaFXAnchorExchangeResponse = createIs<KeetaFXAnchorExchangeResponse>();
+export const isKeetaFXAnchorMarketPricesResponse: (input: unknown) => input is KeetaFXAnchorMarketPricesResponse = createIs<KeetaFXAnchorMarketPricesResponse>();
 export const assertKeetaNetTokenPublicKeyString: (input: unknown)  => KeetaNetTokenPublicKeyString = createAssert<KeetaNetTokenPublicKeyString>();
 export const assertConversionInputCanonicalJSON: (input: unknown) => ConversionInputCanonicalJSON = createAssert<ConversionInputCanonicalJSON>();
 export const assertKeetaFXAnchorClientCreateExchangeRequestJSON: (input: unknown) => KeetaFXAnchorClientCreateExchangeRequestJSON = createAssert<KeetaFXAnchorClientCreateExchangeRequestJSON>();

--- a/src/services/fx/server.test.ts
+++ b/src/services/fx/server.test.ts
@@ -1202,15 +1202,55 @@ test('FX Server acceptedCostAssets and preferredCostAsset Tests', async function
 	expect(noAcceptedBody).toHaveProperty('error');
 }, 30000);
 
-test('getMarketPrices sets Cache-Control from config and callback override', async function() {
+test('getMarketPrices config controls cache, reference amount, and disable', async function() {
 	await using harness = await createFXTestHarness();
 	const { token1, token2, serverAccount, createServer } = harness;
 
 	const token1String = token1.publicKeyString.get();
 	const token2String = token2.publicKeyString.get();
 
-	await using defaultServer = createServer({
-		marketPricesCacheControl: { maxAge: { seconds: 30 }},
+	await using cachedServer = createServer({
+		getMarketPrices: {
+			cacheControl: { maxAge: { seconds: 30 }},
+			referenceAmount: 500n
+		},
+		getConversionRateAndFee: async function(request) {
+			return({
+				account: serverAccount,
+				convertedAmount: BigInt(request.amount) * 2n,
+				cost: {
+					amount: 0n,
+					token: token1
+				}
+			});
+		}
+	});
+
+	await cachedServer.start();
+	const cachedResponse = await fetch(`${cachedServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/json'
+		}
+	});
+
+	expect(cachedResponse.status).toBe(200);
+	expect(cachedResponse.headers.get('Cache-Control')).toBe('public, max-age=30');
+	expect(await cachedResponse.json()).toEqual({
+		ok: true,
+		base: token2String,
+		quoteAssets: {
+			[token1String]: {
+				valueRatio: {
+					quote: '500',
+					base: '1000'
+				}
+			}
+		}
+	});
+
+	await using disabledServer = createServer({
+		getMarketPrices: false,
 		getConversionRateAndFee: async function() {
 			return({
 				account: serverAccount,
@@ -1223,51 +1263,15 @@ test('getMarketPrices sets Cache-Control from config and callback override', asy
 		}
 	});
 
-	await defaultServer.start();
-	const defaultResponse = await fetch(`${defaultServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
+	await disabledServer.start();
+	const metadata = await disabledServer.serviceMetadata();
+	expect(metadata.operations.getMarketPrices).toBeUndefined();
+
+	const disabledResponse = await fetch(`${disabledServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
 		method: 'GET',
 		headers: {
 			'Accept': 'application/json'
 		}
 	});
-
-	expect(defaultResponse.status).toBe(200);
-	expect(defaultResponse.headers.get('Cache-Control')).toBe('public, max-age=30');
-
-	await using overrideServer = createServer({
-		marketPricesCacheControl: { maxAge: { seconds: 30 }},
-		getConversionRateAndFee: async function() {
-			throw(new Error('getConversionRateAndFee should not be called when getMarketPrices is provided'));
-		},
-		getMarketPrices: async function(request) {
-			const quoteAsset = request.quoteAssets[0];
-			if (quoteAsset === undefined) {
-				throw(new Error('Expected at least one quote asset'));
-			}
-
-			return({
-				base: request.base,
-				quoteAssets: {
-					[quoteAsset]: {
-						valueRatio: {
-							quote: '1',
-							base: '1'
-						}
-					}
-				},
-				cacheControl: { maxAge: { seconds: 5 }}
-			});
-		}
-	});
-
-	await overrideServer.start();
-	const overrideResponse = await fetch(`${overrideServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
-		method: 'GET',
-		headers: {
-			'Accept': 'application/json'
-		}
-	});
-
-	expect(overrideResponse.status).toBe(200);
-	expect(overrideResponse.headers.get('Cache-Control')).toBe('public, max-age=5');
+	expect(disabledResponse.status).toBe(404);
 }, 30000);

--- a/src/services/fx/server.test.ts
+++ b/src/services/fx/server.test.ts
@@ -1201,3 +1201,73 @@ test('FX Server acceptedCostAssets and preferredCostAsset Tests', async function
 	expect(noAcceptedBody).toHaveProperty('ok', false);
 	expect(noAcceptedBody).toHaveProperty('error');
 }, 30000);
+
+test('getMarketPrices sets Cache-Control from config and callback override', async function() {
+	await using harness = await createFXTestHarness();
+	const { token1, token2, serverAccount, createServer } = harness;
+
+	const token1String = token1.publicKeyString.get();
+	const token2String = token2.publicKeyString.get();
+
+	await using defaultServer = createServer({
+		marketPricesCacheControl: { maxAge: { seconds: 30 }},
+		getConversionRateAndFee: async function() {
+			return({
+				account: serverAccount,
+				convertedAmount: 100n,
+				cost: {
+					amount: 0n,
+					token: token1
+				}
+			});
+		}
+	});
+
+	await defaultServer.start();
+	const defaultResponse = await fetch(`${defaultServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/json'
+		}
+	});
+
+	expect(defaultResponse.status).toBe(200);
+	expect(defaultResponse.headers.get('Cache-Control')).toBe('public, max-age=30');
+
+	await using overrideServer = createServer({
+		marketPricesCacheControl: { maxAge: { seconds: 30 }},
+		getConversionRateAndFee: async function() {
+			throw(new Error('getConversionRateAndFee should not be called when getMarketPrices is provided'));
+		},
+		getMarketPrices: async function(request) {
+			const quoteAsset = request.quoteAssets[0];
+			if (quoteAsset === undefined) {
+				throw(new Error('Expected at least one quote asset'));
+			}
+
+			return({
+				base: request.base,
+				quoteAssets: {
+					[quoteAsset]: {
+						valueRatio: {
+							quote: '1',
+							base: '1'
+						}
+					}
+				},
+				cacheControl: { maxAge: { seconds: 5 }}
+			});
+		}
+	});
+
+	await overrideServer.start();
+	const overrideResponse = await fetch(`${overrideServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(token1String)}&base=${encodeURIComponent(token2String)}`, {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/json'
+		}
+	});
+
+	expect(overrideResponse.status).toBe(200);
+	expect(overrideResponse.headers.get('Cache-Control')).toBe('public, max-age=5');
+}, 30000);

--- a/src/services/fx/server.test.ts
+++ b/src/services/fx/server.test.ts
@@ -263,6 +263,7 @@ test('FX Server Tests', async function() {
 			}],
 			operations: {
 				getEstimate: new URL('/api/getEstimate', url).toString(),
+				getMarketPrices: new URL('/api/getMarketPrices', url).toString(),
 				getQuote: new URL('/api/getQuote', url).toString(),
 				createExchange: new URL('/api/createExchange', url).toString(),
 				getExchangeStatus: new URL('/api/getExchangeStatus', url).toString() + '/{id}'

--- a/src/services/fx/server.test.ts
+++ b/src/services/fx/server.test.ts
@@ -1275,3 +1275,89 @@ test('getMarketPrices config controls cache, reference amount, and disable', asy
 	});
 	expect(disabledResponse.status).toBe(404);
 }, 30000);
+
+test('getMarketPrices omits or throws failed quote assets based on onQuoteError', async function() {
+	await using harness = await createFXTestHarness();
+	const { token1, token2, serverAccount, serverClient, createServer } = harness;
+
+	const { account: token3 } = await serverClient.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+	if (!token3.isToken()) {
+		throw(new Error('token3 is not a token'));
+	}
+
+	const token1String = token1.publicKeyString.get();
+	const token2String = token2.publicKeyString.get();
+	const token3String = token3.publicKeyString.get();
+
+	await using omitServer = createServer({
+		getMarketPrices: {
+			onQuoteError: 'omit'
+		},
+		getConversionRateAndFee: async function(request) {
+			if (request.from === token3String) {
+				throw(new Error('no liquidity for token3'));
+			}
+
+			return({
+				account: serverAccount,
+				convertedAmount: BigInt(request.amount) * 2n,
+				cost: {
+					amount: 0n,
+					token: token1
+				}
+			});
+		}
+	});
+
+	await omitServer.start();
+	const omitResponse = await fetch(`${omitServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(`${token1String},${token3String}`)}&base=${encodeURIComponent(token2String)}`, {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/json'
+		}
+	});
+
+	expect(omitResponse.status).toBe(200);
+	expect(omitResponse.headers.get('Cache-Control')).toBe('public, max-age=0');
+	expect(await omitResponse.json()).toEqual({
+		ok: true,
+		base: token2String,
+		quoteAssets: {
+			[token1String]: {
+				valueRatio: {
+					quote: '1000',
+					base: '2000'
+				}
+			}
+		}
+	});
+
+	await using throwServer = createServer({
+		getMarketPrices: {
+			onQuoteError: 'throw'
+		},
+		getConversionRateAndFee: async function(request) {
+			if (request.from === token3String) {
+				throw(new Error('no liquidity for token3'));
+			}
+
+			return({
+				account: serverAccount,
+				convertedAmount: BigInt(request.amount) * 2n,
+				cost: {
+					amount: 0n,
+					token: token1
+				}
+			});
+		}
+	});
+
+	await throwServer.start();
+	const throwResponse = await fetch(`${throwServer.url}/api/getMarketPrices?quoteAssets=${encodeURIComponent(`${token1String},${token3String}`)}&base=${encodeURIComponent(token2String)}`, {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/json'
+		}
+	});
+	expect(throwResponse.status).toBe(500);
+}, 30000);

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -19,14 +19,14 @@ import type {
 	KeetaFXAnchorEstimateResponse,
 	KeetaFXAnchorExchangeResponse,
 	KeetaFXAnchorMarketPrices,
+	KeetaFXAnchorMarketPricesCacheControl,
 	KeetaFXAnchorMarketPricesRequest,
 	KeetaFXAnchorMarketPricesResponse,
 	KeetaFXAnchorQuote,
 	KeetaFXAnchorQuoteJSON,
 	KeetaFXAnchorQuoteResponse,
 	KeetaNetAccount,
-	KeetaNetStorageAccount,
-	KeetaNetTokenPublicKeyString
+	KeetaNetStorageAccount
 } from './common.ts';
 import * as Signing from '../../lib/utils/signing.js';
 import type { AssertNever } from '../../lib/utils/never.ts';
@@ -157,8 +157,19 @@ export interface KeetaAnchorFXServerConfig extends KeetaAnchorMetadataServerConf
 		 * Optional callback to provide market prices for a set of quote
 		 * assets against a base asset. When not provided, prices are
 		 * derived from estimate rate data.
+		 *
+		 * The callback may optionally include `cacheControl`, which
+		 * overrides {@link marketPricesCacheControl}.
 		 */
-		getMarketPrices?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices>;
+		getMarketPrices?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices & { cacheControl?: KeetaFXAnchorMarketPricesCacheControl; }>;
+
+		/**
+		 * Default cache policy for GET /api/getMarketPrices responses.
+		 * Overridden when {@link getMarketPrices} returns `cacheControl`.
+		 *
+		 * Example: `{ maxAge: { seconds: 30 } }`
+		 */
+		marketPricesCacheControl?: KeetaFXAnchorMarketPricesCacheControl;
 
 		/**
 		 * Optional callback to validate a quote before completing an exchange
@@ -1217,7 +1228,7 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 		}
 	}
 
-	protected async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices> {
+	protected async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices & { cacheControl?: KeetaFXAnchorMarketPricesCacheControl; }> {
 		if ('getMarketPrices' in this.fx && this.fx.getMarketPrices !== undefined) {
 			return(await this.fx.getMarketPrices(request));
 		}
@@ -1232,7 +1243,7 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 			}, 'estimate');
 
 			return([quoteAsset, {
-				current: {
+				valueRatio: {
 					quote: referenceAmount.toString(),
 					base: rateAndFee.convertedAmount.toString()
 				}
@@ -1365,14 +1376,21 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 					throw(new KeetaAnchorUserError('quoteAssets must contain at least one token'));
 				}
 
-				const marketPrices = await instance.getMarketPrices({ quoteAssets, base });
+				const marketPricesResult = await instance.getMarketPrices({ quoteAssets, base });
+				const cacheControl = marketPricesResult.cacheControl ?? instance.fx.marketPricesCacheControl;
 				const marketPricesResponse: KeetaFXAnchorMarketPricesResponse = {
 					ok: true,
-					...marketPrices
+					base: marketPricesResult.base,
+					quoteAssets: marketPricesResult.quoteAssets
 				};
 
 				return({
-					output: JSON.stringify(marketPricesResponse)
+					output: JSON.stringify(marketPricesResponse),
+					...(cacheControl !== undefined ? {
+						headers: {
+							'Cache-Control': `public, max-age=${cacheControl.maxAge.seconds}`
+						}
+					} : {})
 				});
 			};
 		}

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -19,7 +19,6 @@ import type {
 	KeetaFXAnchorEstimateResponse,
 	KeetaFXAnchorExchangeResponse,
 	KeetaFXAnchorMarketPrices,
-	KeetaFXAnchorMarketPricesConfig,
 	KeetaFXAnchorMarketPricesRequest,
 	KeetaFXAnchorMarketPricesResponse,
 	KeetaFXAnchorQuote,
@@ -58,6 +57,55 @@ import { Buffer } from '../../lib/utils/buffer.js';
  * misconfigurations so it is enabled by default for now.
  */
 const PARANOID = true;
+
+/**
+ * Controls Cache-Control for GET /api/getMarketPrices responses.
+ */
+export type KeetaFXAnchorMarketPricesCacheControl = {
+	/**
+	 * Cache freshness interval. Sets the `max-age` Cache-Control directive.
+	 */
+	maxAge: {
+		seconds: number;
+	};
+};
+
+/**
+ * Configuration for the optional GET /api/getMarketPrices endpoint.
+ *
+ * Set to `false` to disable the endpoint. When enabled (or omitted for
+ * the default enabled behavior), prices are derived from estimate rate
+ * data unless `get` is provided.
+ */
+export type KeetaFXAnchorMarketPricesConfig = {
+	/**
+	 * Cache policy for getMarketPrices responses. Defaults to
+	 * `{ maxAge: { seconds: 0 } }` when omitted.
+	 *
+	 * Example: `{ maxAge: { seconds: 30 } }`
+	 */
+	cacheControl?: KeetaFXAnchorMarketPricesCacheControl;
+
+	/**
+	 * Reference quote amount used when deriving prices from estimate
+	 * rate data. Defaults to `1000n`. Ignored when `get` is provided.
+	 */
+	referenceAmount?: bigint;
+
+	/**
+	 * Behavior when deriving a price for one quote asset fails or yields
+	 * an invalid (zero) ratio. Defaults to `'omit'`.
+	 *
+	 * Invalid/failed quotes are always logged regardless of this setting.
+	 */
+	onQuoteError?: 'omit' | 'throw';
+
+	/**
+	 * Optional custom price provider. When omitted, prices are derived
+	 * from estimate/rate data using {@link referenceAmount}.
+	 */
+	get?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices>;
+};
 
 export type GetConversionRateAndFeeContext = {
 	/**
@@ -1238,13 +1286,32 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 		}
 
 		const referenceAmount = config.referenceAmount ?? 1000n;
+		const onQuoteError = config.onQuoteError ?? 'omit';
 		const quoteAssetEntries = await Promise.all(request.quoteAssets.map(async (quoteAsset) => {
-			const rateAndFee = await this.getUnsignedQuoteData({
-				from: quoteAsset,
-				to: request.base,
-				amount: referenceAmount.toString(),
-				affinity: 'from'
-			}, 'estimate');
+			let rateAndFee;
+			try {
+				rateAndFee = await this.getUnsignedQuoteData({
+					from: quoteAsset,
+					to: request.base,
+					amount: referenceAmount.toString(),
+					affinity: 'from'
+				}, 'estimate');
+			} catch (error) {
+				this.logger.error('GET /api/getMarketPrices', `Failed to derive price for quote asset ${quoteAsset} against base ${request.base}:`, error);
+				if (onQuoteError === 'throw') {
+					throw(error);
+				}
+				return(null);
+			}
+
+			if (referenceAmount === 0n || rateAndFee.convertedAmount === 0n) {
+				const error = new Error(`Invalid market price ratio for quote asset ${quoteAsset} against base ${request.base}: quote=${referenceAmount.toString()} base=${rateAndFee.convertedAmount.toString()}`);
+				this.logger.error('GET /api/getMarketPrices', error.message);
+				if (onQuoteError === 'throw') {
+					throw(error);
+				}
+				return(null);
+			}
 
 			return([quoteAsset, {
 				valueRatio: {
@@ -1256,7 +1323,9 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 
 		return({
 			base: request.base,
-			quoteAssets: Object.fromEntries(quoteAssetEntries)
+			quoteAssets: Object.fromEntries(quoteAssetEntries.filter(function(entry): entry is NonNullable<typeof entry> {
+				return(entry !== null);
+			}))
 		});
 	}
 
@@ -1382,7 +1451,7 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 				}
 
 				const marketPrices = await instance.getMarketPrices({ quoteAssets, base });
-				const cacheControl = marketPricesConfig.cacheControl;
+				const maxAgeSeconds = marketPricesConfig.cacheControl?.maxAge.seconds ?? 0;
 				const marketPricesResponse: KeetaFXAnchorMarketPricesResponse = {
 					ok: true,
 					...marketPrices
@@ -1390,11 +1459,9 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 
 				return({
 					output: JSON.stringify(marketPricesResponse),
-					...(cacheControl !== undefined ? {
-						headers: {
-							'Cache-Control': `public, max-age=${cacheControl.maxAge.seconds}`
-						}
-					} : {})
+					headers: {
+						'Cache-Control': `public, max-age=${maxAgeSeconds}`
+					}
 				});
 			};
 		}

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -19,7 +19,7 @@ import type {
 	KeetaFXAnchorEstimateResponse,
 	KeetaFXAnchorExchangeResponse,
 	KeetaFXAnchorMarketPrices,
-	KeetaFXAnchorMarketPricesCacheControl,
+	KeetaFXAnchorMarketPricesConfig,
 	KeetaFXAnchorMarketPricesRequest,
 	KeetaFXAnchorMarketPricesResponse,
 	KeetaFXAnchorQuote,
@@ -154,22 +154,13 @@ export interface KeetaAnchorFXServerConfig extends KeetaAnchorMetadataServerConf
 		acceptedCostAssets?: NonNullable<ServiceMetadata['services']['fx']>[string]['acceptedCostAssets'];
 
 		/**
-		 * Optional callback to provide market prices for a set of quote
-		 * assets against a base asset. When not provided, prices are
-		 * derived from estimate rate data.
+		 * Market prices endpoint configuration.
 		 *
-		 * The callback may optionally include `cacheControl`, which
-		 * overrides {@link marketPricesCacheControl}.
+		 * - `false` disables GET /api/getMarketPrices and omits it from metadata
+		 * - `{ cacheControl, referenceAmount, get }` enables and configures it
+		 * - omitted enables the endpoint with defaults
 		 */
-		getMarketPrices?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices & { cacheControl?: KeetaFXAnchorMarketPricesCacheControl; }>;
-
-		/**
-		 * Default cache policy for GET /api/getMarketPrices responses.
-		 * Overridden when {@link getMarketPrices} returns `cacheControl`.
-		 *
-		 * Example: `{ maxAge: { seconds: 30 } }`
-		 */
-		marketPricesCacheControl?: KeetaFXAnchorMarketPricesCacheControl;
+		getMarketPrices?: false | KeetaFXAnchorMarketPricesConfig;
 
 		/**
 		 * Optional callback to validate a quote before completing an exchange
@@ -1228,12 +1219,25 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 		}
 	}
 
-	protected async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices & { cacheControl?: KeetaFXAnchorMarketPricesCacheControl; }> {
-		if ('getMarketPrices' in this.fx && this.fx.getMarketPrices !== undefined) {
-			return(await this.fx.getMarketPrices(request));
+	protected getMarketPricesConfig(): KeetaFXAnchorMarketPricesConfig | null {
+		if (this.fx.getMarketPrices === false) {
+			return(null);
 		}
 
-		const referenceAmount = 1000n;
+		return(this.fx.getMarketPrices ?? {});
+	}
+
+	protected async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices> {
+		const config = this.getMarketPricesConfig();
+		if (config === null) {
+			throw(new Error('getMarketPrices is disabled'));
+		}
+
+		if (config.get !== undefined) {
+			return(await config.get(request));
+		}
+
+		const referenceAmount = config.referenceAmount ?? 1000n;
 		const quoteAssetEntries = await Promise.all(request.quoteAssets.map(async (quoteAsset) => {
 			const rateAndFee = await this.getUnsignedQuoteData({
 				from: quoteAsset,
@@ -1350,7 +1354,8 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 			});
 		}
 
-		if (routes['GET /api/getMarketPrices'] === undefined) {
+		const marketPricesConfig = instance.getMarketPricesConfig();
+		if (marketPricesConfig !== null && routes['GET /api/getMarketPrices'] === undefined) {
 			routes['GET /api/getMarketPrices'] = async function(_ignore_params, _ignore_body, _ignore_headers, url) {
 				const quoteAssetsParameter = url.searchParams.get('quoteAssets');
 				const baseParameter = url.searchParams.get('base');
@@ -1376,12 +1381,11 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 					throw(new KeetaAnchorUserError('quoteAssets must contain at least one token'));
 				}
 
-				const marketPricesResult = await instance.getMarketPrices({ quoteAssets, base });
-				const cacheControl = marketPricesResult.cacheControl ?? instance.fx.marketPricesCacheControl;
+				const marketPrices = await instance.getMarketPrices({ quoteAssets, base });
+				const cacheControl = marketPricesConfig.cacheControl;
 				const marketPricesResponse: KeetaFXAnchorMarketPricesResponse = {
 					ok: true,
-					base: marketPricesResult.base,
-					quoteAssets: marketPricesResult.quoteAssets
+					...marketPrices
 				};
 
 				return({
@@ -1403,9 +1407,12 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 	 */
 	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
 		const operations: NonNullable<ServiceMetadata['services']['fx']>[string]['operations'] = {
-			getEstimate: (new URL('/api/getEstimate', this.url)).toString(),
-			getMarketPrices: (new URL('/api/getMarketPrices', this.url)).toString()
+			getEstimate: (new URL('/api/getEstimate', this.url)).toString()
 		};
+
+		if (this.getMarketPricesConfig() !== null) {
+			operations.getMarketPrices = (new URL('/api/getMarketPrices', this.url)).toString();
+		}
 
 		const metadata: NonNullable<ServiceMetadata['services']['fx']>[string] = {
 			from: this.fx.from ?? [],

--- a/src/services/fx/server.ts
+++ b/src/services/fx/server.ts
@@ -9,6 +9,7 @@ import {
 import {
 	assertConversionInputCanonicalJSON,
 	assertKeetaFXAnchorClientCreateExchangeRequestJSON,
+	assertKeetaNetTokenPublicKeyString,
 	Errors
 } from './common.js';
 import type {
@@ -17,11 +18,15 @@ import type {
 	KeetaFXAnchorEstimate,
 	KeetaFXAnchorEstimateResponse,
 	KeetaFXAnchorExchangeResponse,
+	KeetaFXAnchorMarketPrices,
+	KeetaFXAnchorMarketPricesRequest,
+	KeetaFXAnchorMarketPricesResponse,
 	KeetaFXAnchorQuote,
 	KeetaFXAnchorQuoteJSON,
 	KeetaFXAnchorQuoteResponse,
 	KeetaNetAccount,
-	KeetaNetStorageAccount
+	KeetaNetStorageAccount,
+	KeetaNetTokenPublicKeyString
 } from './common.ts';
 import * as Signing from '../../lib/utils/signing.js';
 import type { AssertNever } from '../../lib/utils/never.ts';
@@ -147,6 +152,13 @@ export interface KeetaAnchorFXServerConfig extends KeetaAnchorMetadataServerConf
 		 * can select a preferred cost asset.
 		 */
 		acceptedCostAssets?: NonNullable<ServiceMetadata['services']['fx']>[string]['acceptedCostAssets'];
+
+		/**
+		 * Optional callback to provide market prices for a set of quote
+		 * assets against a base asset. When not provided, prices are
+		 * derived from estimate rate data.
+		 */
+		getMarketPrices?: (request: KeetaFXAnchorMarketPricesRequest) => Promise<KeetaFXAnchorMarketPrices>;
 
 		/**
 		 * Optional callback to validate a quote before completing an exchange
@@ -1205,6 +1217,34 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 		}
 	}
 
+	protected async getMarketPrices(request: KeetaFXAnchorMarketPricesRequest): Promise<KeetaFXAnchorMarketPrices> {
+		if ('getMarketPrices' in this.fx && this.fx.getMarketPrices !== undefined) {
+			return(await this.fx.getMarketPrices(request));
+		}
+
+		const referenceAmount = 1000n;
+		const quoteAssetEntries = await Promise.all(request.quoteAssets.map(async (quoteAsset) => {
+			const rateAndFee = await this.getUnsignedQuoteData({
+				from: quoteAsset,
+				to: request.base,
+				amount: referenceAmount.toString(),
+				affinity: 'from'
+			}, 'estimate');
+
+			return([quoteAsset, {
+				current: {
+					quote: referenceAmount.toString(),
+					base: rateAndFee.convertedAmount.toString()
+				}
+			}] as const);
+		}));
+
+		return({
+			base: request.base,
+			quoteAssets: Object.fromEntries(quoteAssetEntries)
+		});
+	}
+
 	protected async initRoutes(config: ConfigType): Promise<KeetaAnchorHTTPServer.Routes> {
 		const routes: KeetaAnchorHTTPServer.Routes = await super.initRoutes(config);
 
@@ -1299,6 +1339,44 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 			});
 		}
 
+		if (routes['GET /api/getMarketPrices'] === undefined) {
+			routes['GET /api/getMarketPrices'] = async function(_ignore_params, _ignore_body, _ignore_headers, url) {
+				const quoteAssetsParameter = url.searchParams.get('quoteAssets');
+				const baseParameter = url.searchParams.get('base');
+
+				if (!quoteAssetsParameter) {
+					throw(new KeetaAnchorUserError('Missing quoteAssets parameter'));
+				}
+
+				if (!baseParameter) {
+					throw(new KeetaAnchorUserError('Missing base parameter'));
+				}
+
+				const base = assertKeetaNetTokenPublicKeyString(baseParameter.trim());
+				const quoteAssets = quoteAssetsParameter.split(',').map(function(token) {
+					return(token.trim());
+				}).filter(function(token) {
+					return(token.length > 0);
+				}).map(function(token) {
+					return(assertKeetaNetTokenPublicKeyString(token));
+				});
+
+				if (quoteAssets.length === 0) {
+					throw(new KeetaAnchorUserError('quoteAssets must contain at least one token'));
+				}
+
+				const marketPrices = await instance.getMarketPrices({ quoteAssets, base });
+				const marketPricesResponse: KeetaFXAnchorMarketPricesResponse = {
+					ok: true,
+					...marketPrices
+				};
+
+				return({
+					output: JSON.stringify(marketPricesResponse)
+				});
+			};
+		}
+
 		return(routes);
 	}
 
@@ -1307,7 +1385,8 @@ abstract class BaseKeetaNetFXAnchorHTTPServer<ConfigType extends SharedHTTPServe
 	 */
 	protected async buildServiceMetadata(): Promise<NonNullable<ServiceMetadata['services']['fx']>[string]> {
 		const operations: NonNullable<ServiceMetadata['services']['fx']>[string]['operations'] = {
-			getEstimate: (new URL('/api/getEstimate', this.url)).toString()
+			getEstimate: (new URL('/api/getEstimate', this.url)).toString(),
+			getMarketPrices: (new URL('/api/getMarketPrices', this.url)).toString()
 		};
 
 		const metadata: NonNullable<ServiceMetadata['services']['fx']>[string] = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes pricing aggregation in getPrices (new code paths and provider batching); server endpoint is additive but affects how clients compute displayed averages.
> 
> **Overview**
> Adds a **GET `/api/getMarketPrices`** FX operation so providers can return quote-to-base **value ratios** for many assets at once, advertised in resolver metadata and discoverable via `requiredOperations: ['getMarketPrices']`.
> 
> **Server:** Optional `fx.getMarketPrices` config (`false` to disable, or `cacheControl`, `referenceAmount`, `onQuoteError`, custom `get`). Default behavior derives ratios from estimate rate data; responses can set `Cache-Control`.
> 
> **Client:** `KeetaFXAnchorProviderBase.getMarketPrices` and `KeetaFXAnchorClient.getMarketPrices(providerID, …)` call the endpoint. **`getPrices`** is reworked to batch `getMarketPrices` per provider when supported (deduped quote assets), fall back to per-provider `getEstimate` otherwise, and expose `providerMarketPrices` alongside `providerEstimates` in averages. **`onInvalidRatio`** (`omit` | `throw`) handles zero/invalid ratios.
> 
> Shared types and `isKeetaFXAnchorMarketPricesResponse` live in `common.ts`; tests cover server config, client batching, and invalid-ratio behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087480d85f6e28eed1e1e56c8e22b41bf5d236af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->