### PR TITLE
Refactor: Host shared transfer status and amount vocabulary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.96",
+	"version": "0.0.97",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@keetanetwork/anchor",
-			"version": "0.0.96",
+			"version": "0.0.97",
 			"license": "SEE LICENSE IN LICENSE",
 			"dependencies": {
 				"@keetanetwork/currency-info": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@keetanetwork/anchor",
-	"version": "0.0.96",
+	"version": "0.0.97",
 	"description": "KeetaNetwork Network Anchor",
 	"main": "client/index.js",
 	"scripts": {

--- a/src/services/asset-movement/lib/amount.test.ts
+++ b/src/services/asset-movement/lib/amount.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AmountLocation } from './amount.js';
+import { KeetaAnchorAmount } from './amount.js';
+import { KeetaAssetMovementTransferError } from './transfer-error.js';
+import { KeetaNet } from '../../../client/index.js';
+
+const USD_ASSET = '$USD';
+
+const TOKEN_ASSET = KeetaNet.lib.Account
+	.fromSeed(KeetaNet.lib.Account.generateRandomSeed(), 0)
+	.generateIdentifier(KeetaNet.lib.Account.AccountKeyAlgorithm.TOKEN, undefined, 1)
+	.publicKeyString.get();
+
+const BANK_LOCATION: AmountLocation = {
+	assets: [ { id: USD_ASSET, decimals: 2 } ]
+};
+
+const CHAIN_LOCATION: AmountLocation = {
+	assets: [ { id: USD_ASSET, decimals: 6 } ]
+};
+
+/**
+ * The transfer error code `fn` throws, `'NONE'` when it returns.
+ */
+function thrownErrorCode(fn: () => unknown): string {
+	try {
+		fn();
+		return('NONE');
+	} catch (error) {
+		if (KeetaAssetMovementTransferError.isInstance(error)) {
+			return(error.code);
+		}
+
+		return('OTHER');
+	}
+}
+
+describe('KeetaAnchorAmount', function() {
+	it('carries value, decimals, and asset', function() {
+		const amount = new KeetaAnchorAmount(100n, 2, USD_ASSET);
+		expect(amount.value).toBe(100n);
+		expect(amount.decimals).toBe(2);
+		expect(amount.asset).toBe(USD_ASSET);
+	});
+
+	it('rejects a fractional or negative precision', function() {
+		expect(thrownErrorCode(function() {
+			return(new KeetaAnchorAmount(1n, 1.5, USD_ASSET));
+		})).toBe('INVALID_AMOUNT');
+
+		expect(thrownErrorCode(function() {
+			return(new KeetaAnchorAmount(1n, -1, USD_ASSET));
+		})).toBe('INVALID_AMOUNT');
+	});
+
+	it('adopts a token amount at the token precision', function() {
+		const amount = KeetaAnchorAmount.fromToken(1_000_000n, {
+			tokenPublicKey: TOKEN_ASSET,
+			decimals: 6
+		});
+		expect(amount.value).toBe(1_000_000n);
+		expect(amount.decimals).toBe(6);
+		expect(amount.asset).toBe(TOKEN_ASSET);
+		expect(amount.toMajor()).toBe('1.000000');
+	});
+
+	it('rescales up without loss and back down', function() {
+		const cents = new KeetaAnchorAmount(100n, 2, USD_ASSET);
+		const micro = cents.toDecimals(6);
+		expect(micro.value).toBe(1_000_000n);
+		expect(micro.decimals).toBe(6);
+		expect(micro.toDecimals(2).value).toBe(100n);
+	});
+
+	it('rejects a downscale that would lose precision', function() {
+		const micro = new KeetaAnchorAmount(1_000_001n, 6, USD_ASSET);
+		expect(thrownErrorCode(function() {
+			return(micro.toDecimals(2));
+		})).toBe('INVALID_AMOUNT');
+	});
+
+	it('converts to a location precision and transport value', function() {
+		const cents = new KeetaAnchorAmount(100n, 2, USD_ASSET);
+		expect(cents.toLocationValue(BANK_LOCATION)).toBe('100');
+		expect(cents.toLocationValue(CHAIN_LOCATION)).toBe('1000000');
+		expect(cents.toLocationDecimals(CHAIN_LOCATION).decimals).toBe(6);
+	});
+
+	it('rejects a location that does not serve the asset', function() {
+		const tokenAmount = new KeetaAnchorAmount(1n, 6, TOKEN_ASSET);
+		expect(thrownErrorCode(function() {
+			return(tokenAmount.toLocationValue(BANK_LOCATION));
+		})).toBe('UNSUPPORTED_LOCATION_ASSET');
+	});
+
+	it('compares equal across precisions of the same asset', function() {
+		const cents = new KeetaAnchorAmount(100n, 2, USD_ASSET);
+		const micro = new KeetaAnchorAmount(1_000_000n, 6, USD_ASSET);
+		const other = new KeetaAnchorAmount(1_000_000n, 6, TOKEN_ASSET);
+		expect(cents.equals(micro)).toBe(true);
+		expect(micro.equals(cents)).toBe(true);
+		expect(micro.equals(other)).toBe(false);
+		expect(cents.equals(new KeetaAnchorAmount(101n, 2, USD_ASSET))).toBe(false);
+	});
+});

--- a/src/services/asset-movement/lib/amount.ts
+++ b/src/services/asset-movement/lib/amount.ts
@@ -1,0 +1,243 @@
+/**
+ * Bundles a smallest-unit integer with its decimal precision and asset.
+ * Rescaling across locations with different precisions is explicit and
+ * loss-checked.
+ */
+
+import type { Asset } from '../common.js';
+import type { TokenPublicKeyString } from '@keetanetwork/keetanet-client/lib/account.js';
+
+import { KeetaAssetMovementTransferError } from './transfer-error.js';
+
+/**
+ * One asset a location serves, with the precision amounts take there.
+ */
+export interface LocationAssetPrecision {
+	readonly id: Asset['id'];
+	readonly decimals: number;
+}
+
+/**
+ * The per-asset precision table of a location, for
+ * {@link KeetaAnchorAmount.toLocationDecimals}.
+ */
+export interface AmountLocation {
+	readonly assets: readonly LocationAssetPrecision[];
+}
+
+/**
+ * The token shape {@link KeetaAnchorAmount.fromToken} accepts.
+ */
+export interface AmountToken {
+	readonly tokenPublicKey: TokenPublicKeyString;
+	readonly decimals: number;
+}
+
+function stripLeadingZeros(digits: string): string {
+	const trimmed = digits.replace(/^0+/, '');
+	if (trimmed === '') {
+		return('0');
+	}
+
+	return(trimmed);
+}
+
+/**
+ * Smallest-unit integer string to major-unit decimal (e.g. "1000", 2 -> "10.00").
+ */
+export function minorToMajor(value: string, exponent: number): string {
+	if (exponent < 0) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `negative exponent: ${exponent}`));
+	}
+
+	let negative = false;
+	let digits = value;
+	if (value.startsWith('-')) {
+		negative = true;
+		digits = value.slice(1);
+	}
+
+	if (!/^\d+$/.test(digits)) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `not a smallest-unit integer: ${value}`));
+	}
+
+	let sign = '';
+	if (negative) {
+		sign = '-';
+	}
+
+	if (exponent === 0) {
+		return(`${sign}${stripLeadingZeros(digits)}`);
+	}
+
+	const padded = digits.padStart(exponent + 1, '0');
+	const whole = padded.slice(0, padded.length - exponent);
+	const frac = padded.slice(padded.length - exponent);
+
+	return(`${sign}${stripLeadingZeros(whole)}.${frac}`);
+}
+
+/**
+ * Major-unit decimal to smallest-unit integer string (e.g. "10.00", 2 -> "1000").
+ */
+export function majorToMinor(amount: string, exponent: number): string {
+	if (exponent < 0) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `negative exponent: ${exponent}`));
+	}
+
+	let negative = false;
+	let unsigned = amount;
+	if (amount.startsWith('-')) {
+		negative = true;
+		unsigned = amount.slice(1);
+	}
+
+	const parts = unsigned.split('.');
+	if (parts.length > 2) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `malformed amount: ${amount}`));
+	}
+
+	const whole = parts[0] ?? '';
+	const frac = parts[1] ?? '';
+	if (!/^\d+$/.test(whole)) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `malformed amount: ${amount}`));
+	}
+	if (frac !== '' && !/^\d+$/.test(frac)) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `malformed amount: ${amount}`));
+	}
+	if (frac.length > exponent) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `amount ${amount} exceeds ${exponent} minor-unit digits`));
+	}
+
+	const normalized = stripLeadingZeros(`${whole}${frac.padEnd(exponent, '0')}`);
+
+	let sign = '';
+	if (negative && normalized !== '0') {
+		sign = '-';
+	}
+
+	return(`${sign}${normalized}`);
+}
+
+function assertDecimals(decimals: number): void {
+	if (!Number.isInteger(decimals) || decimals < 0) {
+		throw(new KeetaAssetMovementTransferError('INVALID_AMOUNT', `decimals must be a non-negative integer: ${String(decimals)}`));
+	}
+}
+
+/**
+ * An immutable amount value object: smallest-unit integer `value` at
+ * `decimals` precision, denominated in `asset`.
+ */
+export class KeetaAnchorAmount {
+	readonly #value: bigint;
+	readonly #decimals: number;
+	readonly #asset: Asset['id'];
+
+	constructor(value: bigint, decimals: number, asset: Asset['id']) {
+		assertDecimals(decimals);
+
+		this.#value = value;
+		this.#decimals = decimals;
+		this.#asset = asset;
+	}
+
+	/**
+	 * The smallest-unit integer value at {@link decimals} precision.
+	 */
+	get value(): bigint {
+		return(this.#value);
+	}
+
+	get decimals(): number {
+		return(this.#decimals);
+	}
+
+	get asset(): Asset['id'] {
+		return(this.#asset);
+	}
+
+	/**
+	 * An amount of an on-chain token, at the token's precision.
+	 */
+	static fromToken(value: bigint, token: AmountToken): KeetaAnchorAmount {
+		const result = new KeetaAnchorAmount(value, token.decimals, token.tokenPublicKey);
+		return(result);
+	}
+
+	/**
+	 * Rescale to another precision. Scaling down rejects any value that
+	 * would lose precision: an anchor must never round funds silently.
+	 */
+	toDecimals(decimals: number): KeetaAnchorAmount {
+		assertDecimals(decimals);
+
+		if (decimals === this.#decimals) {
+			return(this);
+		}
+
+		if (decimals > this.#decimals) {
+			const factor = 10n ** BigInt(decimals - this.#decimals);
+			return(new KeetaAnchorAmount(this.#value * factor, decimals, this.#asset));
+		}
+
+		const divisor = 10n ** BigInt(this.#decimals - decimals);
+		if (this.#value % divisor !== 0n) {
+			throw(new KeetaAssetMovementTransferError(
+				'INVALID_AMOUNT',
+				`rescaling ${this.#value.toString()} from ${this.#decimals} to ${decimals} decimals loses precision`
+			));
+		}
+
+		const result = new KeetaAnchorAmount(this.#value / divisor, decimals, this.#asset);
+		return(result);
+	}
+
+	/**
+	 * Rescale to the precision `location` declares for this asset.
+	 */
+	toLocationDecimals(location: AmountLocation): KeetaAnchorAmount {
+		const entry = location.assets.find((candidate) => {
+			return(String(candidate.id) === String(this.#asset));
+		});
+		if (entry === undefined) {
+			throw(new KeetaAssetMovementTransferError(
+				'UNSUPPORTED_LOCATION_ASSET',
+				`location does not serve asset "${String(this.#asset)}"`
+			));
+		}
+
+		const result = this.toDecimals(entry.decimals);
+		return(result);
+	}
+
+	/**
+	 * The smallest-unit integer string at the location's precision for this asset.
+	 */
+	toLocationValue(location: AmountLocation): string {
+		const result = this.toLocationDecimals(location).value.toString();
+		return(result);
+	}
+
+	/**
+	 * Major-unit decimal string for display (`100` at 2 decimals -> `"1.00"`).
+	 */
+	toMajor(): string {
+		const result = minorToMajor(this.#value.toString(), this.#decimals);
+		return(result);
+	}
+
+	/**
+	 * Same asset and an identical value once both sides are rescaled to the
+	 * wider precision.
+	 */
+	equals(other: KeetaAnchorAmount): boolean {
+		if (String(this.#asset) !== String(other.#asset)) {
+			return(false);
+		}
+
+		const decimals = Math.max(this.#decimals, other.#decimals);
+		const result = this.toDecimals(decimals).value === other.toDecimals(decimals).value;
+		return(result);
+	}
+}

--- a/src/services/asset-movement/lib/transfer-error.ts
+++ b/src/services/asset-movement/lib/transfer-error.ts
@@ -1,0 +1,100 @@
+/**
+ * Typed errors for the asset-movement transfer layer, carrying a stable
+ * {@link MovementErrorCode} for programmatic handling.
+ */
+
+import { KeetaAnchorError } from '../../../lib/error.js';
+
+export const MovementErrorCodes = [
+	'ILLEGAL_TRANSITION',
+	'UNKNOWN_STATUS',
+	'MALFORMED_MESSAGE',
+	'INVALID_AMOUNT',
+	'UNSUPPORTED_LOCATION_ASSET',
+	'INBOUND_DELIVERY_MISMATCH',
+	'MISSING_LEDGER_EFFECT',
+	'EFFECT_AMOUNT_UNRESOLVED',
+	'EFFECT_RECIPIENT_UNRESOLVED',
+	'EFFECT_ABORTED',
+	'EFFECT_WITHDRAW_UNRESOLVED',
+	'UNKNOWN_ROUTE'
+] as const;
+
+export type MovementErrorCode = typeof MovementErrorCodes[number];
+
+/**
+ * HTTP status per code. Most movement errors are programmer/setup bugs.
+ */
+const STATUS_BY_CODE: { [Code in MovementErrorCode]: number } = {
+	ILLEGAL_TRANSITION: 500,
+	UNKNOWN_STATUS: 500,
+	MALFORMED_MESSAGE: 400,
+	INVALID_AMOUNT: 400,
+	UNSUPPORTED_LOCATION_ASSET: 400,
+	INBOUND_DELIVERY_MISMATCH: 422,
+	MISSING_LEDGER_EFFECT: 500,
+	EFFECT_AMOUNT_UNRESOLVED: 500,
+	EFFECT_RECIPIENT_UNRESOLVED: 500,
+	EFFECT_ABORTED: 503,
+	EFFECT_WITHDRAW_UNRESOLVED: 503,
+	UNKNOWN_ROUTE: 500
+};
+
+/*
+ * A withdrawal whose source hash is consumed on-chain but whose transaction
+ * is not yet locatable must keep retrying resolution.
+ */
+const RETRYABLE_BY_CODE: { [Code in MovementErrorCode]?: true } = {
+	EFFECT_WITHDRAW_UNRESOLVED: true
+};
+
+/**
+ * Error raised by the movement state machine and transfer compiler.
+ */
+export class KeetaAssetMovementTransferError extends KeetaAnchorError {
+	static override readonly name: string = 'KeetaAssetMovementTransferError';
+	private readonly KeetaAssetMovementTransferErrorObjectTypeID!: string;
+	private static readonly KeetaAssetMovementTransferErrorObjectTypeID = 'a3f5c8e2-9b14-4e6d-8a72-6c0d2f1b4e57';
+	readonly code: MovementErrorCode;
+
+	constructor(code: MovementErrorCode, message?: string) {
+		super(message ?? code);
+
+		this.code = code;
+		this.statusCode = STATUS_BY_CODE[code];
+		this.retryable = RETRYABLE_BY_CODE[code] ?? false;
+
+		Object.defineProperty(this, 'KeetaAssetMovementTransferErrorObjectTypeID', {
+			value: KeetaAssetMovementTransferError.KeetaAssetMovementTransferErrorObjectTypeID,
+			enumerable: false
+		});
+	}
+
+	static isInstance(input: unknown): input is KeetaAssetMovementTransferError {
+		return(this.hasPropWithValue(input, 'KeetaAssetMovementTransferErrorObjectTypeID', KeetaAssetMovementTransferError.KeetaAssetMovementTransferErrorObjectTypeID));
+	}
+
+	static isValidCode(value: string): value is MovementErrorCode {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+		return(MovementErrorCodes.includes(value as MovementErrorCode));
+	}
+
+	override toJSON(): { ok: false; retryable: boolean; error: string; name: string; statusCode: number; code: MovementErrorCode } {
+		return({
+			...super.toJSON(),
+			code: this.code
+		});
+	}
+
+	static async fromJSON(input: unknown): Promise<KeetaAssetMovementTransferError> {
+		const { message, other } = this.extractErrorProperties(input, this);
+
+		if (!('code' in other) || typeof other.code !== 'string' || !this.isValidCode(other.code)) {
+			throw(new TypeError('Invalid KeetaAssetMovementTransferError JSON object: missing or invalid code'));
+		}
+
+		const error = new this(other.code, message);
+		error.restoreFromJSON(other);
+		return(error);
+	}
+}

--- a/src/services/asset-movement/lib/transfer-status.test.ts
+++ b/src/services/asset-movement/lib/transfer-status.test.ts
@@ -1,0 +1,86 @@
+import { test, expect } from 'vitest';
+
+import type { TransferStatus } from './transfer-status.js';
+import { KeetaAssetMovementTransferError } from './transfer-error.js';
+import {
+	TransferStatuses,
+	TransferStatusInfos,
+	TransferTransitions,
+	assertTransition,
+	canTransition,
+	isTransferStatus,
+	isTerminalTransferStatus
+} from './transfer-status.js';
+
+const legalPairs: [TransferStatus, TransferStatus][] = [];
+const illegalPairs: [TransferStatus, TransferStatus][] = [];
+
+for (const from of TransferStatuses) {
+	for (const to of TransferStatuses) {
+		if (TransferTransitions[from].includes(to)) {
+			legalPairs.push([ from, to ]);
+		} else {
+			illegalPairs.push([ from, to ]);
+		}
+	}
+}
+
+const terminalCases: [TransferStatus, boolean][] = [
+	[ 'CREATED', false ],
+	[ 'AWAITING_ACTION', false ],
+	[ 'AWAITING_DEPOSIT', false ],
+	[ 'DEPOSIT_SUBMITTED', false ],
+	[ 'DEPOSIT_CONFIRMED', false ],
+	[ 'PROCESSING', false ],
+	[ 'WITHDRAW_SUBMITTED', false ],
+	[ 'WITHDRAW_CONFIRMING', false ],
+	[ 'FINALIZING', false ],
+	[ 'REVERSING', false ],
+	[ 'COMPLETE', true ],
+	[ 'CANCELED', true ],
+	[ 'FAILED', true ],
+	[ 'REVERSED', true ],
+	[ 'RETURNED', true ]
+];
+
+function transitionErrorCode(from: TransferStatus, to: TransferStatus): string {
+	try {
+		assertTransition(from, to);
+		return('NONE');
+	} catch (error) {
+		if (KeetaAssetMovementTransferError.isInstance(error)) {
+			return(error.code);
+		}
+
+		return('OTHER');
+	}
+}
+
+function compareTransferStatusKeys(a: string, b: string): number {
+	return(a.localeCompare(b));
+}
+
+test('every status has transition and metadata entries', function() {
+	const statuses = [ ...TransferStatuses ].sort(compareTransferStatusKeys);
+	expect(Object.keys(TransferTransitions).sort(compareTransferStatusKeys)).toEqual(statuses);
+	expect(Object.keys(TransferStatusInfos).sort(compareTransferStatusKeys)).toEqual(statuses);
+});
+
+test.each(legalPairs)('legal transition %s -> %s', function(from, to) {
+	expect(canTransition(from, to)).toBe(true);
+	expect(transitionErrorCode(from, to)).toBe('NONE');
+});
+
+test.each(illegalPairs)('illegal transition %s -> %s', function(from, to) {
+	expect(canTransition(from, to)).toBe(false);
+	expect(transitionErrorCode(from, to)).toBe('ILLEGAL_TRANSITION');
+});
+
+test.each(terminalCases)('terminal flag for %s', function(status, expected) {
+	expect(isTerminalTransferStatus(status)).toBe(expected);
+});
+
+test('isTransferStatus narrows known and rejects unknown values', function() {
+	expect(isTransferStatus('COMPLETE')).toBe(true);
+	expect(isTransferStatus('NOT_A_STATUS')).toBe(false);
+});

--- a/src/services/asset-movement/lib/transfer-status.ts
+++ b/src/services/asset-movement/lib/transfer-status.ts
@@ -1,0 +1,143 @@
+/**
+ * The transfer state machine every asset-movement transaction follows.
+ *
+ * A transfer is a source deposit, a conversion, and a destination withdrawal,
+ * with an optional finalize and a shared pre-flight and unwind path. The
+ * statuses and transitions are drawn from ISO 20022 pacs.002.
+ */
+
+import { KeetaAssetMovementTransferError } from './transfer-error.js';
+
+export const TransferStatuses = [
+	/* Pre-flight */
+	'CREATED',
+	'AWAITING_ACTION',
+	/* Source deposit (inbound) */
+	'AWAITING_DEPOSIT',
+	'DEPOSIT_SUBMITTED',
+	'DEPOSIT_CONFIRMED',
+	/* Conversion */
+	'PROCESSING',
+	/* Destination withdrawal (outbound) */
+	'WITHDRAW_SUBMITTED',
+	'WITHDRAW_CONFIRMING',
+	/* Finalize (optional) */
+	'FINALIZING',
+	/* Terminal */
+	'COMPLETE',
+	'CANCELED',
+	'FAILED',
+	'REVERSING',
+	'REVERSED',
+	'RETURNED'
+] as const;
+
+export type TransferStatus = typeof TransferStatuses[number];
+
+/**
+ * Which part of the transfer a status belongs to.
+ */
+export type TransferCategory = 'none' | 'source' | 'conversion' | 'destination' | 'finalize' | 'unwind' | 'terminal';
+
+/**
+ * The processing phase: awaiting funds, submitted, confirming, settled, done.
+ */
+export type TransferPhase = 'setup' | 'awaiting_action' | 'awaiting_funds' | 'submitted' | 'confirming' | 'settled' | 'processing' | 'unwinding' | 'done';
+
+/**
+ * Static metadata describing a {@link TransferStatus}.
+ */
+export interface TransferStatusInfo {
+	readonly category: TransferCategory;
+	readonly phase: TransferPhase;
+
+	/**
+	 * Whether the transfer may still be cancelled with no value having moved.
+	 */
+	readonly cancelable: boolean;
+
+	/**
+	 * Whether the status is terminal (no further transitions advance it).
+	 */
+	readonly terminal: boolean;
+}
+
+export const TransferStatusInfos: Readonly<{ [status in TransferStatus]: TransferStatusInfo }> = {
+	CREATED: { category: 'none', phase: 'setup', cancelable: true, terminal: false },
+	AWAITING_ACTION: { category: 'source', phase: 'awaiting_action', cancelable: true, terminal: false },
+	AWAITING_DEPOSIT: { category: 'source', phase: 'awaiting_funds', cancelable: true, terminal: false },
+	DEPOSIT_SUBMITTED: { category: 'source', phase: 'submitted', cancelable: false, terminal: false },
+	DEPOSIT_CONFIRMED: { category: 'source', phase: 'settled', cancelable: false, terminal: false },
+	PROCESSING: { category: 'conversion', phase: 'processing', cancelable: false, terminal: false },
+	WITHDRAW_SUBMITTED: { category: 'destination', phase: 'submitted', cancelable: false, terminal: false },
+	WITHDRAW_CONFIRMING: { category: 'destination', phase: 'confirming', cancelable: false, terminal: false },
+	FINALIZING: { category: 'finalize', phase: 'processing', cancelable: false, terminal: false },
+	COMPLETE: { category: 'terminal', phase: 'done', cancelable: false, terminal: true },
+	CANCELED: { category: 'terminal', phase: 'done', cancelable: false, terminal: true },
+	FAILED: { category: 'terminal', phase: 'done', cancelable: false, terminal: true },
+	REVERSING: { category: 'unwind', phase: 'unwinding', cancelable: false, terminal: false },
+	REVERSED: { category: 'terminal', phase: 'done', cancelable: false, terminal: true },
+	RETURNED: { category: 'terminal', phase: 'done', cancelable: false, terminal: true }
+};
+
+/**
+ * The legal transitions of the machine. A status maps to the set of statuses
+ * it may advance to.
+ *
+ * Terminal statuses map to an empty set.
+ * Optional intermediate statuses may be skipped.
+ */
+export const TransferTransitions: Readonly<{ [status in TransferStatus]: readonly TransferStatus[] }> = {
+	CREATED: [ 'AWAITING_ACTION', 'AWAITING_DEPOSIT', 'CANCELED', 'FAILED' ],
+	AWAITING_ACTION: [ 'AWAITING_DEPOSIT', 'CANCELED', 'FAILED' ],
+	AWAITING_DEPOSIT: [ 'DEPOSIT_SUBMITTED', 'DEPOSIT_CONFIRMED', 'CANCELED', 'FAILED' ],
+	DEPOSIT_SUBMITTED: [ 'DEPOSIT_CONFIRMED', 'FAILED', 'REVERSING' ],
+	DEPOSIT_CONFIRMED: [ 'PROCESSING', 'REVERSING' ],
+	PROCESSING: [ 'WITHDRAW_SUBMITTED', 'REVERSING' ],
+	WITHDRAW_SUBMITTED: [ 'WITHDRAW_CONFIRMING', 'FINALIZING', 'COMPLETE', 'FAILED', 'REVERSING' ],
+	WITHDRAW_CONFIRMING: [ 'FINALIZING', 'COMPLETE', 'REVERSING' ],
+	FINALIZING: [ 'COMPLETE', 'FAILED' ],
+	COMPLETE: [ 'RETURNED' ],
+	CANCELED: [],
+	FAILED: [],
+	REVERSING: [ 'REVERSED', 'FAILED' ],
+	REVERSED: [],
+	RETURNED: []
+};
+
+/**
+ * Narrow an arbitrary string to a {@link TransferStatus}.
+ */
+export function isTransferStatus(value: string): value is TransferStatus {
+	// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+	return(TransferStatuses.includes(value as TransferStatus));
+}
+
+/**
+ * Is `true` once a transfer has reached a terminal status.
+ */
+export function isTerminalTransferStatus(status: TransferStatus): boolean {
+	return(TransferStatusInfos[status].terminal);
+}
+
+/**
+ * Whether `to` is a legal next status from `from`.
+ */
+export function canTransition(from: TransferStatus, to: TransferStatus): boolean {
+	const allowed = TransferTransitions[from];
+	return(allowed.includes(to));
+}
+
+/**
+ * Assert that `from -> to` is a legal transition, throwing a typed
+ * {@link KeetaAssetMovementTransferError} otherwise.
+ */
+export function assertTransition(from: TransferStatus, to: TransferStatus): void {
+	const allowed = TransferTransitions[from];
+	if (allowed === undefined) {
+		throw(new KeetaAssetMovementTransferError('UNKNOWN_STATUS', `Unknown transfer status "${from}"`));
+	}
+	if (!allowed.includes(to)) {
+		throw(new KeetaAssetMovementTransferError('ILLEGAL_TRANSITION', `Illegal transfer transition "${from}" -> "${to}"`));
+	}
+}


### PR DESCRIPTION
## Summary

Downstream consumers (asset-movement-anchor-sdk, sentinel, and the planned sentinel-client) need one shared transfer vocabulary, and anchor is the only common lower layer that keeps the package graph acyclic. This change hosts the ISO 20022 transfer state machine and the self-describing amount value object.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New fund-precision and state-transition rules will govern future transfer flows; incorrect adoption could affect money handling, but this PR only adds library code and tests without wiring production paths yet.
> 
> **Overview**
> Adds shared **asset-movement transfer primitives** in anchor (`src/services/asset-movement/lib/`) so downstream packages can share one vocabulary without circular deps. Package version bumps **0.0.96 → 0.0.97**.
> 
> Introduces an **ISO 20022–style transfer state machine** (`transfer-status.ts`): status constants, per-status metadata (category, phase, cancelable/terminal), a transition graph, and helpers (`canTransition`, `assertTransition`, `isTransferStatus`).
> 
> Adds **`KeetaAssetMovementTransferError`** (`transfer-error.ts`) with stable `MovementErrorCode` values, HTTP status mapping, and JSON serialization—used by amount rescaling and illegal transitions.
> 
> Adds **`KeetaAnchorAmount`** (`amount.ts`) as an immutable smallest-unit + decimals + asset type, with loss-checked `toDecimals`, location-based precision via `AmountLocation`, `minorToMajor` / `majorToMinor`, and cross-precision `equals`. Vitest coverage exercises transitions and amount behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee953b068f08ce4d65dab84b17ffe4fe66f8bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->