### PR TITLE
Release 0.0.90

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.89",
+	"version": "0.0.90",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.89",
+			"version": "0.0.90",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.89",
+	"version": "0.0.90",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
Includes changes from:
 - #368 
 - #412 
 - #409 
 - #410 
 - #413 
 - #414 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only manifest change with no runtime or dependency updates in the diff.
> 
> **Overview**
> **Release 0.0.90** for `@keetanetwork/anchor`: the package version is bumped from **0.0.89** to **0.0.90** in `package.json` and `package-lock.json`. No application source, dependency pins, or scripts change in this diff—the release bundles work already merged via linked PRs (#368, #409–#414, #412).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8380ed2b3396c817a81baf933b401ffa93960b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->