### PR TITLE
Release: v0.0.93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.92",
+	"version": "0.0.93",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.92",
+			"version": "0.0.93",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.92",
+	"version": "0.0.93",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {


### PR DESCRIPTION
Includes changes from:
 - #421 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata only; no runtime or dependency changes in the diff.
> 
> **Overview**
> Bumps **`@keetanetwork/anchor`** from **0.0.92** to **0.0.93** in `package.json` and the root entry in `package-lock.json`. No dependency, script, or source changes appear in this diff—it's a release version alignment for publishing (per PR note, functional work is expected from #421 elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25ba357ebd82aa8344269bd054ae2510a26366c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->