### PR TITLE
Add forwardingOnly support to resolveAssets in chaining

### DIFF
--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4576,6 +4576,114 @@ describe('getPlans forwardingOnly', function() {
 		});
 		expect(initiateOnlyImplied.to).toHaveLength(0);
 	});
+
+	test('resolveAssets forwardingOnly honors maxLegs like getPlans', async function() {
+		const account = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
+		const { userClient: client, fees } = await createNodeAndClient(account);
+		fees.addFeeFreeAccount(client.account);
+
+		const makeToken = async () => {
+			const { account: tokenAccount } = await client.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN);
+			await client.setInfo(
+				{ name: '', description: '', metadata: '', defaultPermission: new KeetaNet.lib.Permissions(['ACCESS']) },
+				{ account: tokenAccount }
+			);
+			return(tokenAccount.assertKeyType(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN));
+		};
+
+		const keetaLocation = `chain:keeta:${client.network}` satisfies AssetLocationLike;
+		const tokens = { USDC: await makeToken() };
+		const EXTERNAL_MULTI = {
+			USDC_ARB: 'evm:0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+			USDC_OP: 'evm:0x0b2c639c533813f4aa9d7837caf62653d097ff85'
+		} as const;
+		const LOC_MULTI = {
+			arb: 'chain:evm:42161',
+			op: 'chain:evm:10'
+		} as const satisfies { [key: string]: AssetLocationLike };
+
+		type AMAssetEntry = KeetaAnchorAssetMovementServerConfig['assetMovement']['supportedAssets'][number];
+		type AMSide = AMAssetEntry['paths'][number]['pair'][number];
+		const keetaSide = (token: TokenAddress): AMSide => ({
+			location: keetaLocation,
+			id: token.publicKeyString.get(),
+			rails: { common: [{ rail: 'KEETA_SEND', supportedOperations: MANAGED_OPS }] }
+		});
+		const baseSide = (id: AMSide['id']): AMSide => ({
+			location: LOC.base,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: PFR_OPS }] }
+		});
+		const ethSide = (id: AMSide['id']): AMSide => ({
+			location: LOC.eth,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: PFR_OPS }] }
+		});
+		const arbSide = (id: AMSide['id']): AMSide => ({
+			location: LOC_MULTI.arb,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: PFR_OPS }] }
+		});
+		const opSide = (id: AMSide['id']): AMSide => ({
+			location: LOC_MULTI.op,
+			id,
+			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: PFR_OPS }] }
+		});
+		const pairEntry = (a: AMSide, b: AMSide): AMAssetEntry => ({
+			asset: [ a.id, b.id ],
+			paths: [{ pair: [ a, b ] }]
+		});
+
+		const am1 = new TestChainAnchorServer({
+			...(DEBUG ? { logger } : {}),
+			client,
+			convert: ({ value }) => value,
+			assetMovement: {
+				supportedAssets: [
+					pairEntry(baseSide(EXTERNAL_IDS.USDC_BASE), ethSide(EXTERNAL_IDS.USDC_ETH)),
+					pairEntry(ethSide(EXTERNAL_IDS.USDC_ETH), arbSide(EXTERNAL_MULTI.USDC_ARB)),
+					pairEntry(arbSide(EXTERNAL_MULTI.USDC_ARB), opSide(EXTERNAL_MULTI.USDC_OP)),
+					pairEntry(opSide(EXTERNAL_MULTI.USDC_OP), keetaSide(tokens.USDC))
+				]
+			}
+		});
+
+		await am1.start();
+		await client.setInfo({
+			description: 'Forwarding-only maxLegs resolveAssets test',
+			name: 'TEST',
+			metadata: Resolver.Metadata.formatMetadata({
+				version: 1,
+				currencyMap: Object.fromEntries(Object.entries(tokens).map(([ sym, token ]) => [ `$${sym}`, token.publicKeyString.get() ])),
+				services: { assetMovement: { AM1: await am1.serviceMetadata() }}
+			} satisfies ServiceMetadataExternalizable)
+		});
+
+		const anchorChaining = new AnchorChaining({
+			client,
+			resolver: new Resolver({ root: client.account, client, trustedCAs: [] })
+		});
+
+		try {
+			const defaultForwarding = await anchorChaining.graph.resolveAssets({
+				from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+				forwardingOnly: true
+			});
+			const defaultKeys = defaultForwarding.to.map((item) =>
+				`${typeof item.asset === 'string' ? item.asset : item.asset.publicKeyString.get()}@${convertAssetLocationToString(item.location)}`
+			);
+			expect(defaultKeys).not.toContain(`${tokens.USDC.publicKeyString.get()}@${keetaLocation}`);
+			expect(defaultKeys).toContain(`${EXTERNAL_MULTI.USDC_ARB}@${LOC_MULTI.arb}`);
+
+			const plans = await anchorChaining.getPlans({
+				source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+				destination: { asset: tokens.USDC, location: keetaLocation, recipient: client.account.publicKeyString.get(), rail: 'KEETA_SEND' }
+			}, { limit: 1, forwardingOnly: true });
+			expect(plans).toBeNull();
+		} finally {
+			await am1[Symbol.asyncDispose]?.();
+		}
+	});
 });
 
 describe('Keeta-to-keeta swap chaining (persistent-forwarding regression)', function() {

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -7,7 +7,7 @@ import { KeetaNetFXAnchorHTTPServer, type KeetaAnchorFXServerConfig, type GetCon
 import type { ConversionInputCanonicalJSON } from '../services/fx/common.js';
 import { Resolver } from './index.js';
 import type { ServiceMetadataExternalizable } from './resolver.js';
-import { AnchorChaining, AnchorChainingForwardingOnlyPlan, AnchorChainingPlan, buildForwardingAdjacency, estimateForwardingValueOut, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan, listChainingPlanFees } from './chaining.js';
+import { AnchorChaining, AnchorChainingForwardingOnlyPlan, AnchorChainingPlan, buildForwardingAdjacency, estimateForwardingValueOut, getForwardingDepositAddress, hasForwardingRoute, isForwardingPath, isForwardingPlan, listChainingPlanFees, supportsPersistentForwarding } from './chaining.js';
 import type { AnchorChainingPathState, ExecutedStep, AnchorChainingAsset, AnchorChainingAssetInfo, AnchorChainingResolveAssetsFilter, Disclaimer, AnchorChainingPathInput, AnchorChainingPath, GetPlansOptions } from './chaining.js';
 import type { GenericAccount, TokenAddress } from '@keetanetwork/keetanet-client/lib/account.js';
 import { KeetaAnchorUserError } from './error.js';
@@ -4078,8 +4078,9 @@ describe('getPlans forwardingOnly', function() {
 	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;
 	const PFR_OPS = { initiateTransfer: false, createPersistentForwarding: true } as const;
 	const DUAL_OPS = { initiateTransfer: true, createPersistentForwarding: true } as const;
+	const INITIATE_ONLY_OPS = { initiateTransfer: true } as const;
 
-	type LegMode = 'managed' | 'pfr';
+	type LegMode = 'managed' | 'pfr' | 'omitted' | 'initiateOnly';
 
 	async function buildForwardingWorld(legMode: LegMode) {
 		const account = KeetaNet.lib.Account.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0);
@@ -4096,7 +4097,14 @@ describe('getPlans forwardingOnly', function() {
 
 		const keetaLocation = `chain:keeta:${client.network}` satisfies AssetLocationLike;
 		const tokens = { USDC: await makeToken(), USD: await makeToken(), EUR: await makeToken(), KTA: await makeToken() };
-		const baseEvmOps = legMode === 'pfr' ? PFR_OPS : MANAGED_OPS;
+		const baseEvmOps = legMode === 'pfr' ? PFR_OPS
+			: legMode === 'omitted' ? undefined
+			: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
+			: MANAGED_OPS;
+		const ethEvmOps = legMode === 'pfr' ? DUAL_OPS
+			: legMode === 'omitted' ? undefined
+			: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
+			: MANAGED_OPS;
 
 		type AMAssetEntry = KeetaAnchorAssetMovementServerConfig['assetMovement']['supportedAssets'][number];
 		type AMSide = AMAssetEntry['paths'][number]['pair'][number];
@@ -4109,12 +4117,12 @@ describe('getPlans forwardingOnly', function() {
 		const baseSide = (id: AMSide['id']): AMSide => ({
 			location: LOC.base,
 			id,
-			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: baseEvmOps }] }
+			rails: { common: [{ rail: 'EVM_SEND', ...(baseEvmOps !== undefined ? { supportedOperations: baseEvmOps } : {}) }] }
 		});
 		const ethSide = (id: AMSide['id']): AMSide => ({
 			location: LOC.eth,
 			id,
-			rails: { common: [{ rail: 'EVM_SEND', supportedOperations: legMode === 'pfr' ? DUAL_OPS : MANAGED_OPS }] }
+			rails: { common: [{ rail: 'EVM_SEND', ...(ethEvmOps !== undefined ? { supportedOperations: ethEvmOps } : {}) }] }
 		});
 		const fiatSide = (iso: AMSide['id']): AMSide => ({
 			location: LOC.sepa,
@@ -4341,7 +4349,7 @@ describe('getPlans forwardingOnly', function() {
 		}
 
 		expect(isForwardingPath(path)).toBe(true);
-		expect(isForwardingPath(path, { maxLegs: 0 })).toBe(false);
+		expect(isForwardingPath(path, { method: 'explicit', maxLegs: 0 })).toBe(false);
 
 		const plan = await AnchorChainingPlan.create(path);
 		expect(isForwardingPlan(plan)).toBe(true);
@@ -4481,6 +4489,92 @@ describe('getPlans forwardingOnly', function() {
 
 		const plan = await AnchorChainingPlan.create(path, { forwardingOnly: true });
 		await expect(plan.execute()).rejects.toThrow(/cannot be executed/i);
+	});
+
+	test('supportsPersistentForwarding distinguishes explicit and implied', function() {
+		expect(supportsPersistentForwarding(undefined, 'explicit')).toBe(false);
+		expect(supportsPersistentForwarding(undefined, 'implied')).toBe(true);
+		expect(supportsPersistentForwarding({ createPersistentForwarding: true }, 'explicit')).toBe(true);
+		expect(supportsPersistentForwarding({ createPersistentForwarding: true }, 'implied')).toBe(true);
+		expect(supportsPersistentForwarding({ initiateTransfer: true }, 'explicit')).toBe(false);
+		expect(supportsPersistentForwarding({ initiateTransfer: true }, 'implied')).toBe(false);
+		expect(supportsPersistentForwarding({ createPersistentForwarding: false }, 'implied')).toBe(false);
+	});
+
+	test('getPlans method:implied includes omitted supportedOperations; explicit does not', async function() {
+		await using w = await buildForwardingWorld('omitted');
+
+		const request = {
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' as const },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' as const }
+		};
+
+		const paths = await w.anchorChaining.getPaths(request);
+		const path = paths?.[0];
+		if (!path) {
+			throw(new Error('Expected path with omitted supportedOperations'));
+		}
+		expect(path.path[0]?.type).toBe('assetMovement');
+		if (path.path[0]?.type === 'assetMovement') {
+			expect(path.path[0].from.supportedOperations).toBeUndefined();
+		}
+
+		expect(isForwardingPath(path, { method: 'explicit' })).toBe(false);
+		expect(isForwardingPath(path, { method: 'implied' })).toBe(true);
+
+		const explicitPlans = await w.anchorChaining.getPlans(request, { limit: 1, forwardingOnly: { method: 'explicit' }});
+		expect(explicitPlans).toBeNull();
+
+		const impliedPlans = await w.anchorChaining.getPlans(request, { limit: 1, forwardingOnly: { method: 'implied' }});
+		expect(impliedPlans).not.toBeNull();
+		expect(impliedPlans?.[0]).toBeInstanceOf(AnchorChainingForwardingOnlyPlan);
+	});
+
+	test('getPlans method:implied excludes initiateTransfer-only rails', async function() {
+		await using w = await buildForwardingWorld('initiateOnly');
+
+		const plans = await w.anchorChaining.getPlans({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' }
+		}, { limit: 1, forwardingOnly: { method: 'implied' }});
+
+		expect(plans).toBeNull();
+	});
+
+	test('resolveAssets forwardingOnly respects explicit vs implied', async function() {
+		await using omitted = await buildForwardingWorld('omitted');
+		await using pfr = await buildForwardingWorld('pfr');
+		await using initiateOnly = await buildForwardingWorld('initiateOnly');
+
+		const omittedExplicit = await omitted.anchorChaining.graph.resolveAssets({
+			from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+			forwardingOnly: { method: 'explicit' }
+		});
+		expect(omittedExplicit.to).toHaveLength(0);
+
+		const omittedImplied = await omitted.anchorChaining.graph.resolveAssets({
+			from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+			forwardingOnly: { method: 'implied' }
+		});
+		const omittedKeys = omittedImplied.to.map((item) =>
+			`${typeof item.asset === 'string' ? item.asset : item.asset.publicKeyString.get()}@${convertAssetLocationToString(item.location)}`
+		);
+		expect(omittedKeys).toContain(`${omitted.tokens.USDC.publicKeyString.get()}@${omitted.keetaLocation}`);
+
+		const pfrExplicit = await pfr.anchorChaining.graph.resolveAssets({
+			from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+			forwardingOnly: true
+		});
+		const pfrKeys = pfrExplicit.to.map((item) =>
+			`${typeof item.asset === 'string' ? item.asset : item.asset.publicKeyString.get()}@${convertAssetLocationToString(item.location)}`
+		);
+		expect(pfrKeys).toContain(`${pfr.tokens.USDC.publicKeyString.get()}@${pfr.keetaLocation}`);
+
+		const initiateOnlyImplied = await initiateOnly.anchorChaining.graph.resolveAssets({
+			from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+			forwardingOnly: { method: 'implied' }
+		});
+		expect(initiateOnlyImplied.to).toHaveLength(0);
 	});
 });
 

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4099,12 +4099,12 @@ describe('getPlans forwardingOnly', function() {
 		const tokens = { USDC: await makeToken(), USD: await makeToken(), EUR: await makeToken(), KTA: await makeToken() };
 		const baseEvmOps = legMode === 'pfr' ? PFR_OPS
 			: legMode === 'omitted' ? undefined
-			: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
-			: MANAGED_OPS;
+				: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
+					: MANAGED_OPS;
 		const ethEvmOps = legMode === 'pfr' ? DUAL_OPS
 			: legMode === 'omitted' ? undefined
-			: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
-			: MANAGED_OPS;
+				: legMode === 'initiateOnly' ? INITIATE_ONLY_OPS
+					: MANAGED_OPS;
 
 		type AMAssetEntry = KeetaAnchorAssetMovementServerConfig['assetMovement']['supportedAssets'][number];
 		type AMSide = AMAssetEntry['paths'][number]['pair'][number];

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -1315,13 +1315,12 @@ test('Asset Movement Chaining Test', async function({ expect }) {
 
 	expect(path.path).toHaveLength(3);
 
-	const BANK_ANCHOR_SUPPORTED_OPS = { createPersistentForwarding: true, initiateTransfer: true } as const;
 	expect(toJSONSerializable([
 		{
 			providerID: 'BankAnchor',
 			type: 'assetMovement',
-			from: { asset: 'USD', location: 'bank-account:us', rail: 'ACH', supportedOperations: BANK_ANCHOR_SUPPORTED_OPS },
-			to: { asset: tokens.USDC, location: keetaLocation, rail: 'KEETA_SEND', supportedOperations: BANK_ANCHOR_SUPPORTED_OPS }
+			from: { asset: 'USD', location: 'bank-account:us', rail: 'ACH' },
+			to: { asset: tokens.USDC, location: keetaLocation, rail: 'KEETA_SEND' }
 		},
 		{
 			from: { asset: tokens.USDC, location: keetaLocation, rail: 'KEETA_SEND' },
@@ -1332,8 +1331,8 @@ test('Asset Movement Chaining Test', async function({ expect }) {
 		{
 			providerID: 'BankAnchor',
 			type: 'assetMovement',
-			from: { asset: tokens.EURC, location: keetaLocation, rail: 'KEETA_SEND', supportedOperations: BANK_ANCHOR_SUPPORTED_OPS },
-			to: { asset: 'EUR', location: 'bank-account:iban-swift', rail: 'SEPA_PUSH', supportedOperations: BANK_ANCHOR_SUPPORTED_OPS }
+			from: { asset: tokens.EURC, location: keetaLocation, rail: 'KEETA_SEND' },
+			to: { asset: 'EUR', location: 'bank-account:iban-swift', rail: 'SEPA_PUSH' }
 		}
 	])).toEqual(toJSONSerializable(path.path));
 });
@@ -4783,7 +4782,9 @@ describe('Keeta-to-keeta swap chaining (persistent-forwarding regression)', func
 		if (!secondLeg || secondLeg.type !== 'assetMovement') {
 			throw(new Error(`Expected the second path leg to be an asset-movement node`));
 		}
-		expect(secondLeg.from.supportedOperations?.createPersistentForwarding).toBe(true);
+		// Bare KEETA_SEND rails omit supportedOperations; plan computation must still
+		// treat Keeta-origin hops as managed sends (not persistent forwarding).
+		expect(secondLeg.from.supportedOperations).toBeUndefined();
 
 		const plan = await AnchorChainingPlan.create(path);
 

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,6 +1,6 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
-import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem, AssetLocationString } from "../services/asset-movement/common.js";
+import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
 import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
@@ -1125,6 +1125,7 @@ class AnchorGraph {
 
 	async resolveAssets(filter: AnchorChainingResolveAssetsFilter = {}): Promise<AnchorChainingResolveAssetsResult> {
 		const { from: fromFilterInput, to: toFilterInput, maxStepCount, onlyAllowFXLike } = filter;
+		// eslint-disable-next-line @typescript-eslint/no-use-before-define
 		const forwardingOpts = normalizeForwardingOnlyOptions(filter.forwardingOnly);
 		const forwardingMethod = forwardingOpts?.method;
 
@@ -2096,7 +2097,7 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 				}
 
 				// Accept explicit createPersistentForwarding:true or omitted supportedOperations
-				// (implied). Reject partial ops that omit the flag — those imply false.
+				// (implied). Reject partial ops that omit the flag - those imply false.
 				const pfrEligible = supportsPersistentForwarding(scanStep.from.supportedOperations, 'implied');
 				const sourceIsKeeta = isChainLocation(toAssetLocation(scanStep.from.location), 'keeta');
 

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,6 +1,6 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
-import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
+import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem, AssetLocationString } from "../services/asset-movement/common.js";
 import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
@@ -259,11 +259,24 @@ export type AnchorChainingListAssetsFilter =
 	| ({ to: AnchorChainingListAssetsSideFilter; from?: never } & AnchorChainingListAssetsShared)
 	| ({ from?: never; to?: never } & AnchorChainingListAssetsShared);
 
+export type ForwardingOnlyMethod = 'explicit' | 'implied';
+
+export type ForwardingOnlyOptions = {
+	method: ForwardingOnlyMethod;
+	/** Max asset-movement legs (default 2, matching deposit UX). */
+	maxLegs?: number;
+};
+
 export type AnchorChainingResolveAssetsFilter = {
 	from?: AnchorChainingListAssetsSideFilter;
 	to?: AnchorChainingListAssetsSideFilter;
 	maxStepCount?: number;
 	onlyAllowFXLike?: boolean;
+	/**
+	 * When set, only consider persistent-forwarding-eligible crypto hops
+	 * (asset-movement, non-Keeta origin). `true` means `{ method: 'explicit' }`.
+	 */
+	forwardingOnly?: boolean | Pick<ForwardingOnlyOptions, 'method'>;
 };
 
 export const DEFAULT_MAX_PATH_LENGTH = 5;
@@ -366,6 +379,47 @@ function isCryptoChainLocation(location: AssetLocationLike): boolean {
 }
 
 /**
+ * Whether a rail's supportedOperations qualify for forwarding-only filtering.
+ * - explicit: createPersistentForwarding must be true
+ * - implied: supportedOperations omitted, or createPersistentForwarding is true
+ *   (a partial object like `{ initiateTransfer: true }` does not qualify)
+ */
+export function supportsPersistentForwarding(
+	supportedOperations: RailSupportedOperations | undefined,
+	method: ForwardingOnlyMethod
+): boolean {
+	if (method === 'explicit') {
+		return(supportedOperations?.createPersistentForwarding === true);
+	}
+
+	if (supportedOperations === undefined) {
+		return(true);
+	}
+
+	return(supportedOperations.createPersistentForwarding === true);
+}
+
+/**
+ * Whether a graph node is a forwarding-eligible crypto hop (asset-movement,
+ * crypto locations, non-Keeta origin, and createPersistentForwarding per method).
+ */
+function isForwardingEligibleNode(node: GraphNodeLike, method: ForwardingOnlyMethod): boolean {
+	if (node.type !== 'assetMovement') {
+		return(false);
+	}
+
+	if (!isCryptoChainLocation(node.from.location) || !isCryptoChainLocation(node.to.location)) {
+		return(false);
+	}
+
+	if (isChainLocation(toAssetLocation(node.from.location), 'keeta')) {
+		return(false);
+	}
+
+	return(supportsPersistentForwarding(node.from.supportedOperations, method));
+}
+
+/**
  * Adjacency over crypto persistent-forwarding edges only - excludes FX edges and
  * any hop that starts on Keeta.
  */
@@ -373,19 +427,7 @@ export function buildForwardingAdjacency(nodes: GraphNodeLike[]): Map<string, Fo
 	const adjacency = new Map<string, ForwardingAssetRef[]>();
 
 	for (const node of nodes) {
-		if (node.type !== 'assetMovement') {
-			continue;
-		}
-
-		if (node.from.supportedOperations?.createPersistentForwarding !== true) {
-			continue;
-		}
-
-		if (!isCryptoChainLocation(node.from.location) || !isCryptoChainLocation(node.to.location)) {
-			continue;
-		}
-
-		if (isChainLocation(toAssetLocation(node.from.location), 'keeta')) {
+		if (!isForwardingEligibleNode(node, 'explicit')) {
 			continue;
 		}
 
@@ -796,6 +838,23 @@ class AnchorGraph {
 							return(retval);
 						}
 
+						const makeFromTo = (input: {
+							asset: { id: AnchorChainingAsset; location: AssetLocationLike; };
+							rail: { rail: Rail; supportedOperations?: RailSupportedOperations | undefined; }
+						}) => {
+							const retval: Extract<GraphNodeLike, { type: 'assetMovement' }>['from' | 'to'] = {
+								asset: input.asset.id,
+								location: input.asset.location,
+								rail: input.rail.rail
+							};
+
+							if (input.rail.supportedOperations !== undefined) {
+								retval.supportedOperations = getProviderSupportedOperationsForRail(input.rail.supportedOperations);
+							}
+
+							return(retval);
+						};
+
 						const pathNodes: GraphNodeLike[] = [];
 						for (const [ src, dest ] of [
 							[ fromResolved, toResolved ],
@@ -817,18 +876,8 @@ class AnchorGraph {
 									pathNodes.push({
 										type: 'assetMovement',
 										providerID: providerID,
-										from: {
-											asset: src.id,
-											location: src.location,
-											rail: inboundRail.rail,
-											supportedOperations: getProviderSupportedOperationsForRail(inboundRail.supportedOperations)
-										},
-										to: {
-											asset: dest.id,
-											location: dest.location,
-											rail: outboundRail.rail,
-											supportedOperations: getProviderSupportedOperationsForRail(outboundRail.supportedOperations)
-										}
+										from: makeFromTo({ asset: src, rail: inboundRail }),
+										to: makeFromTo({ asset: dest, rail: outboundRail })
 									});
 								}
 							}
@@ -1076,6 +1125,8 @@ class AnchorGraph {
 
 	async resolveAssets(filter: AnchorChainingResolveAssetsFilter = {}): Promise<AnchorChainingResolveAssetsResult> {
 		const { from: fromFilterInput, to: toFilterInput, maxStepCount, onlyAllowFXLike } = filter;
+		const forwardingOpts = normalizeForwardingOnlyOptions(filter.forwardingOnly);
+		const forwardingMethod = forwardingOpts?.method;
 
 		const keetaNetworkLocation = `chain:keeta:${this.client.network}` satisfies AssetLocationLike;
 
@@ -1092,6 +1143,16 @@ class AnchorGraph {
 		// of many filtered resolveAssets/listAssets calls doesn't rebuild them n
 		// times.
 		const { nodes, fromAssetKeys, toAssetKeys, fromKeys, toKeys, nodesByFromKey, nodesByToKey, nodesByFromAssetKey, nodesByToAssetKey, railInfo } = await this.#getResolveIndex();
+
+		const nodeAllowed = (node: GraphNodeLike): boolean => {
+			if (onlyAllowFXLike && !isFXLikeNode(node)) {
+				return(false);
+			}
+			if (forwardingMethod !== undefined && !isForwardingEligibleNode(node, forwardingMethod)) {
+				return(false);
+			}
+			return(true);
+		};
 
 		const sideMatchesFilter = (
 			side: GraphNodeLike['from' | 'to'],
@@ -1187,7 +1248,7 @@ class AnchorGraph {
 				if (!node || markKey === undefined || stepKey === undefined) {
 					throw(new Error(`Invalid node index during BFS processing: ${nodeIdx}`));
 				}
-				if (onlyAllowFXLike && !isFXLikeNode(node)) {
+				if (!nodeAllowed(node)) {
 					continue;
 				}
 				markFn(markKey, depth);
@@ -1229,7 +1290,7 @@ class AnchorGraph {
 				if (!node || fromKey === undefined || toKey === undefined) {
 					throw(new Error(`Invalid node index during reachability marking: ${i}`));
 				}
-				if (!onlyAllowFXLike || isFXLikeNode(node)) {
+				if (nodeAllowed(node)) {
 					markFromReachable(fromKey);
 					markFromReachable(toKey);
 					markToReachable(fromKey);
@@ -1240,9 +1301,9 @@ class AnchorGraph {
 
 		// Build result maps by collecting inbound/outbound rails for every reachable
 		// (asset, location) pair. The common path reads the precomputed per-asset
-		// rail aggregation (railInfo) and so is O(reachable). onlyAllowFXLike needs
-		// to exclude non-fx-like nodes' rails -- which railInfo doesn't distinguish
-		// -- so it falls back to the O(nodes) scan.
+		// rail aggregation (railInfo) and so is O(reachable). onlyAllowFXLike and
+		// forwardingOnly need to exclude disallowed nodes' rails -- which railInfo
+		// doesn't distinguish -- so they fall back to the O(nodes) scan.
 		const buildResultMapFast = (
 			reachable: Set<string>,
 			distances: Map<string, number>
@@ -1264,7 +1325,7 @@ class AnchorGraph {
 			return(resultMap);
 		};
 
-		const buildResultMapFXLike = (
+		const buildResultMapFiltered = (
 			reachable: Set<string>,
 			distances: Map<string, number>
 		): Map<string, AnchorChainingAssetInfo> => {
@@ -1292,7 +1353,7 @@ class AnchorGraph {
 				if (!node || toKey === undefined || fromKey === undefined) {
 					throw(new Error(`Invalid node index during result-map construction: ${i}`));
 				}
-				if (!isFXLikeNode(node)) {
+				if (!nodeAllowed(node)) {
 					continue;
 				}
 				if (reachable.has(toKey)) {
@@ -1311,7 +1372,7 @@ class AnchorGraph {
 			return(resultMap);
 		};
 
-		const buildResultMap = onlyAllowFXLike ? buildResultMapFXLike : buildResultMapFast;
+		const buildResultMap = (onlyAllowFXLike || forwardingMethod !== undefined) ? buildResultMapFiltered : buildResultMapFast;
 
 		const fromResultMap = buildResultMap(fromReachable, fromDistances);
 		const toResultMap = buildResultMap(toReachable, toDistances);
@@ -1457,23 +1518,18 @@ export interface ComputePlanOptions {
 	forwardingOnly?: boolean;
 }
 
-export type ForwardingOnlyOptions = {
-	/** Max asset-movement legs (default 2, matching deposit UX). */
-	maxLegs?: number;
-};
-
 export interface GetPlansOptions extends Omit<ComputePlanOptions, 'forwardingOnly'> {
 	includeAllOutput?: boolean;
-	forwardingOnly?: true | ForwardingOnlyOptions;
+	forwardingOnly?: boolean | ForwardingOnlyOptions;
 }
 
-function normalizeForwardingOnlyOptions(forwardingOnly: true | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
+function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
 	if (!forwardingOnly) {
 		return(undefined);
 	}
 
 	if (forwardingOnly === true) {
-		return({ maxLegs: DEFAULT_FORWARDING_MAX_LEGS });
+		return({ method: 'explicit', maxLegs: DEFAULT_FORWARDING_MAX_LEGS });
 	}
 
 	return({
@@ -1502,6 +1558,7 @@ function toComputePlanOptions(options?: GetPlansOptions, forwardingOpts?: Forwar
  */
 export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingOnlyOptions): boolean {
 	const maxLegs = options?.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS;
+	const method = options?.method ?? 'explicit';
 	const legs = path.path;
 
 	if (legs.length < 1 || legs.length > maxLegs) {
@@ -1521,7 +1578,7 @@ export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingO
 			return(false);
 		}
 
-		return(step.from.supportedOperations?.createPersistentForwarding === true);
+		return(supportsPersistentForwarding(step.from.supportedOperations, method));
 	}));
 }
 
@@ -2038,10 +2095,12 @@ export class AnchorChainingPlan extends AnchorChainingPath {
 					continue;
 				}
 
-				const pfrSupported = scanStep.from.supportedOperations?.createPersistentForwarding === true;
+				// Accept explicit createPersistentForwarding:true or omitted supportedOperations
+				// (implied). Reject partial ops that omit the flag — those imply false.
+				const pfrEligible = supportsPersistentForwarding(scanStep.from.supportedOperations, 'implied');
 				const sourceIsKeeta = isChainLocation(toAssetLocation(scanStep.from.location), 'keeta');
 
-				if (sourceIsKeeta || !pfrSupported) {
+				if (sourceIsKeeta || !pfrEligible) {
 					throw(new Error(`Forwarding-only plan requires persistent forwarding support on every leg, but step ${scanIndex} at ${convertAssetLocationToString(scanStep.from.location)} does not qualify`));
 				}
 

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1128,6 +1128,9 @@ class AnchorGraph {
 		// eslint-disable-next-line @typescript-eslint/no-use-before-define
 		const forwardingOpts = normalizeForwardingOnlyOptions(filter.forwardingOnly);
 		const forwardingMethod = forwardingOpts?.method;
+		const traversalStepLimit = forwardingOpts
+			? Math.min(maxStepCount ?? Infinity, forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS)
+			: maxStepCount;
 
 		const keetaNetworkLocation = `chain:keeta:${this.client.network}` satisfies AssetLocationLike;
 
@@ -1253,7 +1256,7 @@ class AnchorGraph {
 					continue;
 				}
 				markFn(markKey, depth);
-				if (maxStepCount !== undefined && depth >= maxStepCount) {
+				if (traversalStepLimit !== undefined && depth >= traversalStepLimit) {
 					continue;
 				}
 				const neighbors = neighborBuckets.get(stepKey);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core chaining graph traversal and forwarding/deposit eligibility semantics; incorrect explicit/implied handling could hide or expose wrong deposit routes.
> 
> **Overview**
> Extends **forwarding-only** filtering beyond `getPlans` so **`resolveAssets`** can list reachable assets using the same persistent-forwarding rules (crypto asset-movement hops, non-Keeta origin), including a **`maxLegs`** cap aligned with deposit UX.
> 
> Introduces **`explicit` vs `implied`** eligibility via `supportsPersistentForwarding` and `ForwardingOnlyOptions.method`: **explicit** requires `createPersistentForwarding: true`; **implied** also treats **omitted** `supportedOperations` as eligible while rejecting partial ops (e.g. `initiateTransfer` only). `forwardingOnly: true` and path checks default to **explicit**; `getPlans` can pass **`method: 'implied'`** for rails that omit metadata.
> 
> Graph edges now **omit** `supportedOperations` when the provider rail does not supply them (instead of always filling defaults), and forwarding-only **plan** validation uses **implied** rules for leg qualification. Tests cover `getPlans`, `resolveAssets`, `maxLegs`, and Keeta swap regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b6dc9b7534005fc3ca98060befcc8b5087714b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->