### PR TITLE
add maxPathLength to getPlans

### DIFF
--- a/src/lib/chaining.ts
+++ b/src/lib/chaining.ts
@@ -1761,6 +1761,7 @@ export interface ComputePlanOptions {
 export interface GetPlansOptions extends Omit<ComputePlanOptions, 'forwardingOnly'> {
 	includeAllOutput?: boolean;
 	forwardingOnly?: boolean | ForwardingOnlyOptions;
+	maxPathLength?: number;
 }
 
 function toComputePlanOptions(options?: GetPlansOptions, forwardingOpts?: ForwardingOnlyOptions): ComputePlanOptions | undefined {
@@ -3445,7 +3446,10 @@ export class AnchorChaining {
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<AnchorChainingPlan[] | null>;
 	async getPlans(input: AnchorChainingPathInput, options?: GetPlansOptions): Promise<(AnchorChainingPlan | AnchorChainingForwardingOnlyPlan | AnchorChainingFullPlanResult | AnchorChainingFullForwardingOnlyPlanResult)[] | null> {
 		const forwardingOpts = normalizeForwardingOnlyOptions(options?.forwardingOnly);
-		const paths = await this.getPaths(input, options?.forwardingOnly ? { forwardingOnly: options.forwardingOnly } : undefined);
+		const paths = await this.getPaths(input, {
+			...(options?.forwardingOnly ? { forwardingOnly: options.forwardingOnly } : {}),
+			...(options?.maxPathLength !== undefined ? { maxPathLength: options.maxPathLength } : {})
+		});
 
 		if (!paths) {
 			return(null);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional API passthrough to existing path search; no change to plan computation or defaults when the option is omitted.
> 
> **Overview**
> **`getPlans`** now accepts an optional **`maxPathLength`** on **`GetPlansOptions`**, so callers can cap how many graph legs are considered when discovering routes before plans are computed.
> 
> That value is forwarded into **`getPaths`** alongside existing **`forwardingOnly`** options, reusing the same path-search limit that **`findPaths`** already honors (default remains the library default when omitted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baecdcffb777179f7578bbfc7383ccdd36f27bef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->