### PR TITLE
kyc: add company certificate attributes

### DIFF
--- a/src/lib/utils/pii.test.ts
+++ b/src/lib/utils/pii.test.ts
@@ -3,6 +3,7 @@ import * as util from 'util';
 import { PIIStore, PIIError } from './pii.js';
 import type { PIIAttributeNames } from './pii.js';
 import type { CertificateAttributeValue } from '../../services/kyc/iso20022.generated.js';
+import { CertificateAttributeOIDDB, SENSITIVE_CERTIFICATE_ATTRIBUTES } from '../../services/kyc/iso20022.generated.js';
 import { createTestCertificate, testAttributeValues, testAccounts } from './tests/certificates.js';
 import { Certificate } from '../certificates.js';
 import * as KeetaNetClient from '@keetanetwork/keetanet-client';
@@ -279,4 +280,46 @@ test('setSensitiveAttribute rejects wrong subject key', async function() {
 	expect(function() {
 		createBuilder().setSensitiveAttribute('email', wrongKeyAttr);
 	}).toThrowError('SensitiveAttribute was encrypted for a different subject');
+});
+
+// ============================================================================
+// Tests: Organization (KYB) Attributes
+// ============================================================================
+
+const ORGANIZATION_TEST_ATTRIBUTES = [
+	attr('organizationName', 'Maple Creek Ventures LLC'),
+	attr('tradeName', 'Maple Creek'),
+	attr('legalForm', 'LLC'),
+	attr('incorporation', {
+		country: 'US',
+		countrySubDivision: 'DE',
+		incorporationDate: new Date('1990-01-01')
+	}),
+	attr('website', 'https://maplecreekventures.example'),
+	attr('entityType', {
+		organization: [{ id: '824531097', schemeName: 'TXID', issuer: 'US' }]
+	})
+];
+
+test('organization attributes round-trip through Certificate.Builder', async function() {
+	const store = createStore();
+	for (const { name, value } of ORGANIZATION_TEST_ATTRIBUTES) {
+		store.setAttribute(name, value);
+	}
+
+	const certificate = await (await store
+		.toCertificateBuilder(createBuilder(), testAccounts.subject))
+		.build({ serial: 1 });
+
+	const certificateWithKey = new Certificate(certificate, { subjectKey: testAccounts.subject });
+
+	for (const { name, value } of ORGANIZATION_TEST_ATTRIBUTES) {
+		expect(certificateWithKey.attributes[name]?.sensitive, name).toBe(true);
+		expect(await certificateWithKey.getAttributeValue(name), name).toEqual(value);
+	}
+});
+
+test('documentBusinessRegistration is registered as a sensitive certificate attribute', function() {
+	expect(SENSITIVE_CERTIFICATE_ATTRIBUTES).toContain('documentBusinessRegistration');
+	expect(CertificateAttributeOIDDB.documentBusinessRegistration).toBe('1.3.6.1.4.1.62675.1.11.7');
 });

--- a/src/services/kyc/utils/oids.json
+++ b/src/services/kyc/utils/oids.json
@@ -445,6 +445,67 @@
 			"type": "Document",
 			"description": "Residence document",
 			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.11.6"
+		},
+		"documentBusinessRegistration": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 11, 7 ],
+			"token": "DocumentBusinessRegistration",
+			"type": "Document",
+			"description": "Business registration document",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.11.7"
+		},
+		"organizationName": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 12 ],
+			"token": "OrganizationName",
+			"type": "UTF8String",
+			"description": "Organization's legal name",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.12"
+		},
+		"tradeName": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 12, 1 ],
+			"token": "TradeName",
+			"type": "UTF8String",
+			"description": "Organization's trade name (doing-business-as name)",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.12.1"
+		},
+		"legalForm": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 13 ],
+			"token": "LegalForm",
+			"type": "UTF8String",
+			"description": "Organization's legal form",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.13"
+		},
+		"incorporation": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 14 ],
+			"token": "Incorporation",
+			"type": "SEQUENCE",
+			"description": "Organization incorporation details",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.14",
+			"fields": {
+				"country": {
+					"type": "Country",
+					"optional": false
+				},
+				"countrySubDivision": {
+					"type": "CountrySubDivision",
+					"optional": true
+				},
+				"incorporationDate": {
+					"type": "GeneralizedTime",
+					"optional": true
+				}
+			},
+			"field_order": [
+				"country",
+				"countrySubDivision",
+				"incorporationDate"
+			]
+		},
+		"website": {
+			"oid": [ 1, 3, 6, 1, 4, 1, 62675, 1, 15 ],
+			"token": "Website",
+			"type": "UTF8String",
+			"description": "Organization's website",
+			"reference": "https://oid-base.com/get/1.3.6.1.4.1.62675.1.15"
 		}
 	},
 	"iso20022_types": {


### PR DESCRIPTION
Adds KYC certificate attributes for organization subjects: organizationName, tradeName, legalForm, incorporation (country, countrySubDivision, incorporationDate), website, and documentBusinessRegistration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the sensitive KYC certificate attribute set and OID assignments used for encoding/decryption; incorrect schema or codegen could break org certificates, though scope is additive with new tests.
> 
> **Overview**
> Extends the KYC certificate OID schema in **`oids.json`** with **organization (KYB)** sensitive attributes: **`organizationName`**, **`tradeName`**, **`legalForm`**, structured **`incorporation`** (country, subdivision, date), **`website`**, and **`documentBusinessRegistration`** (document type under the existing document OID family). These entries feed the auto-generated **`iso20022.generated`** types and sensitive-attribute registry.
> 
> Adds **`pii.test.ts`** coverage that organization fields round-trip through **`PIIStore` → `Certificate.Builder` → decrypt**, are marked sensitive on the certificate, and that **`documentBusinessRegistration`** is listed in **`SENSITIVE_CERTIFICATE_ATTRIBUTES`** with OID **`1.3.6.1.4.1.62675.1.11.7`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b428e4432f277717b200d9e483caafcf836abaf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->