### PR TITLE
Ensure Queue Open and Partition Paths Match

### DIFF
--- a/src/lib/queue/drivers/queue_firestore.ts
+++ b/src/lib/queue/drivers/queue_firestore.ts
@@ -52,7 +52,7 @@ export default class KeetaAnchorQueueStorageDriverFirestore<QueueRequest extends
 		this.logger = options?.logger;
 		this.firestoreInternal = options.firestore;
 		this.path = options.path ?? [];
-		this.pathStr = ['root', ...this.path].join('.');
+		this.pathStr = ['root', ...this.path].join('::');
 		this.namespace = options.namespace;
 		Object.freeze(this.path);
 

--- a/src/lib/queue/index.test.ts
+++ b/src/lib/queue/index.test.ts
@@ -113,7 +113,7 @@ const drivers: {
 	[driverName: string]: {
 		persistent: boolean;
 		skip: boolean | (() => Promise<boolean>);
-		create: (key: string, options?: { leave?: boolean; randomBackingName?: boolean; }) => Promise<{
+		create: (key: string, options?: { leave?: boolean; randomBackingName?: boolean; path?: string[] }) => Promise<{
 			queue: KeetaAnchorQueueStorageDriver<JSONSerializable, JSONSerializable>;
 			[Symbol.asyncDispose]: () => Promise<void>;
 		}>;
@@ -122,8 +122,8 @@ const drivers: {
 	'Memory': {
 		persistent: false,
 		skip: false,
-		create: async function(key: string) {
-			const queue = new KeetaAnchorQueueStorageDriverMemory({ id: key, logger: logger });
+		create: async function(key: string, options) {
+			const queue = new KeetaAnchorQueueStorageDriverMemory({ id: key, logger: logger, path: options?.path });
 			return({
 				queue: queue,
 				[Symbol.asyncDispose]: async function() {
@@ -141,7 +141,8 @@ const drivers: {
 			const queue = new KeetaAnchorQueueStorageDriverFile({
 				filePath: filePath,
 				id: key,
-				logger: logger
+				logger: logger,
+				path: options?.path
 			});
 			return({
 				queue: queue,
@@ -173,7 +174,8 @@ const drivers: {
 					}));
 				},
 				id: key,
-				logger: logger
+				logger: logger,
+				path: options?.path
 			});
 			return({
 				queue: queue,
@@ -225,7 +227,7 @@ const drivers: {
 					return(client);
 				},
 				id: key,
-				path: [`key_${key}_${RunKey}`],
+				path: [`key_${key}_${RunKey}`, ...(options?.path ?? [])],
 				logger: logger
 			});
 
@@ -305,6 +307,7 @@ const drivers: {
 					id: key,
 					logger: logger,
 					tablePrefix: tablePrefix,
+					path: options?.path,
 					pool: async function(): Promise<pg.Pool> {
 						if (!pool) {
 							throw(new Error('Pool is not available'));
@@ -383,7 +386,8 @@ const drivers: {
 				},
 				id: key,
 				namespace: namespace,
-				logger: logger
+				logger: logger,
+				path: options?.path
 			});
 
 			return({
@@ -2042,6 +2046,27 @@ suite.sequential('Driver Tests', async function() {
 					expect(part111_entry).toBeDefined();
 					expect(part111_entry?.request).toEqual({ partition: 'part1.1.1' });
 				});
+
+				/*
+				 * Test that partitioning works and we can
+				 * add and get entries from same partition
+				 * either using `partition` or `path`
+				 */
+				testRunner('Partitioning and Opening Work the same', async function() {
+					await using driverInstance1 = await driverConfig.create('partition_reopen', {
+						randomBackingName: false
+					});
+					await using partition1 = await driverInstance1.queue.partition('partition1');
+					const entry1_id = await partition1.add({ key: 'partition_test_1' });
+
+					await using driverInstance2 = await driverConfig.create('partition_reopen', {
+						randomBackingName: false,
+						path: ['partition1']
+					});
+
+					const check_entry1 = await driverInstance2.queue.get(entry1_id);
+					expect(check_entry1?.id).toBe(entry1_id);
+				}, 60_000);
 			}
 
 			/*


### PR DESCRIPTION
This change adds a test (and fixes a driver where the test fails) to ensure that partitioning and opening a given path both produce  the same queue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Firestore collection name encoding changes for all partitioned queues, so existing emulator/production data under old `root.segment` names would not be found until migrated or recreated.
> 
> **Overview**
> Adds a persistent-driver test that **enqueues on a partition** (`partition('partition1')`) and **reads the same entry** from a second driver instance opened with `path: ['partition1']`, so `partition()` and constructor `path` must target the same backing queue.
> 
> Test harness `create()` now accepts optional **`path`** and passes it through Memory, File, SQLite, Postgres, Firestore, and Redis (Redis appends after its run key prefix).
> 
> **Firestore** changes partition collection naming: `pathStr` is built with **`::`** instead of **`.`** between `root` and path segments (matches the `::` used in partitioned driver IDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d3981090ba725cc8c18b0fcb8180b0ea032e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->