### PR TITLE
Add forwarding only options to get paths

### DIFF
--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4240,6 +4240,51 @@ describe('getPlans forwardingOnly', function() {
 		expect(getForwardingDepositAddress(plan)).toEqual(plan.getDepositAddress());
 	});
 
+	test('getPaths forwardingOnly filters like getPlans', async function() {
+		await using pfr = await buildForwardingWorld('pfr');
+		await using managed = await buildForwardingWorld('managed');
+		await using omitted = await buildForwardingWorld('omitted');
+
+		const requestFor = (w: Awaited<ReturnType<typeof buildForwardingWorld>>) => ({
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' as const },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' as const }
+		});
+
+		const pfrPaths = await pfr.anchorChaining.getPaths(requestFor(pfr), { forwardingOnly: true });
+		expect(pfrPaths).not.toBeNull();
+		expect(pfrPaths?.every((path) => isForwardingPath(path, { method: 'explicit' }))).toBe(true);
+
+		const managedPaths = await managed.anchorChaining.getPaths(requestFor(managed), { forwardingOnly: true });
+		expect(managedPaths).toBeNull();
+
+		const omittedExplicit = await omitted.anchorChaining.getPaths(requestFor(omitted), { forwardingOnly: { method: 'explicit' }});
+		expect(omittedExplicit).toBeNull();
+
+		const omittedImplied = await omitted.anchorChaining.getPaths(requestFor(omitted), { forwardingOnly: { method: 'implied' }});
+		expect(omittedImplied).not.toBeNull();
+		expect(omittedImplied?.every((path) => isForwardingPath(path, { method: 'implied' }))).toBe(true);
+	});
+
+	test('getPaths forwardingOnly honors maxLegs', async function() {
+		await using w = await buildForwardingWorld('pfr');
+
+		const request = {
+			source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' as const },
+			destination: { asset: w.tokens.USDC, location: w.keetaLocation, recipient: w.recipient, rail: 'KEETA_SEND' as const }
+		};
+
+		const defaultPaths = await w.anchorChaining.getPaths(request, { forwardingOnly: true });
+		expect(defaultPaths).not.toBeNull();
+		expect(defaultPaths?.every((path) => path.path.length <= 2)).toBe(true);
+
+		const oneLeg = await w.anchorChaining.getPaths(request, { forwardingOnly: { method: 'explicit', maxLegs: 1 }});
+		expect(oneLeg).not.toBeNull();
+		expect(oneLeg?.every((path) => path.path.length === 1)).toBe(true);
+
+		const zeroLegs = await w.anchorChaining.getPaths(request, { forwardingOnly: { method: 'explicit', maxLegs: 0 }});
+		expect(zeroLegs).toBeNull();
+	});
+
 	test('listFees returns persistent address fees for forwarding-only plans', async function() {
 		await using w = await buildForwardingWorld('pfr');
 
@@ -4664,20 +4709,35 @@ describe('getPlans forwardingOnly', function() {
 		});
 
 		try {
+			const assetKey = (item: { asset: string | { publicKeyString: { get(): string }}; location: AssetLocationLike }) =>
+				`${typeof item.asset === 'string' ? item.asset : item.asset.publicKeyString.get()}@${convertAssetLocationToString(item.location)}`;
+
 			const defaultForwarding = await anchorChaining.graph.resolveAssets({
 				from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
 				forwardingOnly: true
 			});
-			const defaultKeys = defaultForwarding.to.map((item) =>
-				`${typeof item.asset === 'string' ? item.asset : item.asset.publicKeyString.get()}@${convertAssetLocationToString(item.location)}`
-			);
+			const defaultKeys = defaultForwarding.to.map(assetKey);
 			expect(defaultKeys).not.toContain(`${tokens.USDC.publicKeyString.get()}@${keetaLocation}`);
 			expect(defaultKeys).toContain(`${EXTERNAL_MULTI.USDC_ARB}@${LOC_MULTI.arb}`);
+			expect(defaultKeys).not.toContain(`${EXTERNAL_MULTI.USDC_OP}@${LOC_MULTI.op}`);
 
-			const plans = await anchorChaining.getPlans({
-				source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' },
-				destination: { asset: tokens.USDC, location: keetaLocation, recipient: client.account.publicKeyString.get(), rail: 'KEETA_SEND' }
-			}, { limit: 1, forwardingOnly: true });
+			const threeStep = await anchorChaining.graph.resolveAssets({
+				from: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base },
+				forwardingOnly: true,
+				maxStepCount: 3
+			});
+			expect(threeStep.to.map(assetKey)).toContain(`${EXTERNAL_MULTI.USDC_OP}@${LOC_MULTI.op}`);
+
+			const pathRequest = {
+				source: { asset: EXTERNAL_IDS.USDC_BASE, location: LOC.base, value: 1000n, rail: 'EVM_SEND' as const },
+				destination: { asset: tokens.USDC, location: keetaLocation, recipient: client.account.publicKeyString.get(), rail: 'KEETA_SEND' as const }
+			};
+
+			// 4-leg route exceeds default maxLegs=2
+			expect(await anchorChaining.getPaths(pathRequest, { forwardingOnly: true })).toBeNull();
+			expect(await anchorChaining.getPaths(pathRequest, { forwardingOnly: { method: 'explicit', maxLegs: 4 }})).not.toBeNull();
+
+			const plans = await anchorChaining.getPlans(pathRequest, { limit: 1, forwardingOnly: true });
 			expect(plans).toBeNull();
 		} finally {
 			await am1[Symbol.asyncDispose]?.();

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -318,9 +318,6 @@ export type AnchorChainingFindPathsOptions = {
 	forwardingOnly?: boolean | ForwardingOnlyOptions;
 };
 
-/** Options for {@link AnchorChaining.getPaths}; same shape as graph findPaths. */
-export type GetPathsOptions = AnchorChainingFindPathsOptions;
-
 export interface AnchorChainingResolveAssetsResult {
 	from: AnchorChainingAssetInfo[];
 	to: AnchorChainingAssetInfo[];
@@ -3149,7 +3146,7 @@ export class AnchorChaining {
 		}
 	}
 
-	async getPaths(input: AnchorChainingPathInput, options?: GetPathsOptions): Promise<AnchorChainingPath[] | null> {
+	async getPaths(input: AnchorChainingPathInput, options?: AnchorChainingFindPathsOptions): Promise<AnchorChainingPath[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
 		if (forwardingOpts && (forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS) < 1) {
 			return(null);

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -267,6 +267,23 @@ export type ForwardingOnlyOptions = {
 	maxLegs?: number;
 };
 
+const DEFAULT_FORWARDING_MAX_LEGS = 2;
+
+function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
+	if (!forwardingOnly) {
+		return(undefined);
+	}
+
+	if (forwardingOnly === true) {
+		return({ method: 'explicit', maxLegs: DEFAULT_FORWARDING_MAX_LEGS });
+	}
+
+	return({
+		maxLegs: DEFAULT_FORWARDING_MAX_LEGS,
+		...forwardingOnly
+	});
+}
+
 export type AnchorChainingResolveAssetsFilter = {
 	from?: AnchorChainingListAssetsSideFilter;
 	to?: AnchorChainingListAssetsSideFilter;
@@ -275,6 +292,8 @@ export type AnchorChainingResolveAssetsFilter = {
 	/**
 	 * When set, only consider persistent-forwarding-eligible crypto hops
 	 * (asset-movement, non-Keeta origin). `true` means `{ method: 'explicit' }`.
+	 * Depth is controlled by `maxStepCount` when provided; otherwise defaults to
+	 * {@link DEFAULT_FORWARDING_MAX_LEGS} (same as getPlans' maxLegs default).
 	 */
 	forwardingOnly?: boolean | Pick<ForwardingOnlyOptions, 'method'>;
 };
@@ -284,14 +303,23 @@ export const DEFAULT_MAX_PATHS = 50;
 
 export type AnchorChainingFindPathsOptions = {
 	/**
-	 * Maximum number of legs a path may contain. Defaults to DEFAULT_MAX_PATH_LENGTH.
+	 * Maximum number of legs a path may contain. Defaults to DEFAULT_MAX_PATH_LENGTH,
+	 * or to forwarding `maxLegs` when `forwardingOnly` is set.
 	 */
 	maxPathLength?: number;
 	/**
 	 * Maximum number of paths to collect before halting the search. Defaults to DEFAULT_MAX_PATHS.
 	 */
 	maxPaths?: number;
+	/**
+	 * When set, only traverse persistent-forwarding-eligible crypto hops.
+	 * `true` means `{ method: 'explicit' }` with default maxLegs.
+	 */
+	forwardingOnly?: boolean | ForwardingOnlyOptions;
 };
+
+/** Options for {@link AnchorChaining.getPaths}; same shape as graph findPaths. */
+export type GetPathsOptions = AnchorChainingFindPathsOptions;
 
 export interface AnchorChainingResolveAssetsResult {
 	from: AnchorChainingAssetInfo[];
@@ -367,7 +395,6 @@ export type ForwardingAssetRef = {
 	location: AssetLocationLike;
 };
 
-const DEFAULT_FORWARDING_MAX_LEGS = 2;
 const forwardingAssetKeyCache: EVMChecksumCache = new Map();
 
 function forwardingAssetKey(asset: AnchorChainingAsset, location: AssetLocationLike): string {
@@ -926,7 +953,13 @@ class AnchorGraph {
 	}
 
 	async findPaths(input: AnchorChainingPathInput, options?: AnchorChainingFindPathsOptions): Promise<GraphNodeLike[][]> {
-		const maxPathLength = options?.maxPathLength ?? DEFAULT_MAX_PATH_LENGTH;
+		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
+		const maxPathLength = forwardingOpts
+			? Math.min(
+				options?.maxPathLength ?? Infinity,
+				forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS
+			)
+			: (options?.maxPathLength ?? DEFAULT_MAX_PATH_LENGTH);
 		if (maxPathLength < 1) {
 			throw(new Error(`maxPathLength must be at least 1, got ${maxPathLength}`));
 		}
@@ -935,7 +968,10 @@ class AnchorGraph {
 			throw(new Error(`maxPaths must be at least 1, got ${maxPaths}`));
 		}
 
-		const graph = await this.computeGraphNodes();
+		const allNodes = await this.computeGraphNodes();
+		const graph = forwardingOpts
+			? allNodes.filter((node) => isForwardingEligibleNode(node, forwardingOpts.method))
+			: allNodes;
 
 		const nodesWithNext: { node: GraphNodeLike, next: number[] }[] = graph.map(function(node) {
 			return({ node, next: [] });
@@ -1125,11 +1161,10 @@ class AnchorGraph {
 
 	async resolveAssets(filter: AnchorChainingResolveAssetsFilter = {}): Promise<AnchorChainingResolveAssetsResult> {
 		const { from: fromFilterInput, to: toFilterInput, maxStepCount, onlyAllowFXLike } = filter;
-		// eslint-disable-next-line @typescript-eslint/no-use-before-define
 		const forwardingOpts = normalizeForwardingOnlyOptions(filter.forwardingOnly);
 		const forwardingMethod = forwardingOpts?.method;
 		const traversalStepLimit = forwardingOpts
-			? Math.min(maxStepCount ?? Infinity, forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS)
+			? (maxStepCount ?? forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS)
 			: maxStepCount;
 
 		const keetaNetworkLocation = `chain:keeta:${this.client.network}` satisfies AssetLocationLike;
@@ -1525,21 +1560,6 @@ export interface ComputePlanOptions {
 export interface GetPlansOptions extends Omit<ComputePlanOptions, 'forwardingOnly'> {
 	includeAllOutput?: boolean;
 	forwardingOnly?: boolean | ForwardingOnlyOptions;
-}
-
-function normalizeForwardingOnlyOptions(forwardingOnly: boolean | ForwardingOnlyOptions | undefined): ForwardingOnlyOptions | undefined {
-	if (!forwardingOnly) {
-		return(undefined);
-	}
-
-	if (forwardingOnly === true) {
-		return({ method: 'explicit', maxLegs: DEFAULT_FORWARDING_MAX_LEGS });
-	}
-
-	return({
-		maxLegs: DEFAULT_FORWARDING_MAX_LEGS,
-		...forwardingOnly
-	});
 }
 
 function toComputePlanOptions(options?: GetPlansOptions, forwardingOpts?: ForwardingOnlyOptions): ComputePlanOptions | undefined {
@@ -3129,7 +3149,12 @@ export class AnchorChaining {
 		}
 	}
 
-	async getPaths(input: AnchorChainingPathInput): Promise<AnchorChainingPath[] | null> {
+	async getPaths(input: AnchorChainingPathInput, options?: GetPathsOptions): Promise<AnchorChainingPath[] | null> {
+		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
+		if (forwardingOpts && (forwardingOpts.maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS) < 1) {
+			return(null);
+		}
+
 		// Direct send: same Keeta location, same asset, same rail no providers needed.
 		const sourceLocation = toAssetLocation(input.source.location);
 		const destinationLocation = toAssetLocation(input.destination.location);
@@ -3144,6 +3169,11 @@ export class AnchorChaining {
 			isChainLocation(destinationLocation, 'keeta') &&
 			isAnchorChainingAssetEqual(input.source.asset, input.destination.asset)
 		) {
+			// Direct Keeta sends are never forwarding routes.
+			if (forwardingOpts) {
+				return(null);
+			}
+
 			const fromTo = {
 				asset: input.source.asset,
 				location: sourceLocation,
@@ -3154,7 +3184,7 @@ export class AnchorChaining {
 				[{ type: 'keetaSend', from: fromTo, to: fromTo }]
 			];
 		} else {
-			foundPaths = await this.graph.findPaths(input);
+			foundPaths = await this.graph.findPaths(input, options);
 		}
 
 		// Filter out paths with non-chain steps in intermediate positions
@@ -3184,6 +3214,11 @@ export class AnchorChaining {
 			retval.push(new AnchorChainingPath({ request: input, path, parent: this }));
 		}
 
+		if (forwardingOpts) {
+			const forwardingPaths = retval.filter((path) => isForwardingPath(path, forwardingOpts));
+			return(forwardingPaths.length === 0 ? null : forwardingPaths);
+		}
+
 		return(retval);
 	}
 
@@ -3193,17 +3228,10 @@ export class AnchorChaining {
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
-		let paths = await this.getPaths(input);
+		const paths = await this.getPaths(input, options?.forwardingOnly ? { forwardingOnly: options.forwardingOnly } : undefined);
 
 		if (!paths) {
 			return(null);
-		}
-
-		if (forwardingOpts) {
-			paths = paths.filter((path) => isForwardingPath(path, forwardingOpts));
-			if (paths.length === 0) {
-				return(null);
-			}
 		}
 
 		const limit = options?.limit ?? 3;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core route discovery and asset resolution for deposit/forwarding UX; behavior is intentionally aligned with existing `getPlans` forwarding logic and is covered by new tests, but incorrect filtering could hide or expose routes.
> 
> **Overview**
> **`getPaths`** now takes optional **`AnchorChainingFindPathsOptions`**, including **`forwardingOnly`** (`true` or `{ method, maxLegs }`). Path discovery applies the same persistent-forwarding rules as **`getPlans`**: eligible graph hops only, leg cap (default **2**), direct Keeta sends excluded when forwarding is requested, and **`maxLegs: 0`** returns **`null`**.
> 
> **`AnchorGraph.findPaths`** filters nodes with **`isForwardingEligibleNode`** when **`forwardingOnly`** is set and uses forwarding **`maxLegs`** as the effective path length cap (unless **`maxPathLength`** is tighter). **`getPlans`** passes **`forwardingOnly`** into **`getPaths`** and no longer post-filters paths.
> 
> **`normalizeForwardingOnlyOptions`** is hoisted for reuse. **`resolveAssets`** forwarding traversal depth is **`maxStepCount ?? maxLegs ?? DEFAULT_FORWARDING_MAX_LEGS`** (replacing **`Math.min`** with **`maxStepCount`**). Tests cover **`getPaths`** filtering, **`maxLegs`**, and multi-hop **`resolveAssets`** / long routes vs default leg limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ce99902c9004b8c3cf64b729b02002861f1a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->