### PR TITLE
Add asset location to fee asset, make total optional

### DIFF
--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4038,12 +4038,16 @@ describe('getPlans forwardingOnly', function() {
 	} as const satisfies { [key: string]: AssetLocationLike };
 
 	test('listChainingPlanFees reconciles fees.total with line items for persistent forwarding', function() {
+		const feeAssetWithLocation = { id: EXTERNAL_IDS.USDC_ETH, location: LOC.eth } as const;
+		const stepDefaultAsset = { id: EXTERNAL_IDS.USDC_BASE, location: LOC.base } as const;
+		const totalPricedIn = { id: EXTERNAL_IDS.USDC_ETH, location: LOC.eth } as const;
 		const fees = {
 			lineItems: [
-				{ purpose: 'RAIL' as const, value: '5' },
-				{ purpose: 'NETWORK' as const, value: '3' },
+				{ purpose: 'RAIL' as const, value: '5', asset: feeAssetWithLocation },
+				{ purpose: 'NETWORK' as const, value: '3', asset: EXTERNAL_IDS.USDC_BASE },
 				{ purpose: 'VALUE_VARIABLE' as const, basisPoints: 100 }
 			],
+			totalPricedIn,
 			total: '25'
 		};
 
@@ -4070,8 +4074,12 @@ describe('getPlans forwardingOnly', function() {
 
 		const feeSum = listed.lineItems.reduce((sum, item) => sum + BigInt(item.value ?? 0), 0n);
 		expect(feeSum).toEqual(25n);
+		expect(listed.lineItems[0]?.asset).toEqual(feeAssetWithLocation);
+		expect(listed.lineItems[1]?.asset).toEqual(EXTERNAL_IDS.USDC_BASE);
+		expect(listed.lineItems[2]?.asset).toEqual(stepDefaultAsset);
 		expect(listed.lineItems.at(-1)?.purpose).toEqual('OTHER');
 		expect(listed.lineItems.at(-1)?.value).toEqual('7');
+		expect(listed.lineItems.at(-1)?.asset).toEqual(totalPricedIn);
 	});
 
 	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;
@@ -4303,7 +4311,7 @@ describe('getPlans forwardingOnly', function() {
 		expect(fees.lineItems[0]?.value).toEqual('15');
 		expect(fees.lineItems[0]?.metadata.source).toEqual('persistentAddress');
 		expect(fees.lineItems[0]?.metadata.step.type).toEqual('forwarded');
-		expect(fees.lineItems[0]?.asset).toEqual(EXTERNAL_IDS.USDC_BASE);
+		expect(fees.lineItems[0]?.asset).toEqual({ id: EXTERNAL_IDS.USDC_BASE, location: LOC.base });
 		expect('total' in fees).toBe(false);
 		expect(plan.plan.steps[0]?.valueOut).toEqual(985n);
 	});

--- a/src/lib/chaining.test.ts
+++ b/src/lib/chaining.test.ts
@@ -4018,8 +4018,7 @@ describe('getPlans forwardingOnly', function() {
 				{ purpose: 'RAIL' as const, value: '5' },
 				{ purpose: 'NETWORK' as const, value: '3' },
 				{ purpose: 'VALUE_VARIABLE' as const, basisPoints: 100 }
-			],
-			total: '18'
+			]
 		};
 
 		expect(estimateForwardingValueOut(1000n, fees)).toEqual(982n);
@@ -4037,17 +4036,15 @@ describe('getPlans forwardingOnly', function() {
 		sepa: 'bank-account:iban-swift'
 	} as const satisfies { [key: string]: AssetLocationLike };
 
-	test('listChainingPlanFees reconciles fees.total with line items for persistent forwarding', function() {
+	test('listChainingPlanFees preserves fee assets including location', function() {
 		const feeAssetWithLocation = { id: EXTERNAL_IDS.USDC_ETH, location: LOC.eth } as const;
 		const stepDefaultAsset = { id: EXTERNAL_IDS.USDC_BASE, location: LOC.base } as const;
-		const totalPricedIn = { id: EXTERNAL_IDS.USDC_ETH, location: LOC.eth } as const;
 		const fees = {
 			lineItems: [
 				{ purpose: 'RAIL' as const, value: '5', asset: feeAssetWithLocation },
 				{ purpose: 'NETWORK' as const, value: '3', asset: EXTERNAL_IDS.USDC_BASE },
 				{ purpose: 'VALUE_VARIABLE' as const, basisPoints: 100 }
 			],
-			totalPricedIn,
 			total: '25'
 		};
 
@@ -4072,14 +4069,10 @@ describe('getPlans forwardingOnly', function() {
 			}
 		});
 
-		const feeSum = listed.lineItems.reduce((sum, item) => sum + BigInt(item.value ?? 0), 0n);
-		expect(feeSum).toEqual(25n);
-		expect(listed.lineItems[0]?.asset).toEqual(feeAssetWithLocation);
-		expect(listed.lineItems[1]?.asset).toEqual(EXTERNAL_IDS.USDC_BASE);
-		expect(listed.lineItems[2]?.asset).toEqual(stepDefaultAsset);
-		expect(listed.lineItems.at(-1)?.purpose).toEqual('OTHER');
-		expect(listed.lineItems.at(-1)?.value).toEqual('7');
-		expect(listed.lineItems.at(-1)?.asset).toEqual(totalPricedIn);
+		expect(listed.lineItems).toHaveLength(3);
+		expect(listed.lineItems[0]).toMatchObject({ purpose: 'RAIL', value: '5', asset: feeAssetWithLocation });
+		expect(listed.lineItems[1]).toMatchObject({ purpose: 'NETWORK', value: '3', asset: EXTERNAL_IDS.USDC_BASE });
+		expect(listed.lineItems[2]).toMatchObject({ purpose: 'VALUE_VARIABLE', basisPoints: 100, value: '10', asset: stepDefaultAsset });
 	});
 
 	const MANAGED_OPS = { initiateTransfer: true, createPersistentForwarding: false } as const;

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1603,7 +1603,7 @@ export function isForwardingPath(path: AnchorChainingPath, options?: ForwardingO
 	}));
 }
 
-function computeFeeTotalFromBreakdown(valueIn: bigint, fees: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string }): bigint {
+function computeFeeTotalFromBreakdown(valueIn: bigint, fees: AssetFeeBreakdown | PersistentAddressAssetFeeBreakdown): bigint {
 	let feeFromLineItems = 0n;
 
 	for (const lineItem of fees.lineItems) {
@@ -1615,7 +1615,7 @@ function computeFeeTotalFromBreakdown(valueIn: bigint, fees: { lineItems: readon
 	}
 
 	let feeTotal = feeFromLineItems;
-	if (fees.total !== undefined && fees.total !== '') {
+	if ('total' in fees && fees.total !== undefined && fees.total !== '') {
 		feeTotal = BigInt(fees.total);
 	}
 
@@ -1689,12 +1689,11 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 		}
 
 		const appendBreakdown = (
-			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string; totalPricedIn?: AssetOrAssetWithLocation },
+			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[] },
 			source: AnchorChainingFeeLineItemSource
 		) => {
 			const stepDefaultAsset = defaultFeeAsset(step);
 			const metadata = { stepIndex, step, source };
-			const startLength = lineItems.length;
 
 			for (const item of breakdown.lineItems) {
 				const base = {
@@ -1715,36 +1714,6 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 						...base,
 						basisPoints: item.basisPoints,
 						value: (step.valueIn * BigInt(item.basisPoints) / 10000n).toString()
-					});
-				}
-			}
-
-			if (breakdown.total !== undefined && breakdown.total !== '') {
-				const authoritativeTotal = computeFeeTotalFromBreakdown(step.valueIn, breakdown);
-				const totalAsset = breakdown.totalPricedIn ?? stepDefaultAsset;
-				let lineItemSum = 0n;
-
-				for (let i = startLength; i < lineItems.length; i++) {
-					const emitted = lineItems[i];
-					if (emitted?.value !== undefined && emitted.value !== '') {
-						lineItemSum += BigInt(emitted.value);
-					}
-				}
-
-				if (authoritativeTotal > lineItemSum) {
-					lineItems.push({
-						purpose: 'OTHER',
-						asset: totalAsset,
-						value: (authoritativeTotal - lineItemSum).toString(),
-						metadata
-					});
-				} else if (authoritativeTotal < lineItemSum) {
-					lineItems.splice(startLength);
-					lineItems.push({
-						purpose: 'OTHER',
-						asset: totalAsset,
-						value: authoritativeTotal.toString(),
-						metadata
 					});
 				}
 			}

--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1,6 +1,6 @@
 import type { lib as KeetaNetLib } from '@keetanetwork/keetanet-client';
 import * as KeetaNet from "@keetanetwork/keetanet-client";
-import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem } from "../services/asset-movement/common.js";
+import type { AnchorTokenLocationMetadata, AssetLocationLike, AssetFeeBreakdown, AssetFeeLineItemType, AssetTransferInstructions, AssetWithRails, FiatPushRails, KeetaAssetMovementTransaction, KeetaPersistentForwardingAddressDetails, MovableAssetSearchCanonical, PersistentAddressAssetFeeBreakdown, PickChainLocation, Rail, RailOrRailWithExtendedDetails, RecipientResolved, ResolvedFeeLineItem, SimulatedAssetTransferInstructions, UnresolvedFeeLineItem, AssetOrAssetWithLocation } from "../services/asset-movement/common.js";
 import { convertAssetLocationToString, convertAssetSearchInputToCanonical, doesAssetOrPairMatch, isChainLocation, toAssetLocation } from "../services/asset-movement/common.js";
 import type { Resolver } from "./index.js";
 import { getDefaultResolver } from '../config.js';
@@ -1651,7 +1651,7 @@ export type AnchorChainingFeeLineItemMetadata = {
 
 export type AnchorChainingFeeLineItem = {
 	purpose: AssetFeeLineItemType;
-	asset: MovableAssetSearchCanonical;
+	asset: AssetOrAssetWithLocation;
 	value?: string;
 	basisPoints?: number;
 	details?: ClientRenderableContent;
@@ -1667,17 +1667,19 @@ export type AnchorChainingPlanFeeBreakdown = {
 export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPlan }): AnchorChainingPlanFeeBreakdown {
 	const lineItems: AnchorChainingFeeLineItem[] = [];
 
-	const defaultFeeAsset = (step: Exclude<ChainStepResolution, { type: 'keetaSend' }>): MovableAssetSearchCanonical => {
+	const defaultFeeAsset = (step: Exclude<ChainStepResolution, { type: 'keetaSend' }>): AssetOrAssetWithLocation => {
+		const location = convertAssetLocationToString(step.step.from.location);
+
 		if (step.type === 'fx') {
 			const token = step.result.isQuote ? step.result.quote.cost.token : step.result.estimate.expectedCost.token;
-			return(token.publicKeyString.get());
+			return({ id: token.publicKeyString.get(), location });
 		}
 
-		if (KeetaNet.lib.Account.isInstance(step.step.from.asset)) {
-			return(step.step.from.asset.publicKeyString.get());
-		}
+		const id = KeetaNet.lib.Account.isInstance(step.step.from.asset)
+			? step.step.from.asset.publicKeyString.get()
+			: step.step.from.asset;
 
-		return(step.step.from.asset);
+		return({ id, location });
 	};
 
 	for (let stepIndex = 0; stepIndex < plan.plan.steps.length; stepIndex++) {
@@ -1687,7 +1689,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 		}
 
 		const appendBreakdown = (
-			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string },
+			breakdown: { lineItems: readonly (ResolvedFeeLineItem | UnresolvedFeeLineItem)[]; total?: string; totalPricedIn?: AssetOrAssetWithLocation },
 			source: AnchorChainingFeeLineItemSource
 		) => {
 			const stepDefaultAsset = defaultFeeAsset(step);
@@ -1695,10 +1697,9 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 			const startLength = lineItems.length;
 
 			for (const item of breakdown.lineItems) {
-				const asset = item.asset ?? stepDefaultAsset;
 				const base = {
 					purpose: item.purpose,
-					asset,
+					asset: item.asset ?? stepDefaultAsset,
 					metadata,
 					...(item.details !== undefined ? { details: item.details } : {})
 				};
@@ -1709,10 +1710,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 						value: item.value,
 						...(item.purpose === 'VALUE_VARIABLE' && 'basisPoints' in item && item.basisPoints !== undefined ? { basisPoints: item.basisPoints } : {})
 					});
-					continue;
-				}
-
-				if (item.purpose === 'VALUE_VARIABLE' && 'basisPoints' in item && item.basisPoints !== undefined) {
+				} else if (item.purpose === 'VALUE_VARIABLE' && 'basisPoints' in item && item.basisPoints !== undefined) {
 					lineItems.push({
 						...base,
 						basisPoints: item.basisPoints,
@@ -1723,6 +1721,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 
 			if (breakdown.total !== undefined && breakdown.total !== '') {
 				const authoritativeTotal = computeFeeTotalFromBreakdown(step.valueIn, breakdown);
+				const totalAsset = breakdown.totalPricedIn ?? stepDefaultAsset;
 				let lineItemSum = 0n;
 
 				for (let i = startLength; i < lineItems.length; i++) {
@@ -1735,7 +1734,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 				if (authoritativeTotal > lineItemSum) {
 					lineItems.push({
 						purpose: 'OTHER',
-						asset: stepDefaultAsset,
+						asset: totalAsset,
 						value: (authoritativeTotal - lineItemSum).toString(),
 						metadata
 					});
@@ -1743,7 +1742,7 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 					lineItems.splice(startLength);
 					lineItems.push({
 						purpose: 'OTHER',
-						asset: stepDefaultAsset,
+						asset: totalAsset,
 						value: authoritativeTotal.toString(),
 						metadata
 					});
@@ -1769,17 +1768,18 @@ export function listChainingPlanFees(plan: { plan: AnchorChainingPathComputedPla
 		};
 
 		if (step.type === 'fx') {
+			const location = convertAssetLocationToString(step.step.from.location);
 			if (step.result.isQuote) {
 				lineItems.push({
 					purpose: 'PROVIDER',
-					asset: step.result.quote.cost.token.publicKeyString.get(),
+					asset: { id: step.result.quote.cost.token.publicKeyString.get(), location },
 					value: step.result.quote.cost.amount.toString(),
 					metadata: { stepIndex, step, source: 'fxQuote' }
 				});
 			} else {
 				lineItems.push({
 					purpose: 'PROVIDER',
-					asset: step.result.estimate.expectedCost.token.publicKeyString.get(),
+					asset: { id: step.result.estimate.expectedCost.token.publicKeyString.get(), location },
 					value: step.result.estimate.expectedCost.max.toString(),
 					metadata: { stepIndex, step, source: 'fxEstimate' }
 				});

--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -182,9 +182,11 @@ test('Asset Movement Anchor Client Test', async function() {
 			{
 				purpose: 'VALUE_VARIABLE',
 				basisPoints: 50,
+				asset: { id: 'USD', location: 'bank-account:us' },
 				details: { type: 'markdown', content: 'Variable fee of 50 basis points' }
 			}
 		],
+		totalPricedIn: { id: 'USD', location: 'bank-account:us' },
 		total: '10'
 	}
 

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -437,31 +437,34 @@ interface VariableFeeLineItemResolved extends BaseAssetFeeLineItem<VariableFeeLi
 export type ResolvedFeeLineItem = FixedFeeLineItem | VariableFeeLineItemResolved;
 export type UnresolvedFeeLineItem = FixedFeeLineItem | VariableFeeLineItemUnresolved;
 
-interface BaseAssetFeeBreakdown<LineItemType extends ResolvedFeeLineItem | UnresolvedFeeLineItem> {
+type BaseAssetFeeBreakdown<LineItemType extends ResolvedFeeLineItem | UnresolvedFeeLineItem> = {
+	lineItems: LineItemType[];
+} & ({
+	total?: never;
+	totalPricedIn?: never;
+} | {
 	lineItems: LineItemType[];
 
 	/**
-	 * The total fee amount priced in a canonical asset. If omitted, the total is assumed to be in the asset being transferred.
-	 */
-	totalPricedIn?: AssetOrAssetWithLocation;
-
-	/**
-	 * The total fee amount, as a string in the asset's smallest unit (e.g. cents for USD).
+	 * The total fee amount, as a string in the asset's smallest unit (e.g. cents for USD). If omitted, the total is assumed to be the sum of the line items.
 	 */
 	total: string;
-}
+
+	/**
+	 * The total fee amount priced in a canonical asset. If omitted, the total is assumed to be in the asset being transferred. Only valid when `total` is provided.
+	 */
+	totalPricedIn?: AssetOrAssetWithLocation;
+});
 
 /**
- * Breakdown of fees for an asset transfer, including line items and total amounts.
+ * Breakdown of fees for an asset transfer, including line items and an optional total amount.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AssetFeeBreakdown extends BaseAssetFeeBreakdown<ResolvedFeeLineItem> {};
+export type AssetFeeBreakdown = BaseAssetFeeBreakdown<ResolvedFeeLineItem>;
 
 /**
  * Breakdown of fees for an asset transfer with unresolved variable fee line items, where the basis points are provided but the exact fee amount is not yet resolved. This can be used for transfer instructions that are returned before execution, where the variable fee amount cannot be calculated until the transfer value is finalized.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface PersistentAddressAssetFeeBreakdown extends BaseAssetFeeBreakdown<UnresolvedFeeLineItem> {};
+export type PersistentAddressAssetFeeBreakdown = BaseAssetFeeBreakdown<UnresolvedFeeLineItem>;
 
 /**
  * An instruction on how to complete a transfer, ex: where to send tokens, or where to wire USD.

--- a/src/services/asset-movement/common.ts
+++ b/src/services/asset-movement/common.ts
@@ -382,6 +382,13 @@ export function getKeetaAssetMovementAnchorSimulateTransferRequestSigningData(in
 type FixedFeeLineItemType = 'RAIL' | 'NETWORK' | 'PROVIDER' | 'OTHER';
 type VariableFeeLineItemType = 'VALUE_VARIABLE';
 
+interface AssetWithLocation {
+	id: MovableAssetSearchCanonical;
+	location: AssetLocationString;
+}
+
+export type AssetOrAssetWithLocation = AssetWithLocation | MovableAssetSearchCanonical;
+
 /**
  * Fee line item type in an asset transfer fee breakdown, showing the purpose of each fee line item.
  */
@@ -396,7 +403,7 @@ interface BaseAssetFeeLineItem<Purpose extends AssetFeeLineItemType> {
 	/**
 	 * The asset in which the fee line item is denominated. If omitted, it is assumed to be the same as the asset being transferred.
 	 */
-	asset?: MovableAssetSearchCanonical;
+	asset?: AssetOrAssetWithLocation;
 
 	/**
 	 * Additional details about this fee line item that (optionally) can be rendered in the client application.
@@ -432,10 +439,11 @@ export type UnresolvedFeeLineItem = FixedFeeLineItem | VariableFeeLineItemUnreso
 
 interface BaseAssetFeeBreakdown<LineItemType extends ResolvedFeeLineItem | UnresolvedFeeLineItem> {
 	lineItems: LineItemType[];
+
 	/**
 	 * The total fee amount priced in a canonical asset. If omitted, the total is assumed to be in the asset being transferred.
 	 */
-	totalPricedIn?: MovableAssetSearchCanonical;
+	totalPricedIn?: AssetOrAssetWithLocation;
 
 	/**
 	 * The total fee amount, as a string in the asset's smallest unit (e.g. cents for USD).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes fee breakdown typing and chaining fee listing behavior (removed total-vs-line-item reconciliation), which can affect API consumers and UI fee display; logic is localized to asset-movement fees and chaining helpers.
> 
> **Overview**
> Fee line items and chaining plan fees can now carry **`AssetOrAssetWithLocation`** (canonical asset id plus optional **`location`**) instead of bare asset ids only. **`AssetFeeBreakdown`** / **`PersistentAddressAssetFeeBreakdown`** treat **`total`** as optional: breakdowns may be line-items-only, or include **`total`** with optional **`totalPricedIn`** (also **`AssetOrAssetWithLocation`**).
> 
> **`listChainingPlanFees`** no longer reconciles a provider **`total`** against summed line items (no synthetic **`OTHER`** rows). It emits the original line items, fills missing assets with step defaults **`{ id, location }`**, and resolves variable-fee amounts from basis points. Forwarding estimates still honor an authoritative **`total`** via **`computeFeeTotalFromBreakdown`** when present.
> 
> Tests cover preserved per-line assets (including location), default assets on forwarding plans, and **`totalPricedIn`** on persistent-address fees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0220f2a98463510d652bac35cbbd054a0306a17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->