### PR TITLE
Allow human readable names/metadata for anchors

### DIFF
--- a/src/lib/metadata.types.ts
+++ b/src/lib/metadata.types.ts
@@ -28,7 +28,15 @@ export type ServiceMetadataAuthenticationType = {
  */
 export type ServiceMetadataEndpoint = string | { url: string; options?: { authentication?: ServiceMetadataAuthenticationType; }};
 
+export type AnchorMetadataLegalAnchorDetails = {
+	name?: string;
+	description?: ClientRenderableContent;
+	logo?: string;
+};
+
 export interface AnchorMetadataLegalField {
+	anchorDetails?: AnchorMetadataLegalAnchorDetails;
+
 	disclaimers?: {
 		purpose: 'general';
 		content: ClientRenderableContent;
@@ -74,6 +82,44 @@ async function resolveClientRenderableContent(content: ToValuizable<ClientRender
 	})
 }
 
+async function resolveAnchorDetails(anchorDetails: ToValuizable<AnchorMetadataLegalAnchorDetails> | undefined, options: {
+	logger?: Logger | undefined;
+}): Promise<AnchorMetadataLegalAnchorDetails | undefined> {
+	if (!anchorDetails) {
+		return(undefined);
+	}
+
+	const resolved = await anchorDetails('object');
+	if (!resolved) {
+		return(undefined);
+	}
+
+	const name = await resolved.name?.('string');
+	const logo = await resolved.logo?.('string');
+
+	let description: ClientRenderableContent | undefined;
+	if (resolved.description) {
+		try {
+			description = await resolveClientRenderableContent(resolved.description);
+		} catch (error) {
+			options.logger?.warn('resolveSharedAnchorMetadataLegalExtension', 'Failed to resolve anchorDetails.description', error);
+		}
+	}
+
+	const parsed: AnchorMetadataLegalAnchorDetails = {};
+	if (name !== undefined) {
+		parsed.name = name;
+	}
+	if (description !== undefined) {
+		parsed.description = description;
+	}
+	if (logo !== undefined) {
+		parsed.logo = logo;
+	}
+
+	return(parsed);
+}
+
 export async function resolveSharedAnchorMetadataLegalExtension(metadata: ToValuizable<AnchorMetadataLegalField> | undefined, options: {
 	logger?: Logger | undefined;
 }): Promise<SharedAnchorMetadataLegalExtension> {
@@ -86,6 +132,8 @@ export async function resolveSharedAnchorMetadataLegalExtension(metadata: ToValu
 	if (!resolvedField) {
 		return({});
 	}
+
+	const anchorDetails = await resolveAnchorDetails(resolvedField.anchorDetails, options);
 
 	const disclaimers = await (async (): Promise<AnchorMetadataLegalField['disclaimers']> => {
 		const resolvedDisclaimers = await resolvedField.disclaimers?.('array');
@@ -123,6 +171,7 @@ export async function resolveSharedAnchorMetadataLegalExtension(metadata: ToValu
 
 	return({
 		legal: {
+			...(anchorDetails !== undefined ? { anchorDetails } : {}),
 			disclaimers
 		}
 	});

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -98,6 +98,11 @@ test('Asset Movement Anchor Client Test', async function() {
 	}
 
 	const testLegalField: SharedAnchorMetadataLegalExtension['legal'] = {
+		anchorDetails: {
+			name: 'Test Anchor',
+			description: { type: 'plaintext', content: 'Test anchor details' },
+			logo: 'https://example.com/anchor-logo.png'
+		},
 		disclaimers: [
 			{ purpose: 'general', content: { type: 'markdown', content: 'Test Disclaimer' }}
 		]
@@ -463,6 +468,7 @@ test('Asset Movement Anchor Client Test', async function() {
 
 		/* Expect legal field to be parsed properly on the client side */
 		expect(testProvider?.serviceInfo.legal).toEqual(testLegalField);
+		expect(testProvider.serviceInfo.legal?.anchorDetails).toEqual(testLegalField.anchorDetails);
 		expect(testProvider.getLegalDisclaimers()).toEqual(testLegalField.disclaimers);
 
 		/* Expect custom token metadata to be resolved correctly */

--- a/src/services/fx/client.test.ts
+++ b/src/services/fx/client.test.ts
@@ -52,6 +52,11 @@ async function waitForExchangeToComplete(server: KeetaNetFXAnchorHTTPServer, exc
 
 const testingLegalField: SharedAnchorMetadataLegalExtension = {
 	legal: {
+		anchorDetails: {
+			name: 'Test FX Anchor',
+			description: { type: 'markdown', content: 'Test FX anchor details' },
+			logo: 'https://example.com/fx-logo.png'
+		},
 		disclaimers: [
 			{ purpose: 'general', content: { type: 'plaintext', content: 'Test disclaimer' }},
 			{ purpose: 'general', content: { type: 'markdown', content: 'Test disclaimer' }}
@@ -428,6 +433,7 @@ for (const useDeprecated of [false, true]) {
 
 			expect(providers?.length).toEqual(1);
 			expect(providers?.[0]?.serviceInfo.legal).toEqual(testingLegalField.legal);
+			expect(providers?.[0]?.serviceInfo.legal?.anchorDetails).toEqual(testingLegalField.legal?.anchorDetails);
 
 			const disclaimersFromClient = await fxClient.getLegalDisclaimersById('Test');
 			expect(disclaimersFromClient).toEqual(testingLegalField.legal?.disclaimers)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive optional metadata fields and resolution logic; no auth or transfer behavior changes. Failed description resolution is non-fatal.
> 
> **Overview**
> Anchors can now publish optional **human-readable identity** under `legal.anchorDetails` (display **name**, **logo** URL, and **description** as markdown/plaintext), alongside existing disclaimers.
> 
> **`resolveSharedAnchorMetadataLegalExtension`** resolves and merges `anchorDetails` from on-chain/service metadata the same way disclaimers are handled; a bad `description` is logged and omitted rather than failing the whole legal block.
> 
> Asset movement and FX client tests assert **`serviceInfo.legal.anchorDetails`** round-trips through provider metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265dc0cf6e8553d0d4653bfd1eda1b72ef3450ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->