### PR TITLE
Fix anchor chaining plan type issue

### DIFF
--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -3124,7 +3124,8 @@ export class AnchorChaining {
 		return(retval);
 	}
 
-	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<(AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true; forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingFullForwardingOnlyPlanResult[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<AnchorChainingFullPlanResult[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingForwardingOnlyPlan[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -3125,9 +3125,9 @@ export class AnchorChaining {
 	}
 
 	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true; forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingFullForwardingOnlyPlanResult[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true }): Promise<AnchorChainingFullPlanResult[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingForwardingOnlyPlan[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true; forwardingOnly?: false; }): Promise<AnchorChainingFullPlanResult[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput?: false; forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingForwardingOnlyPlan[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
 		let paths = await this.getPaths(input);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -3127,7 +3127,7 @@ export class AnchorChaining {
 	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true; forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingFullForwardingOnlyPlanResult[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput: true; forwardingOnly?: false; }): Promise<AnchorChainingFullPlanResult[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options: GetPlansOptions & { includeAllOutput?: false; forwardingOnly: true | ForwardingOnlyOptions }): Promise<AnchorChainingForwardingOnlyPlan[] | null>;
-	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null>;
+	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
 		let paths = await this.getPaths(input);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Overload signature changes only with no runtime logic modified.
> 
> **Overview**
> Tightens **`AnchorChaining.getPlans`** TypeScript overloads so return types match the **`includeAllOutput`** and **`forwardingOnly`** option combinations instead of a broad union.
> 
> When **`includeAllOutput: true`** is set, callers now get **`AnchorChainingFullForwardingOnlyPlanResult[]`** only if **`forwardingOnly`** is enabled, and **`AnchorChainingFullPlanResult[]`** when forwarding-only is off or omitted. The **`forwardingOnly`** path without **`includeAllOutput`** still resolves to **`AnchorChainingForwardingOnlyPlan[]`**. Implementation behavior is unchanged; this is a compile-time typing fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b674e4c4997b4d999cc62ab3fd7bb72da070bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->