### PR TITLE
fix: resolve EVM asset metadata case-insensitively

### DIFF
--- a/src/services/asset-movement/client.test.ts
+++ b/src/services/asset-movement/client.test.ts
@@ -116,6 +116,12 @@ test('Asset Movement Anchor Client Test', async function() {
 					displayName: 'Cool Token',
 					ticker: '$COOL',
 					logoURI: 'https://example.com/logo.png'
+				},
+				/* Published in EIP-55 form; callers may supply it all-lowercase. */
+				'evm:0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E': {
+					decimalPlaces: 6,
+					displayName: 'USD Coin',
+					ticker: '$USDC'
 				}
 			}
 		},
@@ -481,6 +487,19 @@ test('Asset Movement Anchor Client Test', async function() {
 		expect(testProvider.getAssetMetadataForLocation({ type: 'chain', chain: { type: 'evm', chainId: 1n }}, 'evm:0x5')).toEqual(evm0x5Metadata);
 		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0x0')).toEqual(null);
 		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'solana:test')).toEqual(null);
+
+		/*
+		 * An EVM address is case-insensitive, so every spelling of the same address
+		 * must resolve to the same metadata regardless of how it was published.
+		 */
+		const usdcMetadata = validLocationMetadata['chain:evm:1']['assets']['evm:0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E'];
+		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E')).toEqual(usdcMetadata);
+		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e')).toEqual(usdcMetadata);
+		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0xB97EF9EF8734C71904D8002F8B6BC66DD9C48A6E')).toEqual(usdcMetadata);
+		/* Repeat lookups go through the memoised index. */
+		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e')).toEqual(usdcMetadata);
+		/* A different address must still miss. */
+		expect(testProvider.getAssetMetadataForLocation('chain:evm:1', 'evm:0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6f')).toEqual(null);
 		const solanaGenesis = 'ffffffffffffffffffffffffffffffffffffffffffff';
 		const testSolanaAssetID: SolanaAsset = 'solana:So11111111111111111111111111111111111111112';
 		const testSolanaAssetMetadata = validLocationMetadata[`chain:solana:${solanaGenesis}`]['assets']['solana:So11111111111111111111111111111111111111112'];

--- a/src/services/asset-movement/client.ts
+++ b/src/services/asset-movement/client.ts
@@ -104,7 +104,8 @@ import { SignData } from '../../lib/utils/signing.js';
 import { KeetaAnchorError } from '../../lib/error.js';
 import * as KeetaNet from '@keetanetwork/keetanet-client';
 import { resolveSharedAnchorMetadataLegalExtension, type SharedAnchorMetadataLegalExtension, type AnchorMetadataLegalField } from '../../lib/metadata.types.js';
-import type { ExternalChainAsset, ExternalChainLocationType } from '../../lib/asset.js';
+import type { EVMChecksumCache, ExternalChainAsset, ExternalChainLocationType } from '../../lib/asset.js';
+import { normalizeChainAssetCasing } from '../../lib/asset.js';
 
 // const PARANOID = true;
 
@@ -545,6 +546,8 @@ export class KeetaAssetMovementAnchorProvider extends KeetaAssetMovementAnchorBa
 	readonly serviceInfo: KeetaAssetMovementServiceInfo;
 	readonly providerID: ProviderID;
 	private readonly parent: KeetaAssetMovementAnchorClient;
+	readonly #evmChecksumCache: EVMChecksumCache = new Map();
+	readonly #canonicalAssetsByLocation = new Map<string, Map<string, AnchorTokenLocationMetadata>>();
 
 	constructor(serviceInfo: KeetaAssetMovementServiceInfo, providerID: ProviderID, parent: KeetaAssetMovementAnchorClient) {
 		const parentPrivate = parent._internals(KeetaAssetMovementAnchorClientAccessToken);
@@ -1265,17 +1268,53 @@ export class KeetaAssetMovementAnchorProvider extends KeetaAssetMovementAnchorBa
 		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		const locationSpecificMetadata = (locationMetadata as { [key: string]: PerChainLocationMetadata })[locationString];
 
-		if (!locationSpecificMetadata?.assets || !(asset in locationSpecificMetadata.assets)) {
+		if (!locationSpecificMetadata?.assets) {
 			return(null);
 		}
 
+		/*
+		 * Fast path: the caller supplied exactly the spelling that was published, so
+		 * there is no need to compute any checksum.
+		 */
 		const assetMetadata = locationSpecificMetadata.assets[asset];
 
-		if (!assetMetadata) {
-			return(null);
+		if (assetMetadata) {
+			return(assetMetadata);
 		}
 
-		return(assetMetadata);
+		const canonicalAssets = this.#canonicalAssetsForLocation(locationString, locationSpecificMetadata.assets);
+
+		return(canonicalAssets.get(normalizeChainAssetCasing(asset, this.#evmChecksumCache)) ?? null);
+	}
+
+	/**
+	 * Index a location's published assets by their canonical spelling.
+	 *
+	 * `serviceInfo` is fixed at construction, so the index is built once per location
+	 * and reused. That bounds the work to a single keccak per published asset for the
+	 * lifetime of the provider, and the shared checksum cache makes the lookup side
+	 * free on repeat calls.
+	 */
+	#canonicalAssetsForLocation(locationString: string, assets: NonNullable<PerChainLocationMetadata['assets']>): Map<string, AnchorTokenLocationMetadata> {
+		const cached = this.#canonicalAssetsByLocation.get(locationString);
+
+		if (cached !== undefined) {
+			return(cached);
+		}
+
+		const canonicalAssets = new Map<string, AnchorTokenLocationMetadata>();
+
+		for (const [ publishedAsset, metadata ] of Object.entries(assets)) {
+			if (!metadata) {
+				continue;
+			}
+
+			canonicalAssets.set(normalizeChainAssetCasing(publishedAsset, this.#evmChecksumCache), metadata);
+		}
+
+		this.#canonicalAssetsByLocation.set(locationString, canonicalAssets);
+
+		return(canonicalAssets);
 	}
 
 	getLegalDisclaimers(): NonNullable<AnchorMetadataLegalField['disclaimers']> | null {


### PR DESCRIPTION
EVM addresses are case-insensitive, so an anchor publishing an asset in EIP-55 checksum form (`evm:0xB97EF9...`) would return `null` for a caller passing the same address all-lowercase, and vice versa.

### Changes

- Keep the exact-match fast path: if the caller's spelling matches what was published, return it with no checksum work.
- On a miss, fall back to a per-location index of published assets keyed by their canonical spelling (via `normalizeChainAssetCasing`), then look up the caller's normalized asset.
- The index is built lazily and memoised per location. `serviceInfo` is fixed at construction, so this bounds the cost to one keccak per published asset for the lifetime of the provider, with a shared `EVMChecksumCache` making repeat lookups free.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized client-side lookup change with tests; no auth or transfer execution paths modified.
> 
> **Overview**
> **`getAssetMetadataForLocation`** no longer misses when the caller’s EVM asset string doesn’t match the anchor’s published spelling (e.g. EIP-55 vs all-lowercase).
> 
> On an exact key miss, the provider builds a **lazy, per-location index** of published assets keyed by **`normalizeChainAssetCasing`**, backed by a shared **`EVMChecksumCache`**, while keeping the **exact-match fast path** unchanged. Integration tests cover mixed-case USDC lookups, memoized repeat lookups, and distinct-address misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40854813c479cbee23cfc45adc7751b3478ccbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->